### PR TITLE
fix: compression summary role confusion — merge recap into following user turn (Bug 36)

### DIFF
--- a/devlog/2026-06-27_compress-summary-role/DESIGN.md
+++ b/devlog/2026-06-27_compress-summary-role/DESIGN.md
@@ -1,0 +1,87 @@
+# DESIGN: Merge compression summary into following user turn (Bug 36)
+
+- Task ID: `2026-06-27_compress-summary-role`
+
+## 1. Problem (data-flow level)
+
+Every LLM call runs the message-transform pipeline (`lib/hooks.ts` → `prune` → `filterCompressedRanges`). For each active compression block, the pruned range is replaced by a synthetic summary message. Prior to this change that message was unconditionally `role: "user"`, placed at the start of the range.
+
+Flow before:
+
+```
+raw: [u1(user), a1(asst), u2(user), a2(asst)]   block covers u1,a1
+  → prune → [SUMMARY(user), u2(user), a2(asst)]
+```
+
+Two consecutive user-role historical messages. The model read the recap (containing the assistant's prior output) as a user turn → self-Q&A / role confusion.
+
+## 2. Constraint discovery (why not adaptive role)
+
+`@opencode-ai/sdk/v2` `AssistantMessage` requires fields absent from `UserMessage`: `parentID, modelID, providerID, mode, path, cost, tokens{...}`. The codebase creates **zero** synthetic assistant messages today. Fabricating these fields is unverifiable downstream (token accounting — which this plugin itself depends on — cost tracking, message-tree integrity). For a stability-focused plugin this risk is unacceptable. ⇒ Adaptive-role approach (emit `role: "assistant"` summaries) rejected.
+
+## 3. Chosen design — forward merge (Option F)
+
+Decision rule inside `filterCompressedRanges`, computed per active block:
+
+```
+nextSurviving = first non-pruned message at/after the block's anchor index
+
+if nextSurviving is role "user":
+    prependCompressionSummary(nextSurviving, summary, blockId)
+    // no new message emitted; the recap rides inside the user's real turn
+else (assistant, or no following message):
+    prior behavior — emit a standalone role:"user" synthetic message
+    (includes the [FIX Bug 1] fallback for "no preceding user message")
+```
+
+Flow after:
+
+```
+raw: [u1(user), a1(asst), u2(user), a2(asst)]   block covers u1,a1
+  → prune → [u2'(user = "[recap...]\n\nHow are you?"), a2(asst)]
+```
+
+Single user turn. No fake conversational turn is perceived; the self-Q&A loop has no structural trigger.
+
+### Why this is safe
+
+- Transform is **transient**: rebuilt from raw session state every LLM call. `prune.ts` already mutates message text and tool outputs in-place per pass (e.g. `PRUNED_TOOL_OUTPUT_REPLACEMENT`). Prepending recap text is the same kind of transient mutation — nothing is persisted, decompress/recompress operate on raw state and never observe the merge.
+- **Cache**: compression already breaks strict prefix cache at the compression point regardless; merging changes one message's content vs. inserting one new message — equivalent cache impact.
+- **No new message shapes**: stays entirely within user-role territory. No fabricated `AssistantMessage` fields.
+
+## 4. Idempotency & multi-block edge case
+
+`prependCompressionSummary` uses a block-id-scoped delimiter:
+
+```
+[ACP compressed context summary (block <id>) — prior conversation recap]
+<summary>
+[End ACP compressed context summary]
+
+<original user text>
+```
+
+- If the block's marker is already present in the target text part, the prepend is a no-op (returns false) → the caller falls back to a standalone message. This guards against any re-entry.
+- When two adjacent blocks share the same following user message, each gets its own delimited entry prepended (acceptable: both are valid recaps, each block-scoped).
+
+## 5. What does NOT change
+
+- Compression block data model, `CompressionBlock` shape, persistence.
+- GC truncation (`gc/truncate.ts`) — touches summary length, not placement/role.
+- Decompress/recompress — keyed off block state and the `msg_dcp_summary_` id prefix; role/placement-agnostic.
+- The suffix-guidance nudge (`lib/messages/inject/inject.ts` → `createSuffixMessage`) — still a standalone `role: "user"` message at the end of the array. Its id also uses the `msg_dcp_summary_` prefix (deterministic seed `acp-dynamic-guidance`); tests must distinguish the two by content, not prefix.
+- `createSyntheticUserMessage` signature — unchanged (still used by the non-merge fallback path and by the suffix nudge).
+
+## 6. Alternatives considered
+
+| Option | Verdict |
+|---|---|
+| A. Adaptive role (`assistant` when next is user) | Rejected — requires fabricating full `AssistantMessage` fields; unverifiable downstream risk. |
+| B. Merge into following user msg unconditionally | Subsumed by F (F only merges when next is user, preserving status quo otherwise). |
+| D. Summary role = role of range's first message | Rejected — still collides with the following user in the exact reported pattern. |
+
+## 7. Test impact
+
+- No test previously asserted the summary's role was `"user"`.
+- One e2e test asserted a standalone `msg_dcp_summary_` message existed for a block followed by a user turn — updated to assert the merge (content-based, see §5).
+- Added a structural regression test asserting no two adjacent historical user-role messages after any compression pass.

--- a/devlog/2026-06-27_compress-summary-role/REQ.md
+++ b/devlog/2026-06-27_compress-summary-role/REQ.md
@@ -1,0 +1,49 @@
+# REQ: Fix compression summary causing dialog role confusion (Bug 36)
+
+- Task ID: `2026-06-27_compress-summary-role`
+- Home Repo: `opencode-acp`
+- Created: 2026-06-27
+- Status: InProgress
+- Priority: P1
+- Owner: awork (glm-5.2)
+- References: upstream issue https://github.com/ranxianglei/opencode-acp/issues/14 ; dog/opencode-acp#1
+
+## 1. Background & Problem Statement
+
+- **Context**: ACP replaces compressed conversation ranges with a synthetic summary message on every message-transform pass (`lib/messages/prune.ts` → `filterCompressedRanges`).
+- **Current behavior (symptom)**: The summary is **always** created with `role: "user"` (`createSyntheticUserMessage`, hardcodes `role: "user"`). It is injected at the start of the pruned range. When the first surviving message after the range is also a user turn, the output becomes `[summary(user), user(user), assistant]` — two consecutive user-role messages. The model then reads its own prior assistant output (now inside the user-role summary) as user input, causing **self-Q&A loops** and dialog role confusion. Most noticeable in structured skill flows (e.g. `grill`).
+- **Expected behavior**: After compression, the model must never perceive its own prior assistant output as a fresh user turn. No two consecutive user-role historical messages should result from a compression pass.
+- **Impact**: Conversational derailment in long sessions and skill flows; the plugin's core value proposition is stability.
+
+## 2. Reproduction
+
+- **Minimal reproduction**: A conversation `[u1, a1, u2, a2]` with an active compression block covering `u1,a1` produces `[SUMMARY(user), u2(user), a2(assistant)]`. The model sees two user turns and may respond to its own recapped output.
+- **Relevant configuration**: any; default `compress.mode: "range"` or `"message"` both affected.
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+  - The OpenCode SDK only supports `role: "user"` and `role: "assistant"` for messages (no mid-conversation `system`). The `AssistantMessage` type additionally requires `parentID, modelID, providerID, mode, path, cost, tokens` — fabricating these is high-risk for a stability plugin and is **out of scope**.
+  - The synthetic message id prefix `msg_dcp_summary_` is load-bearing (`isSyntheticMessage`, `assignMessageRefs` skip, state cleanup) and must remain stable/deterministic for prompt-cache stability.
+  - Transform is transient (rebuilt from raw state each LLM call); prune.ts already mutates message text/tool-outputs in-place per pass.
+- **Non-Goals**:
+  - Not changing the compression block data model, GC, decompress/recompress, or the suffix-guidance nudge message (which legitimately must remain `role: "user"`).
+
+## 4. Acceptance Criteria (must be testable)
+
+- **Correctness**:
+  - [x] After compression, no two adjacent historical (non-suffix-nudge) messages both have `role: "user"`.
+  - [x] The recap content is preserved and visible to the model (merged into the following user message, or a separate user message only when no following user turn exists).
+  - [x] The following user message's original text is preserved after the recap is prepended.
+- **Regression**:
+  - [x] Updated `tests/e2e-message-transform.test.ts` compression-blocks test to reflect merge behavior.
+  - [x] Added dedicated regression test "compression summary: never produces two consecutive user turns (Bug 36)".
+  - [x] `npm run typecheck` clean; full test suite green (only the pre-existing bun-runner nested-test limitation in `prompts.test.ts` remains, unrelated).
+
+## 5. Proposed Approach
+
+- **Affected modules & entry files**:
+  - `lib/messages/utils.ts` — add `prependCompressionSummary()` helper (idempotent prepend into a message's first text part, block-scoped delimiter).
+  - `lib/messages/prune.ts` — `filterCompressedRanges`: when the next surviving message is a user turn, merge the summary into it instead of emitting a standalone synthetic user message; otherwise retain prior behavior (standalone user message / fallback).
+- **Risks**: Multiple adjacent blocks sharing the same following user message → multiple recap prefixes (acceptable; each is block-delimited and idempotent per block).
+- **Rollback strategy**: Revert the two-file change; behavior returns to standalone user-role summary messages.

--- a/devlog/2026-06-27_compress-summary-role/WORKLOG.md
+++ b/devlog/2026-06-27_compress-summary-role/WORKLOG.md
@@ -1,0 +1,37 @@
+# WORKLOG: Fix compression summary causing dialog role confusion (Bug 36)
+
+- Task ID: `2026-06-27_compress-summary-role`
+- Branch: `2026-06-27_compress-summary-role`
+
+## Investigation
+
+- Root cause located in `lib/messages/prune.ts` → `filterCompressedRanges`. The compression summary was always created via `createSyntheticUserMessage` (`lib/messages/utils.ts`), hardcoding `role: "user"`. Injected at the start of the pruned range, when the first surviving message was also a user turn the output became `[summary(user), user(user), assistant]`.
+- Confirmed anchor placement: `resolveAnchorMessageId` (`lib/compress/search.ts`) returns the **start** message id of the range; `filterCompressedRanges` injects the summary at that position and skips the pruned range.
+- Confirmed SDK constraint: `AssistantMessage` (`@opencode-ai/sdk/v2`) requires `parentID, modelID, providerID, mode, path, cost, tokens` — fabricating these is high-risk; the codebase has zero synthetic assistant messages today.
+
+## Design decision
+
+- Consulted Oracle (read-only, 2 passes). First pass recommended adaptive role (Option A). After surfacing the `AssistantMessage` required-fields constraint, Oracle revised to **Option F (merge)**: when the next surviving message is a user turn, prepend the recap into that message instead of emitting a standalone user-role summary; otherwise keep prior behavior. Eliminates the consecutive-user turn structure that mechanically drove the self-Q&A loop, stays inside tested user-role territory, no fabricated message shapes.
+
+## Changes
+
+- `lib/messages/utils.ts`
+  - Added `MERGED_SUMMARY_HEADER` / `MERGED_SUMMARY_FOOTER` constants (block-id-scoped delimiter).
+  - Added `prependCompressionSummary(message, summary, blockId)` — idempotent prepend into the first text part (creates one if absent); returns false if the block's marker is already present.
+- `lib/messages/prune.ts`
+  - Imported `prependCompressionSummary`.
+  - `filterCompressedRanges`: converted to indexed loop; added `findNextSurvivingMessage`. When the next surviving message is `role: "user"`, merge the summary into it; otherwise retain the prior standalone-synthetic-message behavior (including the `[FIX Bug 1]` fallback for no preceding user message).
+- `tests/e2e-message-transform.test.ts`
+  - Updated the "compression blocks" test to assert the recap is merged into the following user message (and checks content, not the shared `msg_dcp_summary_` prefix, because the unrelated suffix-guidance nudge reuses that prefix).
+  - Added regression test "compression summary: never produces two consecutive user turns (Bug 36)".
+
+## Verification
+
+- `npm run typecheck` — clean (tsc --noEmit, no errors).
+- `bun test tests/` — **383 pass, 1 fail**. The single failure (`tests/prompts.test.ts`) is a pre-existing bun-runner limitation ("test() inside another test() is not yet implemented in Bun"); the project's real runner (`node --import tsx --test tests/*.test.ts`) supports nested tests. Unrelated to this change.
+- Targeted re-runs: `bun test tests/e2e-message-transform.test.ts` — 12 pass / 0 fail.
+
+## Lessons
+
+- The compression summary's role was an implicit, untested assumption (no test asserted `role: "user"`), yet it drove a real-world failure mode (self-Q&A). The regression test now guards the structural invariant directly (no adjacent user turns).
+- Two distinct synthetic messages share the `msg_dcp_summary_` id prefix (compression summary + suffix-guidance nudge) — tests must key off content, not prefix, when asserting absence of one kind.

--- a/lib/messages/prune.ts
+++ b/lib/messages/prune.ts
@@ -2,7 +2,7 @@ import type { SessionState, WithParts } from "../state"
 import type { Logger } from "../logger"
 import type { PluginConfig } from "../config"
 import { isMessageCompacted } from "../state/utils"
-import { createSyntheticUserMessage, replaceBlockIdsWithBlocked, stripStaleMessageRefs } from "./utils"
+import { createSyntheticUserMessage, prependCompressionSummary, replaceBlockIdsWithBlocked, stripStaleMessageRefs } from "./utils"
 import { getLastUserMessage } from "./query"
 import type { UserMessage } from "@opencode-ai/sdk/v2"
 
@@ -171,7 +171,8 @@ const filterCompressedRanges = (
 
     const result: WithParts[] = []
 
-    for (const msg of messages) {
+    for (let i = 0; i < messages.length; i++) {
+        const msg = messages[i]!
         const msgId = msg.info.id
 
         // Check if there's a summary to inject at this anchor point
@@ -190,59 +191,74 @@ const filterCompressedRanges = (
                     blockId: (summary as { blockId?: unknown }).blockId,
                 })
             } else {
-                // Find user message for variant and as base for synthetic message
-                const msgIndex = messages.indexOf(msg)
-                const userMessage = getLastUserMessage(messages, msgIndex)
                 // [FIX Bug 28] Strip stale mNNNN refs before injection
                 const _cleaned = stripStaleMessageRefs(rawSummaryContent)
+                const summaryContent =
+                    config.compress.mode === "message"
+                        ? replaceBlockIdsWithBlocked(_cleaned)
+                        : _cleaned
 
-                if (userMessage) {
-                    const userInfo = userMessage.info as UserMessage
-                    const summaryContent =
-                        config.compress.mode === "message"
-                            ? replaceBlockIdsWithBlocked(_cleaned)
-                            : _cleaned
-                    const summarySeed = `${summary.blockId}:${summary.anchorMessageId}`
-                    result.push(
-                        createSyntheticUserMessage(userMessage, summaryContent, summarySeed),
-                    )
+                // [FIX Bug 36] When the next surviving message is a user turn, merge the
+                // summary into it instead of emitting a standalone user-role summary
+                // message. The old behavior placed a synthetic user message immediately
+                // before the user's real turn ([summary(user), user(user)]), which the
+                // model often read as two user turns — misattributing the assistant's
+                // prior output to the user and triggering "self-Q&A" loops. Merging
+                // yields a single user turn ([user: recap ‖ real reply]) so no fake
+                // conversational turn is perceived.
+                const nextSurviving = findNextSurvivingMessage(messages, i, state)
+                const merged =
+                    nextSurviving !== null &&
+                    nextSurviving.info.role === "user" &&
+                    prependCompressionSummary(nextSurviving, summaryContent, summary.blockId)
 
-                    logger.info("Injected compress summary", {
+                if (merged) {
+                    logger.info("Merged compress summary into following user message", {
                         anchorMessageId: msgId,
+                        targetMessageId: nextSurviving!.info.id,
                         summaryLength: summaryContent.length,
                     })
                 } else {
-                    // [FIX Bug 1] no preceding user message — build fallback base so summary is always injected
-                    const anchorInfo = msg.info as any
-                    const fallbackBase: WithParts = {
-                        info: {
-                            id: anchorInfo.id || msgId,
-                            sessionID: anchorInfo.sessionID || "",
-                            role: "user" as const,
-                            agent: anchorInfo.agent || "code",
-                            model:
-                                anchorInfo.model || {
-                                    providerID: "",
-                                    modelID: "",
-                                    variant: undefined,
-                                },
-                            time: { created: anchorInfo.time?.created || Date.now() },
-                        },
-                        parts: [],
-                    }
-                    const summaryContent =
-                        config.compress.mode === "message"
-                            ? replaceBlockIdsWithBlocked(_cleaned)
-                            : _cleaned
+                    // [FIX Bug 1] fallback when no suitable user message to merge into:
+                    // emit a standalone synthetic user message (prior behavior).
+                    const userMessage = getLastUserMessage(messages, i)
                     const summarySeed = `${summary.blockId}:${summary.anchorMessageId}`
-                    result.push(
-                        createSyntheticUserMessage(fallbackBase, summaryContent, summarySeed),
-                    )
+                    if (userMessage) {
+                        result.push(
+                            createSyntheticUserMessage(userMessage, summaryContent, summarySeed),
+                        )
 
-                    logger.info("Injected compress summary (fallback, no preceding user message)", {
-                        anchorMessageId: msgId,
-                        summaryLength: summaryContent.length,
-                    })
+                        logger.info("Injected compress summary", {
+                            anchorMessageId: msgId,
+                            summaryLength: summaryContent.length,
+                        })
+                    } else {
+                        const anchorInfo = msg.info as any
+                        const fallbackBase: WithParts = {
+                            info: {
+                                id: anchorInfo.id || msgId,
+                                sessionID: anchorInfo.sessionID || "",
+                                role: "user" as const,
+                                agent: anchorInfo.agent || "code",
+                                model:
+                                    anchorInfo.model || {
+                                        providerID: "",
+                                        modelID: "",
+                                        variant: undefined,
+                                    },
+                                time: { created: anchorInfo.time?.created || Date.now() },
+                            },
+                            parts: [],
+                        }
+                        result.push(
+                            createSyntheticUserMessage(fallbackBase, summaryContent, summarySeed),
+                        )
+
+                        logger.info("Injected compress summary (fallback, no preceding user message)", {
+                            anchorMessageId: msgId,
+                            summaryLength: summaryContent.length,
+                        })
+                    }
                 }
             }
         }
@@ -260,4 +276,25 @@ const filterCompressedRanges = (
     // Replace messages array contents
     messages.length = 0
     messages.push(...result)
+}
+
+// [FIX Bug 36] First surviving (non-pruned) message at or after startIndex.
+// Starts the scan at startIndex inclusive to handle both anchor layouts: when
+// the anchor is itself part of the pruned range (message-start ranges) it is
+// skipped, and when the anchor survives (block-anchor ranges) it is returned —
+// in either case this yields the next real turn the model sees after the recap.
+const findNextSurvivingMessage = (
+    messages: WithParts[],
+    startIndex: number,
+    state: SessionState,
+): WithParts | null => {
+    for (let j = startIndex; j < messages.length; j++) {
+        const candidate = messages[j]!
+        const entry = state.prune.messages.byMessageId.get(candidate.info.id)
+        if (entry && entry.activeBlockIds.length > 0) {
+            continue
+        }
+        return candidate
+    }
+    return null
 }

--- a/lib/messages/utils.ts
+++ b/lib/messages/utils.ts
@@ -4,6 +4,14 @@ import { isMessageCompacted } from "../state/utils"
 import type { UserMessage } from "@opencode-ai/sdk/v2"
 
 const SUMMARY_ID_HASH_LENGTH = 16
+
+// [FIX Bug 36] Delimiters wrapping a compression summary when it is merged into
+// an existing user message. The header embeds the block id so multiple blocks
+// landing on the same user message each get their own clearly delimited entry,
+// and so the prepend is idempotent across re-runs (guarded by the marker check).
+const MERGED_SUMMARY_HEADER = (blockId: number | string) =>
+    `[ACP compressed context summary (block ${blockId}) — prior conversation recap]\n`
+const MERGED_SUMMARY_FOOTER = `\n[End ACP compressed context summary]\n\n`
 const DCP_BLOCK_ID_TAG_REGEX = /(<dcp-message-id(?=[\s>])[^>]*>)b\d+(<\/dcp-message-id>)/g
 // [FIX Bug 28] Regex to strip stale mNNNN refs from compressed summaries
 const DCP_MESSAGE_REF_TAG_REGEX = /<dcp-message-id>m\d+<\/dcp-message-id>/g
@@ -45,6 +53,49 @@ export const createSyntheticUserMessage = (
             },
         ],
     }
+}
+
+// [FIX Bug 36] Merge a compression summary into an existing user message by
+// prepending it (clearly delimited) to that message's first text part. This
+// avoids emitting a standalone user-role summary message adjacent to the user's
+// real turn, which previously produced two consecutive user messages and caused
+// dialog role confusion / "self-Q&A" loops. Returns true when the summary is
+// present after the call — including the idempotent case where the block's
+// marker is already in the text (no-op), matching appendToTextPart so callers
+// never fall through to a standalone message merely because of a re-run.
+export const prependCompressionSummary = (
+    message: WithParts,
+    summary: string,
+    blockId: number | string,
+): boolean => {
+    const parts = Array.isArray(message.parts) ? message.parts : []
+    const header = MERGED_SUMMARY_HEADER(blockId)
+    const marker = MERGED_SUMMARY_HEADER(blockId).trimEnd()
+
+    for (const part of parts) {
+        if (part.type !== "text") {
+            continue
+        }
+        const textPart = part as TextPart
+        const existing = typeof textPart.text === "string" ? textPart.text : ""
+        if (existing.includes(marker)) {
+            return true
+        }
+        textPart.text = `${header}${summary}${MERGED_SUMMARY_FOOTER}${existing}`
+        return true
+    }
+
+    const sessionID = (message.info as { sessionID?: string }).sessionID ?? ""
+    const messageId = (message.info as { id: string }).id
+    parts.unshift({
+        id: generateStableId("prt_dcp_prepend", `${blockId}:${messageId}`),
+        sessionID,
+        messageID: messageId,
+        type: "text" as const,
+        text: `${header}${summary}${MERGED_SUMMARY_FOOTER}`,
+    })
+    message.parts = parts
+    return true
 }
 
 export const createSyntheticTextPart = (

--- a/tests/e2e-message-transform.test.ts
+++ b/tests/e2e-message-transform.test.ts
@@ -382,18 +382,226 @@ test("compression blocks: compressed messages are replaced with summaries", asyn
     assert.ok(remainingIds.includes("u2"), "u2 should survive")
     assert.ok(remainingIds.includes("a2"), "a2 should survive")
 
-    // There should be a synthetic summary message injected at u2's anchor
-    const summaryMsg = output.messages.find(
-        (m: any) => m.info.id?.startsWith("msg_dcp_summary_"),
+    // [FIX Bug 36] The summary is now merged into the following user message (u2)
+    // instead of a standalone synthetic message, so the model no longer sees two
+    // consecutive user turns ([summary(user), u2(user)]) which caused role
+    // confusion / self-Q&A loops.
+    // The recap content is checked (not the msg_dcp_summary_ id prefix) because
+    // the unrelated suffix-guidance nudge message reuses that same id prefix.
+    const standaloneWithRecap = output.messages.find(
+        (m: any) =>
+            m.info.id?.startsWith("msg_dcp_summary_") &&
+            m.parts.some(
+                (p: any) =>
+                    p.type === "text" &&
+                    typeof p.text === "string" &&
+                    p.text.includes("Previous conversation about greetings"),
+            ),
     )
-    assert.ok(summaryMsg, "a synthetic summary message should be injected")
+    assert.ok(
+        !standaloneWithRecap,
+        "recap should be merged into the following user message, not emitted as a standalone synthetic message",
+    )
 
-    // Summary text should contain the compressed content
-    const summaryText = summaryMsg!.parts
+    // The summary content should be prepended into u2 (the following user message),
+    // and u2's original text must still be present after the recap.
+    const u2Msg = output.messages.find((m: any) => m.info.id === "u2")
+    assert.ok(u2Msg, "u2 should survive")
+    const u2Text = u2Msg!.parts
         .filter((p: any) => p.type === "text")
         .map((p: any) => p.text)
         .join("")
-    assert.ok(summaryText.includes("Previous conversation about greetings"))
+    assert.ok(
+        u2Text.includes("Previous conversation about greetings"),
+        "compressed summary should be merged into u2",
+    )
+    assert.ok(
+        u2Text.includes("How are you?"),
+        "u2's original text should be preserved after the summary is prepended",
+    )
+})
+
+// ─── Test: Regression — no consecutive user messages after compression ──────
+
+test("compression summary: never produces two consecutive user turns (Bug 36)", async () => {
+    const { state, handler } = setupPipeline()
+
+    const blockId = 1
+    state.prune.messages.blocksById.set(blockId, {
+        blockId,
+        runId: 1,
+        active: true,
+        deactivatedByUser: false,
+        compressedTokens: 500,
+        summaryTokens: 50,
+        durationMs: 0,
+        mode: "message",
+        topic: "early work",
+        batchTopic: "early work",
+        startId: "m00001",
+        endId: "m00002",
+        anchorMessageId: "u1",
+        compressMessageId: "msg-compress",
+        compressCallId: "call-compress",
+        includedBlockIds: [],
+        consumedBlockIds: [],
+        parentBlockIds: [],
+        directMessageIds: ["u1", "a1"],
+        directToolIds: [],
+        effectiveMessageIds: ["u1", "a1"],
+        effectiveToolIds: [],
+        createdAt: Date.now() - 1000,
+        summary: "The assistant explained the plan and the user acknowledged it.",
+        survivedCount: 0,
+        generation: "old",
+    })
+    state.prune.messages.activeBlockIds.add(blockId)
+    state.prune.messages.activeByAnchorMessageId.set("u1", blockId)
+    state.prune.messages.byMessageId.set("u1", {
+        tokenCount: 200,
+        allBlockIds: [blockId],
+        activeBlockIds: [blockId],
+    })
+    state.prune.messages.byMessageId.set("a1", {
+        tokenCount: 300,
+        allBlockIds: [blockId],
+        activeBlockIds: [blockId],
+    })
+
+    const output = {
+        messages: [
+            makeUserMessage("u1", "What's the plan?"),
+            makeAssistantMessage("a1", "Here is the plan."),
+            makeUserMessage("u2", "Sounds good, continue."),
+            makeAssistantMessage("a2", "Working on it."),
+        ],
+    }
+
+    await handler({}, output)
+
+    // Exclude ONLY the trailing suffix-guidance nudge (the last message, when
+    // synthetic). We must NOT filter all synthetic messages here: the pre-fix bug
+    // emitted the recap itself as a synthetic user message, and filtering it out
+    // would hide the exact consecutive-user pattern this test must catch.
+    const lastIdx = output.messages.length - 1
+    const historical = output.messages.filter(
+        (m: any, idx: number) => !(idx === lastIdx && isSyntheticMessage(m)),
+    )
+
+    // No two adjacent messages may both be role "user" — that pattern is exactly
+    // what caused the model to read its own prior output as user input and fall
+    // into a self-Q&A loop. On the pre-fix code this fails: the standalone
+    // synthetic summary (user) sat immediately before the surviving user turn.
+    for (let i = 1; i < historical.length; i++) {
+        const prev = historical[i - 1]!
+        const curr = historical[i]!
+        const bothUser = prev.info.role === "user" && curr.info.role === "user"
+        assert.ok(
+            !bothUser,
+            `adjacent user turns at index ${i - 1}/${i} (ids ${prev.info.id}, ${curr.info.id}) — compression must not create consecutive user messages`,
+        )
+    }
+
+    // The surviving user turn must carry both the recap and its own original text.
+    const u2 = historical.find((m: WithParts) => m.info.id === "u2")
+    assert.ok(u2, "u2 should survive")
+    const u2Text = u2!.parts
+        .filter((p) => p.type === "text")
+        .map((p) => (p as any).text)
+        .join("")
+    assert.ok(u2Text.includes("The assistant explained the plan"), "recap merged into u2")
+    assert.ok(u2Text.includes("Sounds good, continue."), "u2 original text preserved")
+})
+
+// ─── Test: Fallback — standalone summary when no following user turn (Bug 36) ──
+
+test("compression summary: emits standalone summary when range is last (no user to merge into)", async () => {
+    const { state, handler } = setupPipeline()
+
+    const blockId = 2
+    state.prune.messages.blocksById.set(blockId, {
+        blockId,
+        runId: 2,
+        active: true,
+        deactivatedByUser: false,
+        compressedTokens: 500,
+        summaryTokens: 50,
+        durationMs: 0,
+        mode: "message",
+        topic: "closing work",
+        batchTopic: "closing work",
+        startId: "m00003",
+        endId: "m00004",
+        anchorMessageId: "u2",
+        compressMessageId: "msg-compress",
+        compressCallId: "call-compress",
+        includedBlockIds: [],
+        consumedBlockIds: [],
+        parentBlockIds: [],
+        directMessageIds: ["u2", "a2"],
+        directToolIds: [],
+        effectiveMessageIds: ["u2", "a2"],
+        effectiveToolIds: [],
+        createdAt: Date.now() - 1000,
+        summary: "Final wrap-up of the task.",
+        survivedCount: 0,
+        generation: "old",
+    })
+    state.prune.messages.activeBlockIds.add(blockId)
+    state.prune.messages.activeByAnchorMessageId.set("u2", blockId)
+    state.prune.messages.byMessageId.set("u2", {
+        tokenCount: 200,
+        allBlockIds: [blockId],
+        activeBlockIds: [blockId],
+    })
+    state.prune.messages.byMessageId.set("a2", {
+        tokenCount: 300,
+        allBlockIds: [blockId],
+        activeBlockIds: [blockId],
+    })
+
+    const output = {
+        messages: [
+            makeUserMessage("u1", "Start here"),
+            makeAssistantMessage("a1", "Working"),
+            makeUserMessage("u2", "Almost done"),
+            makeAssistantMessage("a2", "Finished"),
+        ],
+    }
+
+    await handler({}, output)
+
+    const remainingIds = output.messages.map((m: any) => m.info.id)
+    assert.ok(!remainingIds.includes("u2"), "u2 (covered by block) should be pruned")
+    assert.ok(!remainingIds.includes("a2"), "a2 (covered by block) should be pruned")
+
+    // No following user turn exists to merge into, so the recap must be emitted
+    // as a standalone synthetic user message carrying the summary content.
+    const standalone = output.messages.find(
+        (m: any) =>
+            m.info.id?.startsWith("msg_dcp_summary_") &&
+            m.parts.some(
+                (p: any) =>
+                    p.type === "text" &&
+                    typeof p.text === "string" &&
+                    p.text.includes("Final wrap-up of the task."),
+            ),
+    )
+    assert.ok(standalone, "fallback path must emit a standalone synthetic summary")
+
+    // The standalone summary (user) follows a1 (assistant), so alternation holds.
+    const lastIdx = output.messages.length - 1
+    const checkMessages = output.messages.filter(
+        (m: any, idx: number) => !(idx === lastIdx && isSyntheticMessage(m)),
+    )
+    for (let i = 1; i < checkMessages.length; i++) {
+        const prev = checkMessages[i - 1]!
+        const curr = checkMessages[i]!
+        assert.ok(
+            !(prev.info.role === "user" && curr.info.role === "user"),
+            `unexpected adjacent user turns at ${i - 1}/${i}`,
+        )
+    }
 })
 
 // ─── Test: Tool output pruning ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the dialog role confusion / "self-Q&A loop" reported in #14, where after an ACP compression the model's prior assistant output was misattributed as user speech.

**Root cause:** the compression summary was always created with `role: "user"` (`createSyntheticUserMessage`) and injected before the user's real turn, producing `[summary(user), user(user), assistant]` — two consecutive user-role messages. The model read its own prior output (inside the recap) as user input.

**Fix (Option F):** when the next surviving message after a pruned range is a user turn, **prepend the recap into that message's first text part** (clearly delimited, idempotent per block) instead of emitting a standalone synthetic user message. When the next survivor is an assistant turn (or absent), keep the prior standalone-user-message behavior. Result: a single user turn `[user: recap ‖ real reply]` — no fake conversational turn, no self-Q&A trigger.

This avoids fabricating an `AssistantMessage` (the SDK requires `parentID, modelID, providerID, mode, path, cost, tokens` — unverifiable downstream risk for a stability-focused plugin) and stays entirely within tested user-role territory.

## Changes

- `lib/messages/utils.ts` — add `prependCompressionSummary()` helper (idempotent prepend into first text part; returns `true` on success and on no-op, matching `appendToTextPart`)
- `lib/messages/prune.ts` — `filterCompressedRanges`: convert to indexed loop, add `findNextSurvivingMessage`, merge when next survivor is `role: "user"`; otherwise retain prior behavior (incl. the `[FIX Bug 1]` fallback)
- `tests/e2e-message-transform.test.ts` — update the compression-blocks test (assert merge), add a regression test for consecutive user turns, add a fallback-path test (range at end → standalone)
- `devlog/2026-06-27_compress-summary-role/` — REQ.md, WORKLOG.md, DESIGN.md (per §5.1.2)

## Verification

- `npm run typecheck` — clean
- `npm run build` — exit 0 (`dist/index.js`, `dist/index.d.ts` produced)
- Test suite: **384 pass, 1 fail**. The single failure (`tests/prompts.test.ts`) is a **pre-existing** bun-runner limitation (`test() inside another test() is not yet implemented in Bun`); the project's real runner (`node --import tsx --test`) supports nested tests. Unrelated to this change.

## Review

Independently reviewed by two agents (per AGENTS.md §5.3 / §5.6). Both returned **APPROVE WITH FINDINGS**; all MAJOR findings addressed before push:
- `prependCompressionSummary` now returns `true` on idempotent skip (was `false`, which could fall through to a standalone message and reintroduce the bug) — matches the `appendToTextPart` convention.
- Regression test's adjacency assertion fixed to exclude only the trailing suffix nudge (filtering all synthetic messages had hidden the exact bug).
- Added fallback-path test coverage.
- Corrected a misleading comment in `findNextSurvivingMessage`.

Closes #14.