### PR TITLE
fix: skip message transform for OpenCode internal agents (title/summary/compaction)

### DIFF
--- a/devlog/2026-06-27_title-gen-skip/REQ.md
+++ b/devlog/2026-06-27_title-gen-skip/REQ.md
@@ -1,0 +1,89 @@
+# REQ - Skip message transform for OpenCode internal agents (title/summary/compaction)
+
+- Task ID: `2026-06-27_title-gen-skip`
+- Home Repo: `opencode-acp`
+- Created: 2026-06-27
+- Status: InProgress
+- Priority: P0
+- Owner: sisyphus (glm-5.2)
+- References: upstream issue ranxianglei/opencode-acp#15 (kratky-pavel report)
+
+## 1. Background & Problem Statement
+
+- **Context**: OpenCode runs built-in internal LLM requests for session title
+  generation, conversation summary, and compaction. These are carried by hidden
+  primary-mode agents named `title`, `summary`, and `compaction` (confirmed in
+  OpenCode source: `packages/core/src/plugin/agent.ts`).
+- **Current behavior (symptom)**: When `opencode-acp` is enabled, OpenCode's
+  built-in session title generation stops working. New sessions stay named
+  "New session - <timestamp>" even after the first user message. Removing ACP
+  restores title generation. Reported on ACP 1.3.1 / OpenCode 1.17.11.
+- **Expected behavior**: Enabling ACP must not interfere with OpenCode's
+  internal title/summary/compaction agent requests.
+- **Impact**: Every user sees broken session titles whenever ACP is loaded.
+  High-visibility UX regression.
+
+## 2. Root Cause
+
+`createSystemPromptHandler` already skips internal agents via
+`INTERNAL_AGENT_SIGNATURES` (checks system prompt text for
+"You are a title generator", etc.) and returns early.
+
+`createChatMessageTransformHandler` has **no equivalent guard**. It runs the
+full mutation pipeline (checkSession, assignMessageRefs, syncCompressionBlocks,
+runMajorGC, prune, injectCompressNudges, injectMessageIds, ...) on every LLM
+call — including the small internal title/summary/compaction requests.
+
+This both (a) corrupts the internal request (injects mNNNN tags / nudges into
+what should be a pristine prompt) and (b) corrupts shared session state
+(`checkSession` runs `countTurns` on the title request's tiny message set,
+overwriting `state.currentTurn`; `assignMessageRefs` mutates the ref map from
+the wrong message set).
+
+The message transform hook input is typed `{}` (no metadata field exposes the
+request type), but the messages themselves carry the signal: the last user
+message's `info.agent` field equals `"title"`, `"summary"`, or `"compaction"`
+for these internal requests.
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+  - Backward compatibility: no change to persisted state format, exported APIs,
+    or internal `dcp` tags (AGENTS.md §2.6).
+  - The fix must not skip legitimate subagent (task) requests — those are
+    governed separately by `isSubAgent` + `experimental.allowSubAgents`.
+- **Non-Goals** (explicitly out of scope):
+  - Refactoring the existing subagent skip logic.
+  - Changing the `INTERNAL_AGENT_SIGNATURES` system-prompt detection.
+  - Making internal agent names user-configurable (they are OpenCode built-ins).
+
+## 4. Acceptance Criteria (must be testable)
+
+- **Correctness**:
+  - [ ] `createChatMessageTransformHandler` returns early (no mutation, no state
+        change) when the last user message's `agent` is `title`, `summary`, or
+        `compaction`.
+  - [ ] Normal-agent requests (e.g. `agent: "build"`) are processed exactly as
+        before — no behavior change.
+  - [ ] `state.currentTurn` / `state.messageIds` are NOT mutated by an internal
+        agent request.
+- **Performance / Stability**:
+  - [ ] No new per-turn overhead on the normal path (single cheap field read).
+- **Regression**:
+  - [ ] New test cases added to the test suite and passing.
+  - [ ] Existing 350 tests still pass.
+  - [ ] `npm run build` and `npm run typecheck` pass.
+
+## 5. Proposed Approach
+
+- **Affected modules & entry files**:
+  - `lib/hooks.ts` — add an internal-agent guard at the top of
+    `createChatMessageTransformHandler` (before `checkSession`, to avoid state
+    corruption), reusing a shared detector.
+  - `tests/e2e-message-transform.test.ts` — add tests covering the skip.
+- **Risks**:
+  - Low: the detector relies on the `agent` field. If a future OpenCode version
+    renames the internal agents, detection would miss. Mitigated by keeping the
+    system-prompt-signature detection in the system prompt handler as a second
+    layer.
+- **Rollback strategy**: revert the single commit; no data migration needed.

--- a/devlog/2026-06-27_title-gen-skip/WORKLOG.md
+++ b/devlog/2026-06-27_title-gen-skip/WORKLOG.md
@@ -1,0 +1,84 @@
+# WORKLOG - Skip message transform for OpenCode internal agents (title/summary/compaction)
+
+- Task ID: `2026-06-27_title-gen-skip`
+- Home Repo: `opencode-acp`
+- Status: Done
+- Updated: 2026-06-27 03:40
+
+## 1. Summary
+
+- **What was done**: Added an internal-agent guard at the top of
+  `createChatMessageTransformHandler` so that OpenCode's built-in `title`,
+  `summary`, and `compaction` agent requests are returned early without
+  mutation. Detection uses the last user message's `info.agent` field.
+- **Why**: The system-prompt handler already skipped these via
+  `INTERNAL_AGENT_SIGNATURES`, but the message-transform handler ran its full
+  pipeline on them, corrupting both the small internal request (mNNNN/nudge
+  injection) and shared session state (`countTurns` over `currentTurn`,
+  `assignMessageRefs` over the ref map). This broke session title generation
+  whenever ACP was loaded (upstream issue #15).
+- **Behavior / compatibility changes**: No. Persisted state format, exported
+  APIs, and internal `dcp` tags are unchanged. Only runtime skip behavior for
+  three hidden OpenCode agent IDs is added.
+- **Risk level**: Low
+
+## 2. Change Log
+
+### Key Files
+
+- `lib/hooks.ts` — added `INTERNAL_AGENT_NAMES` set + `isInternalAgentRequest()`
+  helper; added early-return guard before `checkSession` in
+  `createChatMessageTransformHandler`. Guard placed before `checkSession`
+  specifically to prevent `countTurns` running on the internal request's
+  message set.
+- `tests/e2e-message-transform.test.ts` — extended `makeUserMessage` with an
+  optional `agent` param; added 3 tests (title skip, summary+compaction skip,
+  build still processed).
+
+## 3. Design & Implementation Notes
+
+- **Entry point**: `createChatMessageTransformHandler` (lib/hooks.ts).
+- **Detection signal**: `getLastUserMessage(messages)?.info.agent` against
+  `{title, summary, compaction}`. These IDs are confirmed in OpenCode source
+  (`packages/core/src/plugin/agent.ts`) as hidden primary-mode agents whose
+  system prompts match `INTERNAL_AGENT_SIGNATURES`.
+- **Why before checkSession**: `checkSession` → `countTurns(state, messages)`
+  would overwrite `state.currentTurn` using the internal request's tiny message
+  set. The guard must precede it to avoid state corruption.
+- **Defence in depth**: The system-prompt handler's signature-based detection
+  remains as a second layer; the two lists are cross-referenced in comments.
+
+## 4. Testing & Verification
+
+### Build & Test Commands
+
+```sh
+npm run typecheck   # PASS (tsc --noEmit, clean)
+npm run build       # PASS (dist/index.js 303.99 KB)
+node --import tsx --test tests/*.test.ts   # 389 pass, 0 fail
+```
+
+### Test Coverage
+
+- New tests: 3 in `tests/e2e-message-transform.test.ts`
+  - title agent request skipped, messages + state unmutated
+  - summary & compaction agent requests skipped
+  - build agent request still fully processed (no false positives)
+- Test count: 389 total, 389 pass, 0 fail (baseline 386 → +3)
+
+### Results
+
+- **PASS**
+
+## 5. Risk Assessment & Rollback
+
+- **Risk points**: Detector relies on the `agent` field naming. If a future
+  OpenCode version renames internal agents, detection would miss — but the
+  system-prompt-signature layer still catches them.
+- **Rollback method**: revert the single commit.
+- **Compatibility notes**: No data format / config schema changes.
+
+## 6. Follow-ups (optional)
+
+- [ ] Consider unifying `INTERNAL_AGENT_NAMES` and `INTERNAL_AGENT_SIGNATURES`
+      into a single source of truth if a third detection site is ever needed.

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -50,7 +50,7 @@ const INTERNAL_AGENT_SIGNATURES = [
     "Summarize what was done in this conversation",
 ]
 
-// [FIX Bug 36] OpenCode built-in hidden primary-mode agents that must NOT be
+// [FIX Bug 37] OpenCode built-in hidden primary-mode agents that must NOT be
 // run through the message-transform pipeline. These small internal LLM
 // requests (title/summary/compaction generation) carry the agent name on the
 // user message's `info.agent` field. Mutating them corrupts the request and
@@ -223,7 +223,7 @@ export function createChatMessageTransformHandler(
             })
         }
 
-        // [FIX Bug 36] Skip OpenCode internal agents (title/summary/compaction).
+        // [FIX Bug 37] Skip OpenCode internal agents (title/summary/compaction).
         // These small hidden LLM requests must not be mutated, and running
         // checkSession on them would corrupt shared state (currentTurn, etc.).
         if (isInternalAgentRequest(messages)) {

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -24,6 +24,7 @@ import {
     resolveCompressionDuration,
 } from "./compress/timing"
 import { filterMessages, filterMessagesInPlace } from "./messages/shape"
+import { getLastUserMessage } from "./messages/query"
 import {
     applyPendingManualTrigger,
     handleContextCommand,
@@ -48,6 +49,24 @@ const INTERNAL_AGENT_SIGNATURES = [
     "You are an anchored context summarization assistant for coding sessions",
     "Summarize what was done in this conversation",
 ]
+
+// [FIX Bug 36] OpenCode built-in hidden primary-mode agents that must NOT be
+// run through the message-transform pipeline. These small internal LLM
+// requests (title/summary/compaction generation) carry the agent name on the
+// user message's `info.agent` field. Mutating them corrupts the request and
+// shared session state (e.g. countTurns runs on the wrong message set).
+// Keep in sync with INTERNAL_AGENT_SIGNATURES (system-prompt layer) and the
+// agent IDs defined in OpenCode's packages/core/src/plugin/agent.ts.
+const INTERNAL_AGENT_NAMES = new Set(["title", "summary", "compaction"])
+
+function isInternalAgentRequest(messages: WithParts[]): boolean {
+    const lastUserMessage = getLastUserMessage(messages)
+    if (!lastUserMessage) {
+        return false
+    }
+    const agent = (lastUserMessage.info as { agent?: unknown }).agent
+    return typeof agent === "string" && INTERNAL_AGENT_NAMES.has(agent)
+}
 
 export function createSystemPromptHandler(
     state: SessionState,
@@ -202,6 +221,14 @@ export function createChatMessageTransformHandler(
                 received: receivedMessages,
                 usable: messages.length,
             })
+        }
+
+        // [FIX Bug 36] Skip OpenCode internal agents (title/summary/compaction).
+        // These small hidden LLM requests must not be mutated, and running
+        // checkSession on them would corrupt shared state (currentTurn, etc.).
+        if (isInternalAgentRequest(messages)) {
+            logger.debug("Skipping message transform for internal agent request")
+            return
         }
 
         await checkSession(client, state, logger, output.messages, config.manualMode.enabled)

--- a/tests/e2e-message-transform.test.ts
+++ b/tests/e2e-message-transform.test.ts
@@ -78,13 +78,14 @@ function makeUserMessage(
     id: string,
     text: string,
     sessionId: string = SID,
+    agent: string = "assistant",
 ): WithParts {
     return {
         info: {
             id,
             sessionID: sessionId,
             role: "user",
-            agent: "assistant",
+            agent,
             time: { created: Date.now() },
             model: { providerID: "test-provider", modelID: "test-model" },
         } as WithParts["info"],
@@ -615,4 +616,116 @@ test("state persistence: session state survives save/load round-trip", async () 
     assert.equal(loaded!.stats.totalPruneTokens, 5000)
 
     rmSync(tempDir, { recursive: true, force: true })
+})
+
+// ─── Test: Internal agent requests are skipped (Bug 36) ──────────────────────
+
+test("title agent request: pipeline is skipped and messages are not mutated", async () => {
+    const { state, handler } = setupPipeline()
+
+    // Seed state as if a normal conversation already happened, so we can detect
+    // corruption of currentTurn / messageIds by the title request.
+    const seedMessages: WithParts[] = [
+        makeUserMessage("seed-u1", "Hello", SID, "build"),
+        makeAssistantMessage("seed-a1", "Hi there"),
+        makeUserMessage("seed-u2", "Second message", SID, "build"),
+    ]
+    await handler({}, { messages: seedMessages })
+
+    const turnBefore = state.currentTurn
+    const nextRefBefore = state.messageIds.nextRef
+    const byRawIdSizeBefore = state.messageIds.byRawId.size
+
+    // Now simulate OpenCode's internal title-generation request. The user message
+    // carries agent: "title". This must NOT be mutated.
+    const titleMessages: WithParts[] = [
+        makeUserMessage("title-u1", "Generate a title for this conversation", SID, "title"),
+    ]
+    const originalText = (titleMessages[0].parts[0] as { text: string }).text
+    await handler({}, { messages: titleMessages })
+
+    // Messages returned unchanged (no mNNNN injection, no suffix, no pruning)
+    assert.equal(titleMessages.length, 1)
+    assert.equal(titleMessages[0].info.id, "title-u1")
+    assert.equal((titleMessages[0].parts[0] as { text: string }).text, originalText)
+
+    // State NOT corrupted by the internal request
+    assert.equal(state.currentTurn, turnBefore, "currentTurn must not change for title request")
+    assert.equal(
+        state.messageIds.nextRef,
+        nextRefBefore,
+        "nextRef must not advance for title request",
+    )
+    assert.equal(
+        state.messageIds.byRawId.size,
+        byRawIdSizeBefore,
+        "messageIds map must not grow for title request",
+    )
+    assert.ok(
+        !state.messageIds.byRawId.has("title-u1"),
+        "title request user message must not get a ref",
+    )
+})
+
+test("summary and compaction agent requests are skipped", async () => {
+    const { state, handler } = setupPipeline()
+
+    // Seed normal conversation state
+    await handler({}, {
+        messages: [
+            makeUserMessage("seed-u1", "Hello", SID, "build"),
+            makeAssistantMessage("seed-a1", "Hi"),
+        ],
+    })
+
+    const nextRefBefore = state.messageIds.nextRef
+
+    for (const internalAgent of ["summary", "compaction"]) {
+        const internalMessages: WithParts[] = [
+            makeUserMessage(
+                `${internalAgent}-u1`,
+                `Internal ${internalAgent} request`,
+                SID,
+                internalAgent,
+            ),
+        ]
+        const originalText = (internalMessages[0].parts[0] as { text: string }).text
+        await handler({}, { messages: internalMessages })
+
+        // Messages untouched
+        assert.equal(internalMessages.length, 1, `${internalAgent}: message count unchanged`)
+        assert.equal(
+            (internalMessages[0].parts[0] as { text: string }).text,
+            originalText,
+            `${internalAgent}: text must not be mutated`,
+        )
+        // No ref assigned
+        assert.ok(
+            !state.messageIds.byRawId.has(`${internalAgent}-u1`),
+            `${internalAgent}: must not get a ref`,
+        )
+    }
+
+    // State unchanged across both internal requests
+    assert.equal(state.messageIds.nextRef, nextRefBefore)
+})
+
+test("normal agent request (build) is still fully processed", async () => {
+    const { state, handler } = setupPipeline()
+
+    const messages: WithParts[] = [
+        makeUserMessage("u1", "Hello", SID, "build"),
+        makeAssistantMessage("a1", "Hi there"),
+    ]
+
+    await handler({}, { messages })
+
+    // Normal processing: refs assigned, suffix message appended
+    assert.ok(state.messageIds.byRawId.has("u1"), "build: u1 should get a ref")
+    assert.ok(state.messageIds.byRawId.has("a1"), "build: a1 should get a ref")
+    assert.ok(state.messageIds.nextRef >= 3, "build: nextRef should advance")
+    assert.ok(
+        messages.length >= 2,
+        "build: messages should be processed (suffix may be appended)",
+    )
 })

--- a/tests/e2e-message-transform.test.ts
+++ b/tests/e2e-message-transform.test.ts
@@ -618,7 +618,7 @@ test("state persistence: session state survives save/load round-trip", async () 
     rmSync(tempDir, { recursive: true, force: true })
 })
 
-// ─── Test: Internal agent requests are skipped (Bug 36) ──────────────────────
+// ─── Test: Internal agent requests are skipped (Bug 37) ──────────────────────
 
 test("title agent request: pipeline is skipped and messages are not mutated", async () => {
     const { state, handler } = setupPipeline()


### PR DESCRIPTION
## Summary

- Fixes #15 — `opencode-acp` prevents built-in session title generation.
- The message-transform hook ran its full mutation pipeline on OpenCode's built-in internal LLM requests (`title` / `summary` / `compaction` generation), corrupting both the small internal request and shared session state.
- The system-prompt handler already skipped these via `INTERNAL_AGENT_SIGNATURES`; the message-transform handler had **no equivalent guard**.

## Root Cause

`createChatMessageTransformHandler` had no internal-agent detection. On every LLM call — including the small hidden title-generation request — it ran `checkSession` (→ `countTurns` overwriting `state.currentTurn` with the wrong message set), `assignMessageRefs`, `prune`, `injectCompressNudges`, `injectMessageIds`, etc. This both polluted the title prompt and corrupted shared session state, which is why the title-generation stream never appeared when ACP was loaded.

Confirmed the internal agent IDs (`title`, `summary`, `compaction`) in OpenCode source (`packages/core/src/plugin/agent.ts`); their system prompts match the existing `INTERNAL_AGENT_SIGNATURES` entries.

## Fix

Add an early-return guard at the top of `createChatMessageTransformHandler`, placed **before `checkSession`** to prevent `countTurns` state corruption. Detection uses the last user message's `info.agent` field against `{title, summary, compaction}`.

The system-prompt handler's signature-based detection (`INTERNAL_AGENT_SIGNATURES`) remains as a defence-in-depth second layer.

## Verification

- `npm run typecheck` — PASS
- `npm run build` — PASS (dist/index.js 303.99 KB)
- `node --import tsx --test tests/*.test.ts` — **389 pass, 0 fail** (3 new tests added)
- New tests in `tests/e2e-message-transform.test.ts`:
  - title agent request skipped, messages + state unmutated
  - summary & compaction agent requests skipped
  - build agent request still fully processed (no false positives)

## Risk

Low. No changes to persisted state format, exported APIs, or internal `dcp` tags. Only runtime skip behavior for three hidden OpenCode agent IDs.

Devlog: `devlog/2026-06-27_title-gen-skip/` (REQ.md + WORKLOG.md).