### PR TITLE
fix: disable in-place tool output pruning to preserve prefix cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ ACP auto-migrates config from `dcp.jsonc` to `acp.jsonc` and prompts from `dcp-p
 ---
 
 <details>
-<summary><strong>Bug Fixes (37 total)</strong> -- applied on top of DCP v3.1.11</summary>
+<summary><strong>Bug Fixes (38 total)</strong> -- applied on top of DCP v3.1.11</summary>
 
 | # | Severity | Summary |
 |---|----------|---------|
@@ -419,6 +419,7 @@ ACP auto-migrates config from `dcp.jsonc` to `acp.jsonc` and prompts from `dcp-p
 | 35 | HIGH | Aging warnings shown at low context usage (<50%) -- triggers unnecessary compress, wastes tokens |
 | 36 | HIGH | Compression summary emitted as a standalone user message before the user's real turn -- model reads its own prior assistant output as user input, causing dialog role confusion / self-Q&A loops |
 | 37 | HIGH | Message-transform pipeline runs on OpenCode's hidden title/summary/compaction agent requests -- corrupts the request and shared session state, breaking session title generation |
+| 38 | CRITICAL | pruneToolOutputs/pruneToolInputs/pruneToolErrors mutate existing messages in-place -- invalidates LLM prefix cache, causing 89% of fresh input tokens to be wasted on cache-invalidating re-sends |
 
 For the complete list with root cause analysis, see the [bug tracker](https://github.com/ranxianglei/opencode-acp/issues).
 

--- a/devlog/2026-06-27_prune-cache-fix/DESIGN.md
+++ b/devlog/2026-06-27_prune-cache-fix/DESIGN.md
@@ -1,0 +1,52 @@
+# DESIGN: Prune cache fix
+
+## Current Architecture
+
+```
+hooks.ts:createChatMessageTransformHandler
+  → prune(state, logger, config, messages)     ← runs EVERY request
+      → filterCompressedRanges(...)              ← rebuilds array (OK: only when blocks change)
+      → pruneToolOutputs(...)                    ← MUTATES part.state.output (BREAKS CACHE)
+      → pruneToolInputs(...)                     ← MUTATES part.state.input  (BREAKS CACHE)
+      → pruneToolErrors(...)                     ← MUTATES error outputs     (BREAKS CACHE)
+```
+
+## After Fix
+
+```
+hooks.ts:createChatMessageTransformHandler
+  → prune(state, logger, config, messages)
+      → filterCompressedRanges(...)              ← still runs, handles compression
+      // pruneToolOutputs — DISABLED (prefix cache breaker)
+      // pruneToolInputs  — DISABLED (prefix cache breaker)
+      // pruneToolErrors  — DISABLED (prefix cache breaker)
+```
+
+## Why This Is Safe
+
+1. **Compression still works**: `filterCompressedRanges` is the actual compression
+   mechanism. When the model calls `compress`, blocks are created, and
+   `filterCompressedRanges` replaces old messages with summaries. This is independent
+   of `pruneToolOutputs`.
+
+2. **Context growth is bounded**: Without pruning, tool outputs stay full until
+   compression triggers (at ~55% context limit). The model sees the large context,
+   ACP nudges it, and the model calls `compress`. This is the intended flow.
+
+3. **Net token savings**: Cache hits on full tool outputs (cheap) vs cache misses
+   from pruning (expensive re-sends of 120K-450K tokens). The math favors keeping
+   outputs cached.
+
+## Related Work
+
+- Issue #5: Same class of bug (nudge injection modifying historical messages).
+  Fixed by moving dynamic content to a suffix message. The prune pipeline was
+  not addressed at that time.
+- PR #13: Added `mark_block` tool (unrelated — mark_block was never called).
+
+## Future Improvement
+
+Move tool pruning to a suffix-message approach (like the issue #5 nudge fix):
+instead of replacing `part.state.output`, append "stale tools: call_xxx" to the
+suffix message. The model sees the staleness note and can compress those tools.
+This preserves both pruning AND cache stability.

--- a/devlog/2026-06-27_prune-cache-fix/REQ.md
+++ b/devlog/2026-06-27_prune-cache-fix/REQ.md
@@ -1,0 +1,39 @@
+# REQ: Disable in-place tool output pruning to preserve prefix cache
+
+## Problem
+
+`pruneToolOutputs` (prune.ts:73-97) replaces tool call outputs in-place with
+`"[Output removed to save context...]"` on **every** `chat.messages.transform`
+call. This mutates existing message content, invalidating the LLM provider's
+prefix cache from the first modified message onward.
+
+Observed impact (ses_102504697, Jun 25-27):
+- 176 cache misses over 2 days, each re-sending 120K-450K tokens
+- 89% of fresh input tokens wasted on cache-invalidating re-sends
+- ~50M tokens wasted total
+
+This is the same class of bug as issue #5 (nudge injection modifying historical
+messages), but in the prune pipeline instead of the nudge pipeline.
+
+## Root Cause
+
+DCP's original design prunes tool outputs by mutating `part.state.output`
+directly. ACP's issue #5 fix applied the suffix-message discipline to nudges
+but **not** to the prune pipeline.
+
+## Fix
+
+Disable `pruneToolOutputs`, `pruneToolInputs`, and `pruneToolErrors` in the
+`prune()` function. These three functions are the only in-place mutation
+sources in the prune pipeline. `filterCompressedRanges` (the actual compression
+mechanism) is unaffected and continues to handle context reduction.
+
+The model still has the `compress` tool available — when context grows large,
+ACP nudges the model to compress, which creates summary blocks processed by
+`filterCompressedRanges`. This is the intended context management flow.
+
+## Non-Goals
+
+- Implementing suffix-message-based tool pruning (future PR)
+- Modifying `filterCompressedRanges` (it rebuilds the array but only when
+  compression blocks change state — infrequent and acceptable)

--- a/devlog/2026-06-27_prune-cache-fix/WORKLOG.md
+++ b/devlog/2026-06-27_prune-cache-fix/WORKLOG.md
@@ -1,0 +1,25 @@
+# WORKLOG
+
+## 2026-06-27
+
+### Investigation
+- Analyzed ses_102504697 cache miss data: 176 misses, 89% waste ratio
+- Identified root cause: `pruneToolOutputs` mutates `part.state.output` in-place
+- Confirmed via source analysis: prune.ts:94 `part.state.output = PRUNED_TOOL_OUTPUT_REPLACEMENT`
+- Cross-referenced with issue #5 (nudge cache fix) — same class of bug, different pipeline
+
+### Implementation
+- Disabled `pruneToolOutputs`, `pruneToolInputs`, `pruneToolErrors` in `prune()` function
+- Kept `filterCompressedRanges` (compression mechanism) intact
+- Deployed hotfix to local cache for immediate testing
+
+### Verification
+- Built with `bun run build` — success
+- Verified dist: `pruneToolOutputs` call count = 0
+- Deployed to `~/.cache/opencode/packages/opencode-acp@latest/` — MD5 match
+- Functional test: proxy + ACP working correctly
+
+### Next Steps
+- Add test coverage
+- Dual-agent review
+- npm publish as 1.4.2

--- a/lib/messages/prune.ts
+++ b/lib/messages/prune.ts
@@ -18,10 +18,12 @@ export const prune = (
     messages: WithParts[],
 ): void => {
     filterCompressedRanges(state, logger, config, messages)
-    // pruneFullTool(state, logger, messages)
-    pruneToolOutputs(state, logger, messages)
-    pruneToolInputs(state, logger, messages)
-    pruneToolErrors(state, logger, messages)
+    // [HOTFIX] Disabled pruneToolOutputs/pruneToolInputs/pruneToolErrors — they mutate
+    // existing messages in-place, breaking GLM prefix cache. Compression still works
+    // via filterCompressedRanges + model-initiated compress tool.
+    // pruneToolOutputs(state, logger, messages)
+    // pruneToolInputs(state, logger, messages)
+    // pruneToolErrors(state, logger, messages)
 }
 
 const pruneFullTool = (state: SessionState, logger: Logger, messages: WithParts[]): void => {

--- a/package.json
+++ b/package.json
@@ -1,75 +1,75 @@
 {
-    "$schema": "https://json.schemastore.org/package.json",
-    "name": "opencode-acp",
-    "version": "1.4.1",
-    "type": "module",
-    "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 34 bug fixes)",
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        },
-        "./server": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
-        }
+  "$schema": "https://json.schemastore.org/package.json",
+  "name": "opencode-acp",
+  "version": "1.4.2",
+  "type": "module",
+  "description": "Active Context Pruning \u2014 model-driven context management for OpenCode (hardened fork of DCP with 34 bug fixes)",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     },
-    "scripts": {
-        "clean": "rm -rf dist",
-        "build": "npm run clean && tsup && tsc --emitDeclarationOnly",
-        "verify:package": "node scripts/verify-package.mjs",
-        "check:package": "npm run build && npm run verify:package",
-        "prepublishOnly": "npm run check:package",
-        "dev": "opencode plugin dev",
-        "typecheck": "tsc --noEmit",
-        "test": "node --import tsx --test tests/*.test.ts",
-        "format": "prettier --write .",
-        "format:check": "prettier --check .",
-        "dcp": "tsx scripts/print.ts"
-    },
-    "keywords": [
-        "opencode",
-        "opencode-plugin",
-        "plugin",
-        "context",
-        "pruning",
-        "active-context",
-        "optimization",
-        "tokens",
-        "acp"
-    ],
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/ranxianglei/opencode-acp.git"
-    },
-    "bugs": {
-        "url": "https://github.com/ranxianglei/opencode-acp/issues"
-    },
-    "homepage": "https://github.com/ranxianglei/opencode-acp#readme",
-    "author": "ranxianglei",
-    "license": "AGPL-3.0-or-later",
-    "peerDependencies": {
-        "@opencode-ai/plugin": ">=1.4.3"
-    },
-    "dependencies": {
-        "@anthropic-ai/tokenizer": "^0.0.4",
-        "@opencode-ai/sdk": "^1.4.3",
-        "jsonc-parser": "^3.3.1",
-        "zod": "^4.3.6"
-    },
-    "devDependencies": {
-        "@opencode-ai/plugin": "^1.4.3",
-        "@types/node": "^25.5.0",
-        "prettier": "^3.8.1",
-        "tsup": "^8.5.1",
-        "tsx": "^4.21.0",
-        "typescript": "^6.0.2"
-    },
-    "files": [
-        "dist/",
-        "README.md",
-        "LICENSE"
-    ]
+    "./server": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "npm run clean && tsup && tsc --emitDeclarationOnly",
+    "verify:package": "node scripts/verify-package.mjs",
+    "check:package": "npm run build && npm run verify:package",
+    "prepublishOnly": "npm run check:package",
+    "dev": "opencode plugin dev",
+    "typecheck": "tsc --noEmit",
+    "test": "node --import tsx --test tests/*.test.ts",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "dcp": "tsx scripts/print.ts"
+  },
+  "keywords": [
+    "opencode",
+    "opencode-plugin",
+    "plugin",
+    "context",
+    "pruning",
+    "active-context",
+    "optimization",
+    "tokens",
+    "acp"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ranxianglei/opencode-acp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ranxianglei/opencode-acp/issues"
+  },
+  "homepage": "https://github.com/ranxianglei/opencode-acp#readme",
+  "author": "ranxianglei",
+  "license": "AGPL-3.0-or-later",
+  "peerDependencies": {
+    "@opencode-ai/plugin": ">=1.4.3"
+  },
+  "dependencies": {
+    "@anthropic-ai/tokenizer": "^0.0.4",
+    "@opencode-ai/sdk": "^1.4.3",
+    "jsonc-parser": "^3.3.1",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@opencode-ai/plugin": "^1.4.3",
+    "@types/node": "^25.5.0",
+    "prettier": "^3.8.1",
+    "tsup": "^8.5.1",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.2"
+  },
+  "files": [
+    "dist/",
+    "README.md",
+    "LICENSE"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,75 +1,75 @@
 {
-  "$schema": "https://json.schemastore.org/package.json",
-  "name": "opencode-acp",
-  "version": "1.4.2",
-  "type": "module",
-  "description": "Active Context Pruning \u2014 model-driven context management for OpenCode (hardened fork of DCP with 34 bug fixes)",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+    "$schema": "https://json.schemastore.org/package.json",
+    "name": "opencode-acp",
+    "version": "1.4.2",
+    "type": "module",
+    "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 34 bug fixes)",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js"
+        },
+        "./server": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js"
+        }
     },
-    "./server": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    }
-  },
-  "scripts": {
-    "clean": "rm -rf dist",
-    "build": "npm run clean && tsup && tsc --emitDeclarationOnly",
-    "verify:package": "node scripts/verify-package.mjs",
-    "check:package": "npm run build && npm run verify:package",
-    "prepublishOnly": "npm run check:package",
-    "dev": "opencode plugin dev",
-    "typecheck": "tsc --noEmit",
-    "test": "node --import tsx --test tests/*.test.ts",
-    "format": "prettier --write .",
-    "format:check": "prettier --check .",
-    "dcp": "tsx scripts/print.ts"
-  },
-  "keywords": [
-    "opencode",
-    "opencode-plugin",
-    "plugin",
-    "context",
-    "pruning",
-    "active-context",
-    "optimization",
-    "tokens",
-    "acp"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/ranxianglei/opencode-acp.git"
-  },
-  "bugs": {
-    "url": "https://github.com/ranxianglei/opencode-acp/issues"
-  },
-  "homepage": "https://github.com/ranxianglei/opencode-acp#readme",
-  "author": "ranxianglei",
-  "license": "AGPL-3.0-or-later",
-  "peerDependencies": {
-    "@opencode-ai/plugin": ">=1.4.3"
-  },
-  "dependencies": {
-    "@anthropic-ai/tokenizer": "^0.0.4",
-    "@opencode-ai/sdk": "^1.4.3",
-    "jsonc-parser": "^3.3.1",
-    "zod": "^4.3.6"
-  },
-  "devDependencies": {
-    "@opencode-ai/plugin": "^1.4.3",
-    "@types/node": "^25.5.0",
-    "prettier": "^3.8.1",
-    "tsup": "^8.5.1",
-    "tsx": "^4.21.0",
-    "typescript": "^6.0.2"
-  },
-  "files": [
-    "dist/",
-    "README.md",
-    "LICENSE"
-  ]
+    "scripts": {
+        "clean": "rm -rf dist",
+        "build": "npm run clean && tsup && tsc --emitDeclarationOnly",
+        "verify:package": "node scripts/verify-package.mjs",
+        "check:package": "npm run build && npm run verify:package",
+        "prepublishOnly": "npm run check:package",
+        "dev": "opencode plugin dev",
+        "typecheck": "tsc --noEmit",
+        "test": "node --import tsx --test tests/*.test.ts",
+        "format": "prettier --write .",
+        "format:check": "prettier --check .",
+        "dcp": "tsx scripts/print.ts"
+    },
+    "keywords": [
+        "opencode",
+        "opencode-plugin",
+        "plugin",
+        "context",
+        "pruning",
+        "active-context",
+        "optimization",
+        "tokens",
+        "acp"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/ranxianglei/opencode-acp.git"
+    },
+    "bugs": {
+        "url": "https://github.com/ranxianglei/opencode-acp/issues"
+    },
+    "homepage": "https://github.com/ranxianglei/opencode-acp#readme",
+    "author": "ranxianglei",
+    "license": "AGPL-3.0-or-later",
+    "peerDependencies": {
+        "@opencode-ai/plugin": ">=1.4.3"
+    },
+    "dependencies": {
+        "@anthropic-ai/tokenizer": "^0.0.4",
+        "@opencode-ai/sdk": "^1.4.3",
+        "jsonc-parser": "^3.3.1",
+        "zod": "^4.3.6"
+    },
+    "devDependencies": {
+        "@opencode-ai/plugin": "^1.4.3",
+        "@types/node": "^25.5.0",
+        "prettier": "^3.8.1",
+        "tsup": "^8.5.1",
+        "tsx": "^4.21.0",
+        "typescript": "^6.0.2"
+    },
+    "files": [
+        "dist/",
+        "README.md",
+        "LICENSE"
+    ]
 }

--- a/tests/e2e-blocks-nudges.test.ts
+++ b/tests/e2e-blocks-nudges.test.ts
@@ -305,7 +305,7 @@ test("block aging: old blocks are deactivated by major GC", async () => {
 
 // ─── Test: Tool error input pruning ─────────────────────────────────────────
 
-test("tool error pruning: error tool inputs are replaced with placeholder", async () => {
+test("tool error pruning: error tool inputs are preserved (prefix cache fix)", async () => {
     const { state, handler } = setupPipeline()
 
     const callID = "call-bash-err"
@@ -332,8 +332,8 @@ test("tool error pruning: error tool inputs are replaced with placeholder", asyn
 
     const toolState = (tool as any).state
     assert.equal(toolState.status, "error")
-    assert.equal(toolState.input.command, "[input removed due to failed tool call]")
-    assert.equal(toolState.input.cwd, "[input removed due to failed tool call]")
+    assert.equal(toolState.input.command, "rm -rf /")
+    assert.equal(toolState.input.cwd, "/home/user")
 })
 
 // ─── Test: Session switch resets state ──────────────────────────────────────

--- a/tests/e2e-message-transform.test.ts
+++ b/tests/e2e-message-transform.test.ts
@@ -608,7 +608,7 @@ test("compression summary: emits standalone summary when range is last (no user 
 
 // ─── Test: Tool output pruning ───────────────────────────────────────────────
 
-test("prune: pruned tool outputs are replaced with placeholder", async () => {
+test("prune: pruned tool outputs are preserved (prefix cache fix)", async () => {
     const { state, handler } = setupPipeline()
 
     const callID = "call-read-1"
@@ -631,8 +631,8 @@ test("prune: pruned tool outputs are replaced with placeholder", async () => {
     assert.ok(tool, "tool part should be present")
     const toolOutput = (tool as any).state.output as string
     assert.ok(
-        toolOutput.startsWith("[Output removed to save context - information superseded or no longer needed]"),
-        `tool output should be replaced, got: ${toolOutput}`,
+        !toolOutput.includes("[Output removed"),
+        `tool output should be preserved, got: ${toolOutput}`,
     )
 })
 

--- a/tests/prune.test.ts
+++ b/tests/prune.test.ts
@@ -329,13 +329,13 @@ test("prune strips stale mNNNN refs from summary content (Bug 28 fix)", () => {
 // pruneToolOutputs — completed tool output replacement
 // =====================================================================
 
-test("prune replaces completed tool outputs with placeholder", () => {
+test("prune preserves completed tool outputs (prefix cache fix)", () => {
     const state = createSessionState()
     state.prune.tools.set("call-1", 1)
 
     const messages: WithParts[] = [
         assistantMessage("a1", 1, [
-            toolPart("call-1", "bash", "long output that should be replaced"),
+            toolPart("call-1", "bash", "long output that should be preserved"),
         ]),
     ]
 
@@ -344,7 +344,7 @@ test("prune replaces completed tool outputs with placeholder", () => {
     const part = messages[0]!.parts[0] as any
     assert.equal(
         part.state.output,
-        "[Output removed to save context - information superseded or no longer needed]",
+        "long output that should be preserved",
     )
 })
 
@@ -407,7 +407,7 @@ test("prune does not replace outputs for error-status tools", () => {
 // pruneToolInputs — question tool input replacement
 // =====================================================================
 
-test("prune replaces question tool input questions with placeholder", () => {
+test("prune preserves question tool inputs (prefix cache fix)", () => {
     const state = createSessionState()
     state.prune.tools.set("call-q", 1)
 
@@ -424,7 +424,7 @@ test("prune replaces question tool input questions with placeholder", () => {
     const part = messages[0]!.parts[0] as any
     assert.equal(
         part.state.input.questions,
-        "[questions removed - see output for user's answers]",
+        "What color do you prefer?",
     )
 })
 
@@ -450,7 +450,7 @@ test("prune does not replace question input for non-question tools", () => {
 // pruneToolErrors — error tool input replacement
 // =====================================================================
 
-test("prune replaces string inputs in errored tools with placeholder", () => {
+test("prune preserves error tool inputs (prefix cache fix)", () => {
     const state = createSessionState()
     state.prune.tools.set("call-err", 1)
 
@@ -467,16 +467,9 @@ test("prune replaces string inputs in errored tools with placeholder", () => {
     prune(state, logger, buildConfig(), messages)
 
     const part = messages[0]!.parts[0] as any
-    assert.equal(
-        part.state.input.command,
-        "[input removed due to failed tool call]",
-    )
-    assert.equal(
-        part.state.input.description,
-        "[input removed due to failed tool call]",
-    )
-    // Non-string values should NOT be replaced
-    assert.equal(part.state.input.count, 5, "non-string input should NOT be replaced")
+    assert.equal(part.state.input.command, "rm -rf /")
+    assert.equal(part.state.input.description, "dangerous command")
+    assert.equal(part.state.input.count, 5)
 })
 
 test("prune does not replace inputs for completed tools in error pruning", () => {
@@ -542,13 +535,14 @@ test("prune handles mixed scenario: compressed range + tool output pruning", () 
     const ids = messages.map((m) => m.info.id)
     assert.ok(!ids.includes("m2"), "m2 should be pruned by compression range")
 
-    // m3's tool output should be replaced
+    // m3's tool output should be preserved (prefix cache fix)
     const m3 = messages.find((m) => m.info.id === "m3")
     assert.ok(m3, "m3 should survive")
     const toolPartResult = m3!.parts.find((p: any) => p.type === "tool") as any
-    assert.ok(
-        toolPartResult.state.output.includes("[Output removed"),
-        "m3 tool output should be pruned",
+    assert.equal(
+        toolPartResult.state.output,
+        "output to be pruned",
+        "m3 tool output should be preserved (prefix cache fix)",
     )
 })
 


### PR DESCRIPTION
## Summary

- Disabled `pruneToolOutputs`, `pruneToolInputs`, `pruneToolErrors` in `prune()` — these mutated `part.state.output/input` in-place on existing messages, breaking LLM prefix cache
- Compression still works via `filterCompressedRanges` + model-initiated `compress` tool (untouched)
- Root cause of 89% fresh-token waste (50M tokens over 2 days) in long sessions

## Problem

`pruneToolOutputs` replaced completed tool outputs with a placeholder string (`"[pruned]"`) directly on the message part. This in-place mutation changes the message content that the LLM already cached → every subsequent request gets a cache miss → full context re-send (120K-450K tokens per miss).

Same bug class as issue #5 (nudge injection), which was fixed with suffix-message approach. This PR applies the same hotfix pattern to the prune pipeline.

## Evidence

Session `ses_102504697` (828 messages, 263M cache_read tokens):
- 176 cache misses over 2 days, each re-sending 120K-450K tokens
- 50.8M tokens wasted on misses (89% of all fresh input)
- Pattern: every 10-30 min, a miss followed by recovery to 99% hit rate

## Changes

| File | Change |
|------|--------|
| `lib/messages/prune.ts` | Commented out 3 mutating calls, kept `filterCompressedRanges` |
| `tests/prune.test.ts` | 4 tests updated to assert outputs preserved |
| `tests/e2e-message-transform.test.ts` | 1 e2e test updated |
| `tests/e2e-blocks-nudges.test.ts` | 1 e2e test updated |
| `devlog/2026-06-27_prune-cache-fix/` | REQ.md, DESIGN.md, WORKLOG.md |

## Review

Dual-agent review completed (Oracle + Momus) — both APPROVE.
- tsc --noEmit: 0 errors
- 42 affected tests pass
- Full suite: 376 pass, 10 fail (all environmental — Bun nested-test limitation)