### PR TITLE
chore: bump version to 1.6.0

### DIFF
--- a/devlog/2026-06-29_release-1.6.0/REQ.md
+++ b/devlog/2026-06-29_release-1.6.0/REQ.md
@@ -1,0 +1,19 @@
+# REQ: Release v1.6.0
+
+## Background
+PR #36 (context optimization) merged to master. Need to publish npm v1.6.0 with all changes.
+
+## Changes in v1.6.0 (since v1.5.1)
+1. Two-tier summary length limits (soft 200 / hard 800)
+2. Minimum compress range (2000 chars)
+3. Step marker truncation (step-start skipped, step-finish ~50 chars)
+4. Nudge strengthening + directive consolidation guidance
+5. mark_block + unmark_block removed from model tools
+6. Auto-detect consumed blocks in compress (Plan B)
+7. Directive nudge range fix (anchorMessageId, visible range filter)
+8. GC simplified to hardcoded 100% fallback
+9. README updated (English + Chinese)
+
+## Version Bump
+- 1.5.1 → 1.6.0
+- Minor version bump: significant feature changes (tool removal, new auto-detection, config options)

--- a/devlog/2026-06-29_release-1.6.0/WORKLOG.md
+++ b/devlog/2026-06-29_release-1.6.0/WORKLOG.md
@@ -1,0 +1,15 @@
+# WORKLOG: Release v1.6.0
+
+## Steps
+1. Synced master with GitHub (PR #36 merged, commit c734daf)
+2. Bumped version: 1.5.1 → 1.6.0 in package.json
+3. Ran official checks: typecheck ✅, test 0 fail ✅, build ✅ (323KB)
+4. Created devlog (REQ.md + WORKLOG.md)
+5. Committed + pushed release branch
+6. Created PR for human merge
+7. After merge: npm publish + install to local dist paths
+
+## Verification
+- `npm run typecheck`: clean
+- `npm run test`: 495 pass, 0 fail
+- `npm run build`: success (dist/index.js 323KB)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.5.1",
+    "version": "1.6.0",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 34 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
Version bump for npm release. PR #36 (context optimization) is merged.

## Changes
- `package.json`: 1.5.1 → 1.6.0
- Devlog: `devlog/2026-06-29_release-1.6.0/{REQ,WORKLOG}.md`

## v1.6.0 includes (since v1.5.1)
1. Two-tier summary limits (soft 200 / hard 800)
2. Minimum compress range (2000 chars)
3. Step marker truncation
4. Nudge strengthening + directive consolidation
5. mark_block + unmark_block removed
6. Auto-detect consumed blocks (Plan B)
7. Directive nudge range fix
8. GC simplified to 100% hardcoded
9. README updated (EN + ZH)

## Verification
- typecheck ✅ | test 495 pass 0 fail ✅ | build ✅

After merge: `npm publish` + install to local dist.