### PR TITLE
chore: bump version to 1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 34 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
Release version bump after #34 (fix: synthetic suffix messages break title generation). Tag `v1.5.1` pushed; `opencode-acp@1.5.1` already published to npm. This PR puts the version-bump commit on master (master is branch-protected).