### PR TITLE
chore: bump version to 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.4.2",
+    "version": "1.5.0",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 34 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
Version bump after npm publish of v1.5.0 (content-aware compression nudges).

npm package already published: https://www.npmjs.com/package/opencode-acp/v/1.5.0