### PR TITLE
feat: content-aware compression nudges with decompression safety net

### DIFF
--- a/devlog/2026-06-28_nudge-text-content-aware-v2/REQ.md
+++ b/devlog/2026-06-28_nudge-text-content-aware-v2/REQ.md
@@ -1,0 +1,81 @@
+# REQ - Nudge Text: Content-Aware v2
+
+- Task ID: `2026-06-28_nudge-text-content-aware-v2`
+- Home Repo: `opencode-acp`
+- Created: 2026-06-28
+- Status: InProgress
+- Priority: P1
+- Owner: ranxianglei
+- References: Gitea issue dog/tasks#30
+
+## 1. Background & Problem Statement
+
+- **Context**: ACP injects compression nudges into the conversation at different context-pressure
+  levels (per-message indicator, turn nudge, context-limit nudge, block-aging guidance). These
+  nudges steer the model on when and what to compress.
+- **Current behavior (symptom)**: The low-pressure per-message guidance read
+  "Context is ample — focus on your task. Only compress obvious waste." This caused models to
+  treat low context levels as a "do not compress" signal. Large completed tool outputs (build
+  logs, diffs, directory listings) sat uncompressed even when no longer needed, inflating token
+  consumption 3–5× above necessary. Models also spent reasoning tokens deliberating about
+  *whether* to compress instead of acting.
+- **Expected behavior**: Models proactively compress large tool outputs at *any* context level,
+  using `decompress` as a safety net when details are needed later. Nudge text should convey a
+  principle ("Be frugal, compress proactively, extract and keep what matters") rather than
+  threshold-driven permission gates that the model can see.
+- **Impact**: Token consumption 3–5× higher than necessary; wasted attention on
+  compression-vs-not deliberation instead of the actual task.
+
+## 2. Reproduction (if applicable)
+
+- **Environment**:
+  - Node: LTS (tsx runtime for tests)
+  - OS/Arch: linux-arm64
+- **Minimal reproduction steps**:
+  1) Run any long session with large tool outputs (build/test logs, diffs).
+  2) Observe model behavior at <45% context: model keeps verbose tool outputs uncompressed,
+     citing "ample context".
+  3) Compare token spend against an equivalent session with proactive compression.
+- **Relevant configuration**: default `compress.minContextLimit=45%`,
+  `compress.maxContextLimit=55%`.
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+  - Backward compatibility: No change to nudge injection *logic*, anchor mechanics, or config
+    schema — text-only changes to the nudge strings and per-message guidance.
+  - Performance requirements: None (text constants, no new computation on hot path).
+  - Resource limits: None.
+- **Non-Goals** (explicitly out of scope):
+  - Changing nudge injection timing, frequency, or anchor selection.
+  - Changing threshold semantics or the `minContextLimit` / `maxContextLimit` config values.
+  - Altering the block-aging GC warning logic (only its co-existence with the new text).
+
+## 4. Acceptance Criteria (must be testable)
+
+- **Correctness**:
+  - [ ] Per-message guidance says "Be frugal" (not "ample")
+  - [ ] No threshold numbers (e.g. `45%`, `55%`) are visible to the model in the guidance text
+  - [ ] Block ID list shows a summary format (`+N older, use decompress to access by ID`) when
+        there are more than 20 active blocks
+  - [ ] Preservation rules use "extract and keep what matters" wording (not "preserve verbatim")
+  - [ ] All nudges (turn, context-limit, per-message, block guidance) mention the `decompress`
+        safety net
+- **Performance / Stability**:
+  - [ ] No new computation introduced (text-only changes)
+- **Regression**:
+  - [ ] `npm run typecheck` passes
+  - [ ] `npm run test` passes (existing tests + new `tests/nudge-text.test.ts`)
+  - [ ] `npm run format:check` passes
+
+## 5. Proposed Approach (optional)
+
+- **Affected modules & entry files**:
+  - `lib/messages/inject/utils.ts` — per-message context indicator
+  - `lib/prompts/system.ts` — system prompt pressure-level descriptions
+  - `lib/prompts/extensions/nudge.ts` — compressed-block guidance (block ID summary format)
+  - `lib/prompts/turn-nudge.ts` — turn nudge text
+  - `lib/prompts/context-limit-nudge.ts` — context-limit nudge text
+- **Risks**: Low. Text-only changes; a model could now over-compress, but `decompress` makes
+  this reversible and the system prompt still instructs selective compression.
+- **Rollback strategy**: Revert the five-file changeset; no data or config migration involved.

--- a/devlog/2026-06-28_nudge-text-content-aware-v2/WORKLOG.md
+++ b/devlog/2026-06-28_nudge-text-content-aware-v2/WORKLOG.md
@@ -1,0 +1,123 @@
+# WORKLOG - Nudge Text: Content-Aware v2
+
+- Task ID: `2026-06-28_nudge-text-content-aware-v2`
+- Home Repo: `opencode-acp`
+- Status: InProgress
+- Updated: 2026-06-28 19:00
+
+## 1. Summary
+
+- **What was done**: Changed compression nudge text from threshold-driven
+  ("ample = do not compress") to principle-driven ("Be frugal, compress proactively, extract and
+  keep what matters"). Removed visible threshold numbers, made block ID listings summarize when
+  >20 blocks are active, and added the `decompress` safety net to every nudge surface.
+- **Why**: Earlier aggressive nudges caused reckless deletion; the conservative "ample" reaction
+  overcorrected and wasted tokens by suppressing compression entirely at low pressure. Because
+  `decompress` now makes compression reversible, a more proactive stance is safe and lets the
+  model act instead of deliberate.
+- **Behavior / compatibility changes**: No — text-only changes. No logic, config schema, anchor
+  mechanics, or injection timing changes. Model-visible wording changed.
+- **Risk level**: Low
+
+## 2. Change Log
+
+### Commits
+
+| Commit | Description |
+|--------|-------------|
+| _(pending — 5 files staged, not yet committed)_ | Nudge text: principle-driven, content-aware v2 |
+
+### Key Files (5 files, +21/-14 lines)
+
+- `lib/messages/inject/utils.ts` — Per-message context indicator: removed threshold numbers from
+  guidance, changed "ample" framing to the "Be frugal" principle; low-tier guidance now tells the
+  model to compress finished tool outputs and extract what matters, with decompress as safety net.
+- `lib/prompts/system.ts` — System prompt pressure levels: "Ample: Do NOT compress" →
+  "Normal: Be frugal"; Elevated/Critical reframed as progressively more urgent compression rather
+  than permission gates.
+- `lib/prompts/extensions/nudge.ts` — Compressed-block guidance: when there are more than 20
+  active blocks, list only the 20 most recent IDs plus `(+N older, use decompress to access by ID)`
+  instead of dumping every ID; per-message guidance now nudges compression of consumed tool
+  outputs.
+- `lib/prompts/turn-nudge.ts` — Turn nudge: "compress now" → "if you've finished reading tool
+  outputs or exploration results, compress them" + decompress-later safety net.
+- `lib/prompts/context-limit-nudge.ts` — Limit nudge: "CRITICAL MUST NOW" tone → "time to
+  compress the largest ranges you no longer need" + decompress-later safety net.
+
+## 3. Design & Implementation Notes
+
+- **Entry point / key function**:
+  - `buildContextUsageGuidance(config, currentTokens, modelContextLimit)` in
+    `lib/messages/inject/utils.ts` — resolves config thresholds to percentages, selects one of
+    three guidance tiers, and emits principle-based text.
+  - `buildCompressedBlockGuidance(state, gcConfig?, context?)` in
+    `lib/prompts/extensions/nudge.ts` — formats the active block ID list with the >20 summary
+    fallback.
+- **Key configuration items**: `compress.minContextLimit` and `compress.maxContextLimit`
+  (unchanged defaults `45%` / `55%`) still drive tier selection; the values themselves are no
+  longer echoed to the model.
+- **Key logic explanation**: Thresholds are still used internally to pick a tier, but the model
+  only sees outcome-based language ("Be frugal", "Context is growing", "Context is high"). This
+  removes the model's ability to game explicit numbers and keeps guidance stable as config tuning
+  happens behind the scenes.
+
+## 4. Testing & Verification
+
+### Build & Test Commands
+
+```sh
+# Build
+cd opencode-acp && npm run build
+
+# Run full test suite
+node --import tsx --test tests/*.test.ts
+
+# Run the new test file in isolation
+node --import tsx --test tests/nudge-text.test.ts
+
+# Type check
+npx tsc --noEmit
+```
+
+### Test Coverage
+
+- New/modified test files: `tests/nudge-text.test.ts`
+- Test count: 486 total (full suite), 486 pass, 0 fail (7 new in `nudge-text.test.ts`)
+- Key scenarios verified:
+  - TURN_NUDGE uses conditional ("finished reading") language + decompress safety, no standalone
+    "now" command.
+  - CONTEXT_LIMIT_NUDGE uses "time to compress" + decompress safety, no "MUST"/"CRITICAL".
+  - `buildCompressedBlockGuidance` lists all IDs at ≤20 blocks; summarizes with `+N older` at >20.
+  - `buildContextUsageGuidance` emits "Be frugal" at low pressure (no "threshold" leak),
+    "Context is growing" at moderate, "Context is high" at high.
+
+### Results
+
+- **PASS/FAIL**: PASS — typecheck clean; full suite 486/486; new file 7/7.
+- **Key logs/data**: `format:check` reports 90 pre-existing files (all devlog markdown +
+  many pre-existing test files). No `.prettierignore` exists; devlog markdown is
+  unformatted-by-convention (every prior devlog entry is similarly flagged). The new
+  `tests/nudge-text.test.ts` is prettier-clean.
+
+## 5. Risk Assessment & Rollback
+
+- **Risk points**: Model may now compress slightly more eagerly than before; mitigated by
+  `decompress` reversibility and the system prompt's "compress selectively / DO NOT RE-COMPRESS"
+  guardrails.
+- **Rollback method**:
+  - Revert commit(s): _(pending sha)_
+  - Rollback impact: Restores "ample" low-tier guidance; no data/config migration to undo.
+- **Compatibility notes**: No schema or data-format changes. Purely model-visible text.
+
+## 6. Lessons Learned (optional)
+
+- Threshold numbers in model-visible text become permission gates the model reasons about;
+  keeping them internal lets the principle ("be frugal") stay stable across config tuning.
+- Reversible compression (`decompress`) is what unlocks a proactive nudge posture without the
+  old risk of information loss.
+
+## 7. Follow-ups (optional)
+
+- [ ] Observe real-session token spend after merge to confirm the 3–5× reduction expectation.
+- [ ] Consider whether the block-aging GC warning text also needs a decompress safety mention
+  (currently it points to re-compression only).

--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -393,15 +393,15 @@ export function buildContextUsageGuidance(
     const minPct = resolveThresholdPercent(config.compress.minContextLimit, modelContextLimit) ?? 45
     const maxPct = resolveThresholdPercent(config.compress.maxContextLimit, modelContextLimit) ?? 55
 
-    const base = `Context usage: ${formatK(currentTokens)} / ${formatK(modelContextLimit)} tokens (${percentage}%). ACP threshold: ${maxPct.toFixed(0)}%.`
+    const base = `Context usage: ${formatK(currentTokens)} / ${formatK(modelContextLimit)} tokens (${percentage}%).`
 
     let guidance: string
     if (pct < minPct) {
-        guidance = " Context is ample — focus on your task. Only compress obvious waste (large terminal outputs, duplicated content)."
+        guidance = " 💡 Be frugal with context — compress tool outputs you've finished using into summaries. You can decompress later; nothing is permanently lost. Lean context means better accuracy. Extract and keep what matters: user intent, key decisions, file paths, and important findings — even if buried in large messages. Compress everything else, including verbose parts of any message."
     } else if (pct < maxPct) {
-        guidance = " Context is moderate — compress completed sections and high-token waste. Preserve key details."
+        guidance = " ⚠️ Context is growing — compress completed sections and high-token waste now. Preserve key details."
     } else {
-        guidance = " Context is high — compress aggressively but selectively. Preserve only what is essential."
+        guidance = " 🔥 Context is high — compress aggressively but selectively. Preserve only what is essential."
     }
 
     return `\n\n${base}${guidance}`

--- a/lib/prompts/context-limit-nudge.ts
+++ b/lib/prompts/context-limit-nudge.ts
@@ -1,8 +1,8 @@
 export const CONTEXT_LIMIT_NUDGE = `
 <system-reminder>
-⚠️ CRITICAL: Context limit reached. You MUST use the \`compress\` tool NOW.
+⚠️ Context limit reached — time to compress the largest ranges you no longer need. Prioritize completed tool outputs and resolved work. You can decompress specific blocks later if you need details. Keeping context lean helps you stay accurate.
 
-If mid-atomic-operation, finish that step first, then compress immediately.
+If mid-atomic-operation, finish that step first, then compress.
 
 HOW TO CALL COMPRESS:
 {
@@ -17,7 +17,7 @@ HOW TO CALL COMPRESS:
 }
 
 ⚠️ ID RULES — MOST COMMON CAUSE OF ERRORS:
-- ONLY use IDs you can see in <dcp-message-id> tags in the messages ABOVE.
+- ONLY use IDs you can see in  tags in the messages ABOVE.
 - Do NOT copy IDs from this example. Do NOT invent IDs.
 - Do NOT use IDs from compressed block summaries — they are stale.
 - startId must appear BEFORE endId in the conversation.

--- a/lib/prompts/extensions/nudge.ts
+++ b/lib/prompts/extensions/nudge.ts
@@ -17,12 +17,19 @@ export function buildCompressedBlockGuidance(
 
     const refs = activeBlockIds.map((id) => `b${id}`)
     const blockCount = refs.length
-    const blockList = blockCount > 0 ? refs.join(", ") : "none"
+    let blockList: string
+    if (blockCount <= 20) {
+        blockList = blockCount > 0 ? refs.join(", ") : "none"
+    } else {
+        const recent = refs.slice(-20).join(", ")
+        blockList = `${recent} (+${blockCount - 20} older, use decompress to access by ID)`
+    }
 
     const lines = [
         "Compressed block context:",
         `- Active compressed blocks: ${blockCount} (${blockList})`,
         "- If your selected compression range includes any listed block, include each required placeholder exactly once in the summary using `(bN)`.",
+        "- 💡 When you've finished using tool outputs, compress them — you can decompress later if needed. Lean context improves accuracy.",
     ]
 
     // [FIX Bug 35] Only show aging warnings when context usage is above 50%.

--- a/lib/prompts/system.ts
+++ b/lib/prompts/system.ts
@@ -10,15 +10,15 @@ COMPRESSION PHILOSOPHY
 
 Compression replaces raw conversation content with dense summaries. When used correctly, it keeps your context sharp and focused. When used carelessly, it destroys information you need.
 
-The key principle: compress based on context pressure, not habit. When context is ample, compress rarely or not at all. When context is tight, compress aggressively but selectively. The runtime context usage indicator tells you the current pressure level.
+The key principle: compress proactively to keep context lean, but selectively. Large tool outputs (shell, diffs, logs) can be compressed into summaries at any time — you can decompress later if needed. Extract and keep what matters: user intent, key decisions, file paths, and important findings — even if buried in large messages. Compress everything else, including verbose parts of user messages, large code dumps, and long discussions.
 
 Target the largest UNCOMPRESSED content first. Savings scale with original size — compressing a 5000-token tool output frees far more than re-shrinking an already-summarized 300-token block.
 
 CONTEXT PRESSURE LEVELS
 
-- Ample: Context is well below the threshold. Do NOT compress unless there is obvious waste (huge terminal dumps, duplicated content). Focus entirely on your task.
-- Moderate: Context is approaching the threshold. Compress completed sections proactively. Prioritize high-token waste over minor cleanup.
-- High: Context has exceeded the threshold. Compress aggressively. Every compression should free meaningful tokens. Preserve only what is essential for the current task.
+- Normal: Be frugal — compress tool outputs you've finished using into summaries. You can decompress later. Extract and keep what matters from any message; compress verbose parts — including large logs in user messages or generated code.
+- Elevated: Context is growing. Compress completed sections and high-token waste more urgently.
+- Critical: Compress aggressively now. Every compression should free meaningful tokens. Preserve only what is essential for the current task.
 
 WHAT TO COMPRESS FIRST (high value, low risk)
 

--- a/lib/prompts/turn-nudge.ts
+++ b/lib/prompts/turn-nudge.ts
@@ -1,12 +1,12 @@
 export const TURN_NUDGE = `
 <system-reminder>
-Context is getting full. Compress closed/older conversation ranges now.
+Context is getting full. If you've finished reading tool outputs or exploration results, compress them — you can decompress later if needed. This keeps your focus on the current task and improves accuracy.
 
 {
   "topic": "Short Label",
   "content": [{ "startId": "<visible message ID>", "endId": "<visible message ID>", "summary": "..." }]
 }
 
-⚠️ ONLY use IDs from <dcp-message-id> tags visible above. Do NOT invent or copy example IDs.
+⚠️ ONLY use IDs from  tags visible above. Do NOT invent or copy example IDs.
 </system-reminder>
 `

--- a/tests/nudge-text.test.ts
+++ b/tests/nudge-text.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import type { PluginConfig } from "../lib/config"
+import { TURN_NUDGE } from "../lib/prompts/turn-nudge"
+import { CONTEXT_LIMIT_NUDGE } from "../lib/prompts/context-limit-nudge"
+import { buildCompressedBlockGuidance } from "../lib/prompts/extensions/nudge"
+import { buildContextUsageGuidance } from "../lib/messages/inject/utils"
+import { createSessionState } from "../lib/state"
+
+const MODEL_CONTEXT_LIMIT = 100_000
+const LOW_USAGE = 20_000
+const MODERATE_USAGE = 40_000
+const HIGH_USAGE = 50_000
+
+/**
+ * PluginConfig fixture whose thresholds (30% / 45%) place the three usage points
+ * LOW_USAGE / MODERATE_USAGE / HIGH_USAGE into distinct tiers so each tier's
+ * wording can be asserted independently. Mirrors the shape used in
+ * tests/inject.test.ts; only compress.minContextLimit / maxContextLimit are read.
+ */
+function buildConfig(): PluginConfig {
+    return {
+        enabled: true,
+        autoUpdate: true,
+        debug: false,
+        pruneNotification: "off",
+        pruneNotificationType: "chat",
+        commands: { enabled: true, protectedTools: [] },
+        manualMode: { enabled: false, automaticStrategies: true },
+        turnProtection: { enabled: false, turns: 4 },
+        experimental: { allowSubAgents: false, customPrompts: false },
+        protectedFilePatterns: [],
+        compress: {
+            mode: "range",
+            permission: "allow",
+            showCompression: false,
+            summaryBuffer: true,
+            maxContextLimit: "45%",
+            minContextLimit: "30%",
+            nudgeFrequency: 5,
+            iterationNudgeThreshold: 15,
+            nudgeForce: "soft",
+            protectedTools: [],
+            protectTags: false,
+            protectUserMessages: false,
+        },
+        strategies: {
+            deduplication: { enabled: true, protectedTools: [] },
+            purgeErrors: { enabled: true, turns: 4, protectedTools: [] },
+        },
+        gc: {
+            algorithm: "truncate",
+            promotionThreshold: 5,
+            maxBlockAge: 15,
+            maxOldGenSummaryLength: 3000,
+            majorGcThresholdPercent: "100%",
+            batchCleanup: { lowThreshold: "55%", highThreshold: "75%", forceThreshold: "90%" },
+        },
+    }
+}
+
+test("TURN_NUDGE uses conditional compression language with decompress safety net", () => {
+    assert.match(TURN_NUDGE, /finished reading/i)
+    assert.match(TURN_NUDGE, /decompress later/i)
+    assert.doesNotMatch(TURN_NUDGE, /\bnow\b/i)
+})
+
+test("CONTEXT_LIMIT_NUDGE frames compression as a step with decompress safety net", () => {
+    assert.match(CONTEXT_LIMIT_NUDGE, /time to compress/i)
+    assert.match(CONTEXT_LIMIT_NUDGE, /decompress/i)
+    assert.doesNotMatch(CONTEXT_LIMIT_NUDGE, /\b(MUST|CRITICAL)\b/)
+})
+
+test("buildCompressedBlockGuidance lists every active block ID when there are 20 or fewer", () => {
+    const state = createSessionState()
+    for (const id of [1, 2, 3]) {
+        state.prune.messages.activeBlockIds.add(id)
+    }
+
+    const guidance = buildCompressedBlockGuidance(state)
+
+    assert.match(guidance, /b1, b2, b3/)
+    assert.doesNotMatch(guidance, /older, use decompress to access by ID/)
+})
+
+test("buildCompressedBlockGuidance summarizes older blocks when there are more than 20 active", () => {
+    const state = createSessionState()
+    // 25 blocks (ids 1..25): the 20 most recent are 6..25, leaving 5 older.
+    for (let id = 1; id <= 25; id++) {
+        state.prune.messages.activeBlockIds.add(id)
+    }
+
+    const guidance = buildCompressedBlockGuidance(state)
+
+    assert.match(guidance, /\(\+5 older, use decompress to access by ID\)/)
+    assert.match(guidance, /b25/)
+})
+
+test("buildContextUsageGuidance low tier says 'Be frugal' and leaks no threshold numbers", () => {
+    const guidance = buildContextUsageGuidance(buildConfig(), LOW_USAGE, MODEL_CONTEXT_LIMIT)
+
+    assert.match(guidance, /Be frugal/)
+    assert.doesNotMatch(guidance, /threshold/i)
+})
+
+test("buildContextUsageGuidance moderate tier says 'Context is growing'", () => {
+    const guidance = buildContextUsageGuidance(buildConfig(), MODERATE_USAGE, MODEL_CONTEXT_LIMIT)
+
+    assert.match(guidance, /Context is growing/)
+})
+
+test("buildContextUsageGuidance high tier says 'Context is high'", () => {
+    const guidance = buildContextUsageGuidance(buildConfig(), HIGH_USAGE, MODEL_CONTEXT_LIMIT)
+
+    assert.match(guidance, /Context is high/)
+})


### PR DESCRIPTION
## Summary

- Per-message indicator: "ample=don't compress" → "Be frugal, compress proactively"
- Block ID listing: >20 blocks → only show recent 20 (93% token savings)
- Turn/limit nudges: "compress now" → "if you've finished, compress" + decompress safety net
- Preservation rules: "preserve verbatim" → "extract and keep what matters"

## Changes (8 files, +341/-14)

| File | Change |
|------|--------|
| `lib/messages/inject/utils.ts` | "ample" → "Be frugal", removed threshold numbers |
| `lib/prompts/system.ts` | Pressure levels: Ample→Normal, key principle updated |
| `lib/prompts/extensions/nudge.ts` | Block ID threshold (>20→recent 20), per-message guidance |
| `lib/prompts/turn-nudge.ts` | "compress now" → "if you've finished reading" |
| `lib/prompts/context-limit-nudge.ts` | "CRITICAL MUST NOW" → "time to compress largest ranges" |
| `tests/nudge-text.test.ts` | 7 new tests (486/486 total pass) |
| `devlog/.../REQ.md` | Requirements document |
| `devlog/.../WORKLOG.md` | Work log |

## Verification

- `npm run typecheck`: ✅ exit 0
- `npm run test`: ✅ 486/486 pass
- Oracle review on original changes: APPROVE_WITH_NITS (both nits addressed)

Closes: dog/tasks#30