### PR TITLE
chore: release v1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 34 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
Version bump 1.3.1 → 1.4.0 for the release. All prior PRs (#13 mark_block, #16 title-gen-skip/Bug37, #17 compress-summary-role/Bug36, #18/#19 README) are merged. typecheck/build/verify:package all green. Tag v1.4.0 + npm publish follow this merge.