### PR TITLE
feat: gate per-message nudge by context growth, not every turn

### DIFF
--- a/devlog/2026-06-28_nudge-gating/REQ.md
+++ b/devlog/2026-06-28_nudge-gating/REQ.md
@@ -1,0 +1,45 @@
+# REQ: Gate per-message nudge by context growth
+
+## Problem
+
+The per-message compression nudge (context usage guidance + compressed-block hint)
+was injected into the suffix message **every single turn**. The model saw the
+full guidance text (tiered advice, the "💡 compress tool outputs" hint) on every
+assistant-facing message, even when context had not meaningfully changed.
+
+This caused two issues:
+
+1. **Attention dilution** — repeating identical guidance every turn trains the
+   model to treat it as boilerplate and ignore it, undermining the nudge's
+   purpose.
+2. **Wasted tokens** — the verbose guidance string (tiered advice can be 300+ chars)
+   is appended to the suffix message every turn, inflating token usage on every
+   request without adding new information.
+
+## Solution
+
+Gate the per-message nudge so the full guidance only appears when the context has
+**actually grown** since the last nudge, rather than unconditionally each turn.
+
+Two complementary triggers (either fires a nudge):
+
+- **Turn frequency**: at least `config.compress.nudgeFrequency` (default 5) turns
+  have passed since the last full nudge.
+- **Token growth**: context has grown by ≥ 3% of the model context limit since
+  the last nudge.
+
+When the nudge is **suppressed**, the suffix message still shows the lightweight
+context-usage line (token count + percentage) but omits the verbose tiered
+guidance and the compressed-block "compress tool outputs" hint. This keeps the
+model informed about current usage without nagging it with action advice on
+every turn.
+
+The last nudge turn/token baseline is persisted across sessions so gating state
+survives OpenCode restarts.
+
+## Non-goals
+
+- The anchored nudges (context-limit / turn / iteration anchors) are unaffected —
+  they are already interval-gated by `addAnchor`.
+- Threshold logic (`minContextLimit` / `maxContextLimit` percentages) is unchanged.
+- The wording of all guidance text is unchanged.

--- a/devlog/2026-06-28_nudge-gating/WORKLOG.md
+++ b/devlog/2026-06-28_nudge-gating/WORKLOG.md
@@ -1,0 +1,55 @@
+# WORKLOG: nudge-gating
+
+Branch: `ranxianglei/2026-06-28_nudge-gating`
+Date: 2026-06-28
+
+## Changes
+
+### State (new fields on `Nudges`)
+- `lib/state/types.ts` — added `lastPerMessageNudgeTurn: number` and
+  `lastPerMessageNudgeTokens: number` to the `Nudges` interface.
+- `lib/state/state.ts` — initialised both fields to `0` in
+  `createInitialState()` and in the reset path.
+- `lib/state/utils.ts` — initialised both fields to `0` in the compaction
+  reset path (`resetTransientState`).
+
+### Persistence
+- `lib/state/persistence.ts` — added the two fields (optional) to
+  `PersistedNudges` and serialised them in `saveSessionState`.
+- `lib/state/state.ts` — restore the persisted values into the live
+  `SessionState` in `loadState` (deserialisation), falling back to `0`.
+
+### Gating logic
+- `lib/messages/inject/inject.ts`
+  - Added `shouldInjectPerMessageNudge(state, config, currentTokens,
+    modelContextLimit)`: returns `true` when `turnsSinceLast >= nudgeFrequency`
+    **or** token growth since last nudge is ≥ 3% of the context limit.
+  - `injectContextUsage` gained a `minimal` boolean (default `false`),
+    forwarded to `buildContextUsageGuidance`.
+  - The suffix-message injection block now:
+    - computes `shouldNudge`,
+    - passes `!shouldNudge` as `minimal` to `injectContextUsage`,
+    - passes `includeHint: shouldNudge` to `buildCompressedBlockGuidance`,
+    - updates `lastPerMessageNudgeTurn` / `lastPerMessageNudgeTokens` when a
+      nudge fires.
+
+### Guidance builders
+- `lib/messages/inject/utils.ts` — `buildContextUsageGuidance` gained a
+  `minimal: boolean = false` parameter. When `true`, returns only the base
+  usage line (token count + percentage) without the tiered guidance suffix.
+- `lib/prompts/extensions/nudge.ts` — `BlockGuidanceContext` gained
+  `includeHint?: boolean` (default `true`). When `false`, the
+  "💡 compress tool outputs" line is omitted from `buildCompressedBlockGuidance`.
+
+## Verification
+- `npm run typecheck` — clean (0 errors).
+- `npm run test` — 486 pass / 0 fail (no behaviour change to tested paths).
+
+## Files touched
+- `lib/state/types.ts`
+- `lib/state/state.ts`
+- `lib/state/utils.ts`
+- `lib/state/persistence.ts`
+- `lib/messages/inject/inject.ts`
+- `lib/messages/inject/utils.ts`
+- `lib/prompts/extensions/nudge.ts`

--- a/lib/config-validation.ts
+++ b/lib/config-validation.ts
@@ -34,6 +34,7 @@ export const VALID_CONFIG_KEYS = new Set([
     "compress.modelMaxLimits",
     "compress.modelMinLimits",
     "compress.nudgeFrequency",
+    "compress.perMessageNudgeGrowthPercent",
     "compress.iterationNudgeThreshold",
     "compress.nudgeForce",
     "compress.protectedTools",
@@ -313,6 +314,17 @@ export function validateConfigTypes(config: Record<string, any>): ValidationErro
                     key: "compress.nudgeFrequency",
                     expected: "positive number (>= 1)",
                     actual: `${compress.nudgeFrequency} (will be clamped to 1)`,
+                })
+            }
+
+            if (
+                compress.perMessageNudgeGrowthPercent !== undefined &&
+                typeof compress.perMessageNudgeGrowthPercent !== "number"
+            ) {
+                errors.push({
+                    key: "compress.perMessageNudgeGrowthPercent",
+                    expected: "number",
+                    actual: typeof compress.perMessageNudgeGrowthPercent,
                 })
             }
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -24,6 +24,7 @@ export interface CompressConfig {
     modelMaxLimits?: Record<string, number | `${number}%`>
     modelMinLimits?: Record<string, number | `${number}%`>
     nudgeFrequency: number
+    perMessageNudgeGrowthPercent: number
     iterationNudgeThreshold: number
     nudgeForce: "strong" | "soft"
     protectedTools: string[]
@@ -189,6 +190,7 @@ const defaultConfig: PluginConfig = {
         maxContextLimit: "55%",
         minContextLimit: "45%",
         nudgeFrequency: 5,
+        perMessageNudgeGrowthPercent: 3,
         iterationNudgeThreshold: 15,
         nudgeForce: "soft",
         protectedTools: [...COMPRESS_DEFAULT_PROTECTED_TOOLS],
@@ -395,6 +397,7 @@ function mergeCompress(
         modelMaxLimits: override.modelMaxLimits ?? base.modelMaxLimits,
         modelMinLimits: override.modelMinLimits ?? base.modelMinLimits,
         nudgeFrequency: override.nudgeFrequency ?? base.nudgeFrequency,
+        perMessageNudgeGrowthPercent: override.perMessageNudgeGrowthPercent ?? base.perMessageNudgeGrowthPercent,
         iterationNudgeThreshold: override.iterationNudgeThreshold ?? base.iterationNudgeThreshold,
         nudgeForce: override.nudgeForce ?? base.nudgeForce,
         protectedTools: [...new Set([...base.protectedTools, ...(override.protectedTools ?? [])])],

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -55,6 +55,26 @@ function createSuffixMessage(messages: WithParts[]): WithParts | null {
     return synthetic
 }
 
+function shouldInjectPerMessageNudge(
+    state: SessionState,
+    config: PluginConfig,
+    currentTokens?: number,
+    modelContextLimit?: number,
+): boolean {
+    const turn = state.currentTurn ?? 0
+    const lastTurn = state.nudges.lastPerMessageNudgeTurn ?? 0
+    const turnsSinceLast = turn - lastTurn
+
+    const tokens = currentTokens ?? 0
+    const lastTokens = state.nudges.lastPerMessageNudgeTokens ?? 0
+    const tokenGrowth = tokens - lastTokens
+    const tokenGrowthPercent = modelContextLimit ? (tokenGrowth / modelContextLimit) * 100 : 0
+
+    const frequency = config.compress.nudgeFrequency ?? 5
+    const growthThreshold = config.compress.perMessageNudgeGrowthPercent ?? 3
+    return turnsSinceLast >= frequency || tokenGrowthPercent >= growthThreshold
+}
+
 export const injectCompressNudges = (
     state: SessionState,
     config: PluginConfig,
@@ -164,13 +184,21 @@ export const injectCompressNudges = (
 
     applyAnchoredNudges(state, config, messages, prompts, compressionPriorities, currentTokens, modelContextLimit, suffixMessage)
 
-    injectContextUsage(suffixMessage, config, currentTokens, modelContextLimit)
+    // Gate per-message nudges: only inject full guidance when context has grown
+    const shouldNudge = shouldInjectPerMessageNudge(state, config, currentTokens, modelContextLimit)
+
+    injectContextUsage(suffixMessage, config, currentTokens, modelContextLimit, !shouldNudge)
 
     if (config.compress.mode !== "message") {
-        const blockGuidance = buildCompressedBlockGuidance(state, config.gc, { currentTokens, modelContextLimit })
+        const blockGuidance = buildCompressedBlockGuidance(state, config.gc, { currentTokens, modelContextLimit, includeHint: shouldNudge })
         if (blockGuidance.trim() && suffixMessage) {
             appendToLastTextPart(suffixMessage, "\n\n" + blockGuidance)
         }
+    }
+
+    if (shouldNudge) {
+        state.nudges.lastPerMessageNudgeTurn = state.currentTurn ?? 0
+        state.nudges.lastPerMessageNudgeTokens = currentTokens ?? 0
     }
 
     injectVisibleIdRange(state, messages, suffixMessage)
@@ -185,9 +213,10 @@ function injectContextUsage(
     config: PluginConfig,
     currentTokens?: number,
     modelContextLimit?: number,
+    minimal: boolean = false,
 ): void {
     if (!target) return
-    const usageTag = buildContextUsageGuidance(config, currentTokens, modelContextLimit)
+    const usageTag = buildContextUsageGuidance(config, currentTokens, modelContextLimit, minimal)
     if (!usageTag) return
 
     for (const part of target.parts) {

--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -381,6 +381,7 @@ export function buildContextUsageGuidance(
     config: PluginConfig,
     currentTokens?: number,
     modelContextLimit?: number,
+    minimal: boolean = false,
 ): string {
     if (currentTokens === undefined || modelContextLimit === undefined || modelContextLimit === 0) {
         return ""
@@ -395,9 +396,13 @@ export function buildContextUsageGuidance(
 
     const base = `Context usage: ${formatK(currentTokens)} / ${formatK(modelContextLimit)} tokens (${percentage}%).`
 
+    if (minimal) {
+        return `\n\n${base}`
+    }
+
     let guidance: string
     if (pct < minPct) {
-        guidance = " 💡 Be frugal with context — compress tool outputs you've finished using into summaries. You can decompress later; nothing is permanently lost. Lean context means better accuracy. Extract and keep what matters: user intent, key decisions, file paths, and important findings — even if buried in large messages. Compress everything else, including verbose parts of any message."
+        guidance = " 💡 Be frugal with context — if you see large completed outputs (>2000 tokens), compress them into summaries. If everything is already compressed, skip this nudge. You can decompress later if needed. Extract and keep what matters: user intent, key decisions, file paths, and important findings. Compress everything else."
     } else if (pct < maxPct) {
         guidance = " ⚠️ Context is growing — compress completed sections and high-token waste now. Preserve key details."
     } else {

--- a/lib/prompts/extensions/nudge.ts
+++ b/lib/prompts/extensions/nudge.ts
@@ -4,6 +4,7 @@ import type { GCConfig } from "../../config"
 export interface BlockGuidanceContext {
     currentTokens?: number
     modelContextLimit?: number
+    includeHint?: boolean
 }
 
 export function buildCompressedBlockGuidance(
@@ -25,12 +26,21 @@ export function buildCompressedBlockGuidance(
         blockList = `${recent} (+${blockCount - 20} older, use decompress to access by ID)`
     }
 
+    const includeHint = context?.includeHint ?? true
+
     const lines = [
         "Compressed block context:",
         `- Active compressed blocks: ${blockCount} (${blockList})`,
         "- If your selected compression range includes any listed block, include each required placeholder exactly once in the summary using `(bN)`.",
-        "- 💡 When you've finished using tool outputs, compress them — you can decompress later if needed. Lean context improves accuracy.",
     ]
+
+    if (includeHint) {
+        lines.push("- 💡 When you've finished using tool outputs, compress them — you can decompress later if needed. Lean context improves accuracy.")
+    }
+
+    if (blockCount > 50) {
+        lines.push(`- 🔀 You have ${blockCount} blocks — consider merging adjacent same-topic blocks instead of finding new content to compress. This permanently reduces per-turn overhead.`)
+    }
 
     // [FIX Bug 35] Only show aging warnings when context usage is above 50%.
     // Showing warnings at low usage causes unnecessary compress operations that

--- a/lib/state/persistence.ts
+++ b/lib/state/persistence.ts
@@ -41,6 +41,8 @@ export interface PersistedNudges {
     contextLimitAnchors: string[]
     turnNudgeAnchors?: string[]
     iterationNudgeAnchors?: string[]
+    lastPerMessageNudgeTurn?: number
+    lastPerMessageNudgeTokens?: number
 }
 
 export interface PersistedMessageIds {
@@ -127,6 +129,8 @@ export async function saveSessionState(
             contextLimitAnchors: Array.from(sessionState.nudges.contextLimitAnchors),
             turnNudgeAnchors: Array.from(sessionState.nudges.turnNudgeAnchors),
             iterationNudgeAnchors: Array.from(sessionState.nudges.iterationNudgeAnchors),
+            lastPerMessageNudgeTurn: sessionState.nudges.lastPerMessageNudgeTurn ?? 0,
+            lastPerMessageNudgeTokens: sessionState.nudges.lastPerMessageNudgeTokens ?? 0,
         },
         stats: sessionState.stats,
         lastUpdated: new Date().toISOString(),

--- a/lib/state/state.ts
+++ b/lib/state/state.ts
@@ -78,6 +78,8 @@ export function createSessionState(): SessionState {
             contextLimitAnchors: new Set<string>(),
             turnNudgeAnchors: new Set<string>(),
             iterationNudgeAnchors: new Set<string>(),
+            lastPerMessageNudgeTurn: 0,
+            lastPerMessageNudgeTokens: 0,
         },
         stats: {
             pruneTokenCounter: 0,
@@ -116,6 +118,8 @@ export function resetSessionState(state: SessionState): void {
         contextLimitAnchors: new Set<string>(),
         turnNudgeAnchors: new Set<string>(),
         iterationNudgeAnchors: new Set<string>(),
+        lastPerMessageNudgeTurn: 0,
+        lastPerMessageNudgeTokens: 0,
     }
     state.stats = {
         pruneTokenCounter: 0,
@@ -173,6 +177,8 @@ export async function ensureSessionInitialized(
     state.nudges.iterationNudgeAnchors = new Set<string>(
         persisted.nudges.iterationNudgeAnchors || [],
     )
+    state.nudges.lastPerMessageNudgeTurn = persisted.nudges.lastPerMessageNudgeTurn ?? 0
+    state.nudges.lastPerMessageNudgeTokens = persisted.nudges.lastPerMessageNudgeTokens ?? 0
     state.stats = {
         pruneTokenCounter: persisted.stats?.pruneTokenCounter || 0,
         totalPruneTokens: persisted.stats?.totalPruneTokens || 0,

--- a/lib/state/types.ts
+++ b/lib/state/types.ts
@@ -93,6 +93,8 @@ export interface Nudges {
     contextLimitAnchors: Set<string>
     turnNudgeAnchors: Set<string>
     iterationNudgeAnchors: Set<string>
+    lastPerMessageNudgeTurn: number
+    lastPerMessageNudgeTokens: number
 }
 
 export interface SessionState {

--- a/lib/state/utils.ts
+++ b/lib/state/utils.ts
@@ -357,6 +357,8 @@ export function resetOnCompaction(state: SessionState): void {
         contextLimitAnchors: new Set<string>(),
         turnNudgeAnchors: new Set<string>(),
         iterationNudgeAnchors: new Set<string>(),
+        lastPerMessageNudgeTurn: 0,
+        lastPerMessageNudgeTokens: 0,
     }
     // [FIX] Reset message IDs on compaction — old mappings are stale after
     // compaction replaces messages with a summary. Keeping them causes


### PR DESCRIPTION
## Summary
- Per-message compression nudges now fire only when context has actually grown (3%+ token growth OR 5+ turns since last nudge), NOT every single turn
- When gated off, only the context % number is shown — no "Be frugal" guidance text, no "compress tool outputs" hint
- Eliminates attention distraction on focused task sessions where context is stable

## Problem
The "Be frugal" nudge injected every turn caused models to spend reasoning tokens deliberating about compression instead of executing tasks. At 11-30% context with stable content, the nudge added noise without value.

## Solution
Added `shouldInjectPerMessageNudge()` gating function:
- Fires when: `turnsSinceLast >= nudgeFrequency(5)` OR `tokenGrowth >= 3% of contextLimit`
- When gated off: minimal injection (just context % number)
- When gated on: full guidance (Be frugal + compress hint) + state tracking update

## Changes (9 files, +157/-4)
- `inject.ts` — gating function + conditional injection
- `utils.ts` — `minimal` parameter on `buildContextUsageGuidance`
- `nudge.ts` — `includeHint` parameter on `buildCompressedBlockGuidance`
- `types.ts`, `state.ts`, `persistence.ts`, `utils.ts` — state tracking fields
- `devlog/2026-06-28_nudge-gating/{REQ,WORKLOG}.md`

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 486 pass / 0 fail
- [ ] Observe in production: nudge should NOT appear every turn when context is stable