### PR TITLE
feat: dual-trigger nudge wording — proactive after use + pressure rises

### DIFF
--- a/lib/prompts/system.ts
+++ b/lib/prompts/system.ts
@@ -16,7 +16,7 @@ Target the largest UNCOMPRESSED content first. Savings scale with original size 
 
 CONTEXT PRESSURE LEVELS
 
-- Normal: Be frugal — compress large completed outputs into summaries. You can decompress later if needed.
+- Normal: Proactively compress finished outputs (agent results, verbose commands, large tool outputs) into summaries after you've finished using them. You can decompress later if needed.
 - Elevated: Context is growing — compress completed sections and high-token waste now.
 - Critical: Compress aggressively now — preserve only what is essential for the current task.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.4.2",
+    "version": "1.5.0",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 34 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- system.ts Normal level: "Be frugal" → "Proactively compress finished outputs (agent results, verbose commands, large tool outputs) into summaries after you've finished using them"
- Two triggers coexist: proactive (Normal) + pressure-based (Elevated/Critical)
- Config: nudgeFrequency 8 → 6

## Changes
- `lib/prompts/system.ts` line 19: Updated Normal pressure level wording