### PR TITLE
chore: release v1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 34 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
Version bump 1.4.0 → 1.4.1 (picks up the v5 README refresh from PR #21). typecheck/build/verify:package green. Tag v1.4.1 + npm publish follow this merge.