### PR TITLE
fix: break chicken-and-egg deadlock in batch cleanup nudge system

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -213,7 +213,7 @@ const defaultConfig: PluginConfig = {
         maxOldGenSummaryLength: 3000,
         majorGcThresholdPercent: "100%",
         batchCleanup: {
-            lowThreshold: "60%",
+            lowThreshold: "55%",
             highThreshold: "75%",
             forceThreshold: "90%",
         },

--- a/lib/gc/merge.ts
+++ b/lib/gc/merge.ts
@@ -24,10 +24,16 @@ export interface BatchCleanupResult {
 }
 
 const DEFAULT_BATCH_CLEANUP: BatchCleanupConfig = {
-    lowThreshold: "60%",
+    lowThreshold: "55%",
     highThreshold: "75%",
     forceThreshold: "90%",
 }
+
+/** Minimum marked-block count to trigger escalation nudge (tier 2 active compress). */
+const ESCALATE_MIN_MARKED = 3
+
+/** Minimum marked/old-gen ratio to trigger escalation nudge. */
+const ESCALATE_MIN_RATIO = 0.4
 
 function resolveBatchCleanup(gc: GCConfig): BatchCleanupConfig {
     return gc.batchCleanup ?? DEFAULT_BATCH_CLEANUP
@@ -62,11 +68,15 @@ function collectActiveOldGenBlocks(state: SessionState, maxOldGenSummaryLength: 
 }
 
 function collectActiveMarkedBlocks(state: SessionState): CompressionBlock[] {
-    const ids = Array.from(state.prune.messages.markedForCleanup).sort((a, b) => a - b)
+    const messagesState = state.prune.messages
+    const ids = Array.from(messagesState.markedForCleanup).sort((a, b) => a - b)
     const blocks: CompressionBlock[] = []
     for (const id of ids) {
-        const block = state.prune.messages.blocksById.get(id)
-        if (!block || !block.active) continue
+        const block = messagesState.blocksById.get(id)
+        if (!block || !block.active) {
+            messagesState.markedForCleanup.delete(id)
+            continue
+        }
         blocks.push(block)
     }
     return blocks
@@ -218,25 +228,67 @@ export function mergeMarkedBlocks(
     return { mergedCount: sourceBlocks.length, savedTokens }
 }
 
-function buildNudgeText(state: SessionState, maxMergedLength: number): string | undefined {
-    const blocks = collectActiveMarkedBlocks(state)
-    if (blocks.length < 1) return undefined
-
-    const refs = blocks.map((b) => formatBlockRef(b.blockId)).join(", ")
-    const sourceTokens = blocks.reduce(
+function estimateTokens(blocks: CompressionBlock[]): number {
+    return blocks.reduce(
         (sum, block) => sum + (block.summaryTokens || Math.round(block.summary.length / 4)),
         0,
     )
-    const estimatedMergedTokens = Math.round(maxMergedLength / 4)
-    const estimatedSavings = Math.max(0, sourceTokens - estimatedMergedTokens)
+}
+
+function buildNudgeText(state: SessionState, maxMergedLength: number): string | undefined {
+    const marked = collectActiveMarkedBlocks(state)
+    const oldGen = collectActiveOldGenBlocks(state, maxMergedLength)
+
+    if (oldGen.length === 0) return undefined
+
+    const oldGenIds = new Set(oldGen.map((b) => b.blockId))
+    const markedOldGen = marked.filter((b) => oldGenIds.has(b.blockId))
+    const markedOldGenCount = markedOldGen.length
+    const oldGenCount = oldGen.length
+    const ratio = markedOldGenCount / oldGenCount
+    const ratioPct = Math.round(ratio * 100)
+    const escalateMinPct = Math.round(ESCALATE_MIN_RATIO * 100)
+
+    // Escalation: enough old-gen blocks marked → urge active compress now
+    if (markedOldGenCount >= ESCALATE_MIN_MARKED && ratio >= ESCALATE_MIN_RATIO) {
+        const refs = marked.map((b) => formatBlockRef(b.blockId)).join(", ")
+        const firstRef = formatBlockRef(marked[0].blockId)
+        const lastRef = formatBlockRef(marked[marked.length - 1].blockId)
+        const estimatedSavings = Math.max(0, estimateTokens(marked) - Math.round(maxMergedLength / 4))
+
+        return [
+            `🔥 ${markedOldGenCount}/${oldGenCount} old-gen blocks marked (${ratioPct}%) — ready for batch cleanup.`,
+            `Compressing ${refs} (range ${firstRef}–${lastRef}) would free ~${estimatedSavings} tokens in one cache break.`,
+            `Call compress with this range now to consolidate them.`,
+        ].join(" ")
+    }
+
+    // Some marks, not enough to escalate → keep marking
+    if (marked.length >= 1) {
+        const refs = marked.map((b) => formatBlockRef(b.blockId)).join(", ")
+        const estimatedSavings = Math.max(0, estimateTokens(marked) - Math.round(maxMergedLength / 4))
+
+        return [
+            `⚠️ ${marked.length} block(s) marked for batch cleanup (${refs}).`,
+            `Merge-compressing them would free ~${estimatedSavings} tokens.`,
+            marked.length >= 2
+                ? "They will auto-merge when context pressure reaches the high threshold."
+                : "A single marked block won't auto-merge on its own — use compress to consolidate it, or unmark_block if no longer needed.",
+            `Mark more old-gen blocks (need ≥${ESCALATE_MIN_MARKED} at ≥${escalateMinPct}%) to trigger batch cleanup sooner.`,
+            "To act now, use compress with a range covering these blocks.",
+        ].join(" ")
+    }
+
+    // No marks yet → guide the model to start marking (fixes chicken-and-egg deadlock)
+    const shown = oldGen.slice(0, 5)
+    const oldGenRefs = shown.map((b) => formatBlockRef(b.blockId)).join(", ")
+    const more = oldGenCount > 5 ? ` (+${oldGenCount - 5} more)` : ""
 
     return [
-        `⚠️ ${blocks.length} block(s) marked for batch cleanup (${refs}).`,
-        `Merge-compressing them would free ~${estimatedSavings} tokens.`,
-        blocks.length >= 2
-            ? "They will auto-merge when context pressure reaches the high threshold."
-            : "A single marked block won't auto-merge on its own — use compress to consolidate it, or unmark_block if no longer needed.",
-        "To act now, use compress with a range covering these blocks.",
+        `📋 Context pressure rising — ${oldGenCount} old-gen compressed block(s) occupy ~${estimateTokens(oldGen)} tokens (${oldGenRefs}${more}).`,
+        `Review which blocks contain information you no longer need, and use mark_block to flag them.`,
+        `Once enough are marked (≥${ESCALATE_MIN_MARKED} at ≥${escalateMinPct}% of old-gen), they'll be batch-merged in one cache break to preserve cache hit rate.`,
+        `Do NOT mark blocks you may still need.`,
     ].join(" ")
 }
 
@@ -292,26 +344,25 @@ export function runBatchCleanup(
 
     if (currentTokens >= highTokens) {
         const marked = collectActiveMarkedBlocks(state)
-        if (marked.length < 2) {
-            return noop
+        if (marked.length >= 2) {
+            const ids = marked.map((b) => b.blockId)
+            const result = mergeMarkedBlocks(state, ids, maxMergedLength)
+            if (result.mergedCount > 0) {
+                logger.info("Batch cleanup tier 2 (high): merged marked blocks", {
+                    mergedCount: result.mergedCount,
+                    savedTokens: result.savedTokens,
+                    currentTokens,
+                    highThreshold: batchCleanup.highThreshold,
+                })
+                return {
+                    tier: 2,
+                    action: "merge",
+                    mergedCount: result.mergedCount,
+                    savedTokens: result.savedTokens,
+                }
+            }
         }
-        const ids = marked.map((b) => b.blockId)
-        const result = mergeMarkedBlocks(state, ids, maxMergedLength)
-        if (result.mergedCount === 0) {
-            return noop
-        }
-        logger.info("Batch cleanup tier 2 (high): merged marked blocks", {
-            mergedCount: result.mergedCount,
-            savedTokens: result.savedTokens,
-            currentTokens,
-            highThreshold: batchCleanup.highThreshold,
-        })
-        return {
-            tier: 2,
-            action: "merge",
-            mergedCount: result.mergedCount,
-            savedTokens: result.savedTokens,
-        }
+        // Not enough marks or merge produced nothing — fall through to nudge
     }
 
     if (currentTokens >= lowTokens) {

--- a/tests/gc-merge.test.ts
+++ b/tests/gc-merge.test.ts
@@ -128,7 +128,7 @@ function buildConfig(gcOverrides: Partial<GCConfig> = {}): PluginConfig {
             maxOldGenSummaryLength: 3000,
             majorGcThresholdPercent: "100%",
             batchCleanup: {
-                lowThreshold: "60%",
+                lowThreshold: "55%",
                 highThreshold: "75%",
                 forceThreshold: "90%",
             },
@@ -374,7 +374,7 @@ test("runBatchCleanup: below low threshold (50%) → noop tier 0", () => {
     assert.equal(state.prune.messages.activeBlockIds.size, 2)
 })
 
-test("runBatchCleanup: at low threshold (60%) with marked blocks → tier 1 nudge", () => {
+test("runBatchCleanup: above low threshold (55%) with marked blocks → tier 1 nudge", () => {
     const blocks = [
         makeBlock({ blockId: 1, anchorMessageId: "a1", summary: wrapCompressedSummary(1, "one") }),
         makeBlock({ blockId: 2, runId: 2, anchorMessageId: "a2", summary: wrapCompressedSummary(2, "two") }),
@@ -409,7 +409,7 @@ test("runBatchCleanup: at high threshold (75%) with >= 2 marked blocks → tier 
     assert.equal(state.prune.messages.activeBlockIds.size, 1)
 })
 
-test("runBatchCleanup: at high threshold (75%) with 1 marked block → noop (< 2)", () => {
+test("runBatchCleanup: at high threshold (75%) with 1 marked block → tier 1 nudge (not enough for merge)", () => {
     const blocks = [
         makeBlock({ blockId: 1, anchorMessageId: "a1", summary: wrapCompressedSummary(1, "one") }),
         makeBlock({ blockId: 2, runId: 2, anchorMessageId: "a2", summary: wrapCompressedSummary(2, "two") }),
@@ -418,9 +418,11 @@ test("runBatchCleanup: at high threshold (75%) with 1 marked block → noop (< 2
     const messages: WithParts[] = [makeAssistantMessage("a1", 750)]
 
     const result = runBatchCleanup(state, buildConfig(), logger, messages)
-    assert.equal(result.tier, 0)
-    assert.equal(result.action, "none")
+    assert.equal(result.tier, 1, "should fall through to nudge when merge conditions unmet")
+    assert.equal(result.action, "nudge")
     assert.equal(result.mergedCount, 0)
+    assert.ok(result.nudgeText, "nudge text should be provided")
+    assert.ok(result.nudgeText!.includes("b1"), "nudge should reference the marked block")
     assert.equal(state.prune.messages.activeBlockIds.size, 2)
 })
 
@@ -488,7 +490,7 @@ test("runBatchCleanup: tier ordering — force takes precedence over high and lo
     assert.equal(result.action, "merge")
 })
 
-test("runBatchCleanup: high tier requires marked blocks, old-gen alone does not trigger it", () => {
+test("runBatchCleanup: at high threshold with unmarked old-gen → tier 1 nudge (mark guidance, fixes chicken-and-egg)", () => {
     const blocks = [
         makeBlock({
             blockId: 1,
@@ -508,6 +510,115 @@ test("runBatchCleanup: high tier requires marked blocks, old-gen alone does not 
     const messages: WithParts[] = [makeAssistantMessage("a1", 800)]
 
     const result = runBatchCleanup(state, buildConfig(), logger, messages)
-    assert.equal(result.tier, 0, "without marks, high tier should not fire for unmarked old-gen blocks")
-    assert.equal(result.action, "none")
+    assert.equal(result.tier, 1, "should nudge even without marks — fixes chicken-and-egg deadlock")
+    assert.equal(result.action, "nudge")
+    assert.ok(result.nudgeText, "nudge text should be provided")
+    assert.ok(result.nudgeText!.includes("mark_block"), "should guide model to use mark_block")
+    assert.ok(result.nudgeText!.includes("b1"), "should reference old-gen blocks")
+    assert.ok(result.nudgeText!.includes("b2"))
+})
+
+test("runBatchCleanup: tier 1b nudge — no marks, old-gen blocks → guides marking", () => {
+    const blocks = [
+        makeBlock({ blockId: 1, anchorMessageId: "a1", summary: wrapCompressedSummary(1, "one"), generation: "old" }),
+        makeBlock({ blockId: 2, runId: 2, anchorMessageId: "a2", summary: wrapCompressedSummary(2, "two"), generation: "old" }),
+        makeBlock({ blockId: 3, runId: 3, anchorMessageId: "a3", summary: wrapCompressedSummary(3, "three"), generation: "old" }),
+    ]
+    const state = makeState(blocks, { modelContextLimit: 1000 })
+    const messages: WithParts[] = [makeAssistantMessage("a1", 560)]
+
+    const result = runBatchCleanup(state, buildConfig(), logger, messages)
+    assert.equal(result.tier, 1)
+    assert.equal(result.action, "nudge")
+    assert.ok(result.nudgeText!.includes("mark_block"))
+    assert.ok(result.nudgeText!.includes("3 old-gen"))
+    assert.ok(!result.nudgeText!.includes("🔥"), "should not show escalation emoji without marks")
+})
+
+test("runBatchCleanup: tier 1 escalation — ≥3 marked at ≥40% → urges active compress", () => {
+    const blocks = [
+        makeBlock({ blockId: 1, anchorMessageId: "a1", summary: wrapCompressedSummary(1, "one"), generation: "old" }),
+        makeBlock({ blockId: 2, runId: 2, anchorMessageId: "a2", summary: wrapCompressedSummary(2, "two"), generation: "old" }),
+        makeBlock({ blockId: 3, runId: 3, anchorMessageId: "a3", summary: wrapCompressedSummary(3, "three"), generation: "old" }),
+        makeBlock({ blockId: 4, runId: 4, anchorMessageId: "a4", summary: wrapCompressedSummary(4, "four"), generation: "old" }),
+    ]
+    const state = makeState(blocks, { modelContextLimit: 1000, marked: [1, 2, 3] })
+    const messages: WithParts[] = [makeAssistantMessage("a1", 560)]
+
+    const result = runBatchCleanup(state, buildConfig(), logger, messages)
+    assert.equal(result.tier, 1)
+    assert.equal(result.action, "nudge")
+    assert.ok(result.nudgeText!.includes("🔥"), "should show escalation indicator")
+    assert.ok(result.nudgeText!.includes("3/4"), "should show marked/total ratio")
+    assert.ok(result.nudgeText!.includes("75%"), "should show percentage")
+    assert.ok(result.nudgeText!.includes("compress"), "should urge compress action")
+    assert.ok(result.nudgeText!.includes("b1") && result.nudgeText!.includes("b3"), "should reference range")
+})
+
+test("runBatchCleanup: tier 1 count gate — 2 marked (100% ratio) but < 3 count → no escalation", () => {
+    const blocks = [
+        makeBlock({ blockId: 1, anchorMessageId: "a1", summary: wrapCompressedSummary(1, "one"), generation: "old" }),
+        makeBlock({ blockId: 2, runId: 2, anchorMessageId: "a2", summary: wrapCompressedSummary(2, "two"), generation: "old" }),
+    ]
+    const state = makeState(blocks, { modelContextLimit: 1000, marked: [1, 2] })
+    const messages: WithParts[] = [makeAssistantMessage("a1", 560)]
+
+    const result = runBatchCleanup(state, buildConfig(), logger, messages)
+    assert.equal(result.tier, 1)
+    assert.ok(result.nudgeText!.includes("⚠️"), "should show some-marks indicator, not escalation")
+    assert.ok(!result.nudgeText!.includes("🔥"), "should NOT escalate with only 2 marked blocks")
+})
+
+test("runBatchCleanup: tier 1 ratio gate — 3 marked out of 10 (30%) → no escalation", () => {
+    const blocks: CompressionBlock[] = []
+    for (let i = 1; i <= 10; i++) {
+        blocks.push(makeBlock({
+            blockId: i,
+            runId: i,
+            anchorMessageId: `a${i}`,
+            summary: wrapCompressedSummary(i, `block ${i}`),
+            generation: "old",
+        }))
+    }
+    const state = makeState(blocks, { modelContextLimit: 1000, marked: [1, 2, 3] })
+    const messages: WithParts[] = [makeAssistantMessage("a1", 560)]
+
+    const result = runBatchCleanup(state, buildConfig(), logger, messages)
+    assert.equal(result.tier, 1)
+    assert.ok(result.nudgeText!.includes("⚠️"), "should show some-marks indicator, not escalation")
+    assert.ok(!result.nudgeText!.includes("🔥"), "should NOT escalate with 30% ratio < 40% threshold")
+    assert.ok(result.nudgeText!.includes("b1"), "should still reference marked blocks")
+})
+
+test("runBatchCleanup: young-gen block marked → escalation ratio uses old-gen subset only", () => {
+    const blocks = [
+        makeBlock({ blockId: 1, anchorMessageId: "a1", summary: wrapCompressedSummary(1, "one"), generation: "old" }),
+        makeBlock({ blockId: 2, runId: 2, anchorMessageId: "a2", summary: wrapCompressedSummary(2, "two"), generation: "old" }),
+        makeBlock({ blockId: 3, runId: 3, anchorMessageId: "a3", summary: wrapCompressedSummary(3, "three"), generation: "old" }),
+        makeBlock({ blockId: 4, runId: 4, anchorMessageId: "a4", summary: wrapCompressedSummary(4, "four"), generation: "old" }),
+        makeBlock({ blockId: 5, runId: 5, anchorMessageId: "a5", summary: wrapCompressedSummary(5, "young"), generation: "young" }),
+    ]
+    // Mark 2 old-gen + 1 young-gen = 3 total, but only 2 old-gen
+    const state = makeState(blocks, { modelContextLimit: 1000, marked: [1, 2, 5] })
+    const messages: WithParts[] = [makeAssistantMessage("a1", 560)]
+
+    const result = runBatchCleanup(state, buildConfig(), logger, messages)
+    assert.equal(result.tier, 1)
+    assert.ok(!result.nudgeText!.includes("🔥"), "should NOT escalate: only 2 old-gen marked < 3 minimum")
+    assert.ok(result.nudgeText!.includes("⚠️"), "should show some-marks indicator")
+})
+
+test("collectActiveMarkedBlocks: sweeps stale marks for deactivated blocks", () => {
+    const block1 = makeBlock({ blockId: 1, anchorMessageId: "a1", summary: wrapCompressedSummary(1, "one"), generation: "old" })
+    const block2 = makeBlock({ blockId: 2, runId: 2, anchorMessageId: "a2", summary: wrapCompressedSummary(2, "two"), generation: "old" })
+    const state = makeState([block1, block2], { modelContextLimit: 1000, marked: [1, 2] })
+
+    // Simulate block 2 being deactivated by something other than merge/unmark
+    block2.active = false
+
+    const messages: WithParts[] = [makeAssistantMessage("a1", 560)]
+    runBatchCleanup(state, buildConfig(), logger, messages)
+
+    assert.equal(state.prune.messages.markedForCleanup.has(2), false, "stale mark for deactivated block should be swept")
+    assert.equal(state.prune.messages.markedForCleanup.has(1), true, "active block mark should remain")
 })


### PR DESCRIPTION
buildNudgeText() returned undefined when no blocks were marked, creating a deadlock: model doesn't mark → nudge doesn't fire → model doesn't know to mark → repeat. The nudge that's supposed to encourage marking required an existing mark to fire.

Three-tier escalation design:
- No marks + old-gen blocks: guide model to start marking (📋)
- Some marks (<3 or <40% ratio): encourage marking more (⚠️)
- Enough marks (≥3 AND ≥40% old-gen ratio): urge active compress (🔥)

Additional fixes:
- High-tier (75%) now falls through to nudge instead of returning noop when merge conditions unmet — model gets guidance at high pressure
- lowThreshold lowered from 60% to 55% (aligns with compress trigger)
- Escalation ratio computed against old-gen subset (not all marked blocks)
- collectActiveMarkedBlocks self-cleans stale marks for deactivated blocks

Oracle review: APPROVE_WITH_NITS (both nits addressed)
Tests: 22/22 pass, tsc --noEmit clean