### PR TITLE
feat: content-aware compression nudges with decompression safety net

### DIFF
--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -393,15 +393,15 @@ export function buildContextUsageGuidance(
     const minPct = resolveThresholdPercent(config.compress.minContextLimit, modelContextLimit) ?? 45
     const maxPct = resolveThresholdPercent(config.compress.maxContextLimit, modelContextLimit) ?? 55
 
-    const base = `Context usage: ${formatK(currentTokens)} / ${formatK(modelContextLimit)} tokens (${percentage}%). ACP threshold: ${maxPct.toFixed(0)}%.`
+    const base = `Context usage: ${formatK(currentTokens)} / ${formatK(modelContextLimit)} tokens (${percentage}%).`
 
     let guidance: string
     if (pct < minPct) {
-        guidance = " Context is ample — focus on your task. Only compress obvious waste (large terminal outputs, duplicated content)."
+        guidance = " 💡 Be frugal with context — compress tool outputs you've finished using into summaries. You can decompress later; nothing is permanently lost. Lean context means better accuracy. Extract and keep what matters: user intent, key decisions, file paths, and important findings — even if buried in large messages. Compress everything else, including verbose parts of any message."
     } else if (pct < maxPct) {
-        guidance = " Context is moderate — compress completed sections and high-token waste. Preserve key details."
+        guidance = " ⚠️ Context is growing — compress completed sections and high-token waste now. Preserve key details."
     } else {
-        guidance = " Context is high — compress aggressively but selectively. Preserve only what is essential."
+        guidance = " 🔥 Context is high — compress aggressively but selectively. Preserve only what is essential."
     }
 
     return `\n\n${base}${guidance}`

--- a/lib/prompts/context-limit-nudge.ts
+++ b/lib/prompts/context-limit-nudge.ts
@@ -1,8 +1,8 @@
 export const CONTEXT_LIMIT_NUDGE = `
 <system-reminder>
-⚠️ CRITICAL: Context limit reached. You MUST use the \`compress\` tool NOW.
+⚠️ Context limit reached — time to compress the largest ranges you no longer need. Prioritize completed tool outputs and resolved work. You can decompress specific blocks later if you need details. Keeping context lean helps you stay accurate.
 
-If mid-atomic-operation, finish that step first, then compress immediately.
+If mid-atomic-operation, finish that step first, then compress.
 
 HOW TO CALL COMPRESS:
 {
@@ -17,7 +17,7 @@ HOW TO CALL COMPRESS:
 }
 
 ⚠️ ID RULES — MOST COMMON CAUSE OF ERRORS:
-- ONLY use IDs you can see in <dcp-message-id> tags in the messages ABOVE.
+- ONLY use IDs you can see in  tags in the messages ABOVE.
 - Do NOT copy IDs from this example. Do NOT invent IDs.
 - Do NOT use IDs from compressed block summaries — they are stale.
 - startId must appear BEFORE endId in the conversation.

--- a/lib/prompts/extensions/nudge.ts
+++ b/lib/prompts/extensions/nudge.ts
@@ -17,12 +17,19 @@ export function buildCompressedBlockGuidance(
 
     const refs = activeBlockIds.map((id) => `b${id}`)
     const blockCount = refs.length
-    const blockList = blockCount > 0 ? refs.join(", ") : "none"
+    let blockList: string
+    if (blockCount <= 20) {
+        blockList = blockCount > 0 ? refs.join(", ") : "none"
+    } else {
+        const recent = refs.slice(-20).join(", ")
+        blockList = `${recent} (+${blockCount - 20} older, use decompress to access by ID)`
+    }
 
     const lines = [
         "Compressed block context:",
         `- Active compressed blocks: ${blockCount} (${blockList})`,
         "- If your selected compression range includes any listed block, include each required placeholder exactly once in the summary using `(bN)`.",
+        "- 💡 When you've finished using tool outputs, compress them — you can decompress later if needed. Lean context improves accuracy.",
     ]
 
     // [FIX Bug 35] Only show aging warnings when context usage is above 50%.

--- a/lib/prompts/system.ts
+++ b/lib/prompts/system.ts
@@ -10,15 +10,15 @@ COMPRESSION PHILOSOPHY
 
 Compression replaces raw conversation content with dense summaries. When used correctly, it keeps your context sharp and focused. When used carelessly, it destroys information you need.
 
-The key principle: compress based on context pressure, not habit. When context is ample, compress rarely or not at all. When context is tight, compress aggressively but selectively. The runtime context usage indicator tells you the current pressure level.
+The key principle: compress proactively to keep context lean, but selectively. Large tool outputs (shell, diffs, logs) can be compressed into summaries at any time — you can decompress later if needed. Extract and keep what matters: user intent, key decisions, file paths, and important findings — even if buried in large messages. Compress everything else, including verbose parts of user messages, large code dumps, and long discussions.
 
 Target the largest UNCOMPRESSED content first. Savings scale with original size — compressing a 5000-token tool output frees far more than re-shrinking an already-summarized 300-token block.
 
 CONTEXT PRESSURE LEVELS
 
-- Ample: Context is well below the threshold. Do NOT compress unless there is obvious waste (huge terminal dumps, duplicated content). Focus entirely on your task.
-- Moderate: Context is approaching the threshold. Compress completed sections proactively. Prioritize high-token waste over minor cleanup.
-- High: Context has exceeded the threshold. Compress aggressively. Every compression should free meaningful tokens. Preserve only what is essential for the current task.
+- Normal: Be frugal — compress tool outputs you've finished using into summaries. You can decompress later. Extract and keep what matters from any message; compress verbose parts — including large logs in user messages or generated code.
+- Elevated: Context is growing. Compress completed sections and high-token waste more urgently.
+- Critical: Compress aggressively now. Every compression should free meaningful tokens. Preserve only what is essential for the current task.
 
 WHAT TO COMPRESS FIRST (high value, low risk)
 

--- a/lib/prompts/turn-nudge.ts
+++ b/lib/prompts/turn-nudge.ts
@@ -1,12 +1,12 @@
 export const TURN_NUDGE = `
 <system-reminder>
-Context is getting full. Compress closed/older conversation ranges now.
+Context is getting full. If you've finished reading tool outputs or exploration results, compress them — you can decompress later if needed. This keeps your focus on the current task and improves accuracy.
 
 {
   "topic": "Short Label",
   "content": [{ "startId": "<visible message ID>", "endId": "<visible message ID>", "summary": "..." }]
 }
 
-⚠️ ONLY use IDs from <dcp-message-id> tags visible above. Do NOT invent or copy example IDs.
+⚠️ ONLY use IDs from  tags visible above. Do NOT invent or copy example IDs.
 </system-reminder>
 `


### PR DESCRIPTION
Restructures ACP compression nudges from binary threshold-driven to principle-driven (be frugal, compress proactively, decompress later). 5 files, +21/-14 lines. Tested locally for 2 days.