### PR TITLE
fix(compress): raise maxSummaryLengthHard default to 3000, fix reject feedback

### DIFF
--- a/lib/compress/message.ts
+++ b/lib/compress/message.ts
@@ -55,7 +55,7 @@ export function createCompressMessageTool(ctx: ToolContext): ReturnType<typeof t
             for (const entry of input.content) {
                 if (entry.summary.length > maxSummaryLengthHard) {
                     throw new Error(
-                        `Summary too long (${entry.summary.length} chars, hard ceiling ${maxSummaryLengthHard}). Aim for <=${ctx.config.compress.maxSummaryLength}; exceed only when strictly necessary. Rewrite more concisely.`,
+                        `Summary too long (${entry.summary.length} chars; limit ${maxSummaryLengthHard}). Rewrite to under ${maxSummaryLengthHard} chars — keep only the most essential details (conclusions, file paths, decisions, exact values) and drop verbose narration or raw dumps.`,
                     )
                 }
             }

--- a/lib/compress/range.ts
+++ b/lib/compress/range.ts
@@ -70,7 +70,7 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
             for (const entry of input.content) {
                 if (entry.summary.length > maxSummaryLengthHard) {
                     throw new Error(
-                        `Summary too long (${entry.summary.length} chars, hard ceiling ${maxSummaryLengthHard}). Aim for <=${ctx.config.compress.maxSummaryLength}; exceed only when strictly necessary. Rewrite more concisely.`,
+                        `Summary too long (${entry.summary.length} chars; limit ${maxSummaryLengthHard}). Rewrite to under ${maxSummaryLengthHard} chars — keep only the most essential details (conclusions, file paths, decisions, exact values) and drop verbose narration or raw dumps.`,
                     )
                 }
             }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -198,7 +198,7 @@ const defaultConfig: PluginConfig = {
         protectTags: false,
         protectUserMessages: false,
         maxSummaryLength: 200,
-        maxSummaryLengthHard: 800,
+        maxSummaryLengthHard: 3000,
         minCompressRange: 2000,
     },
     strategies: {


### PR DESCRIPTION
## Summary
Fixes #42 (prihuda's report: `maxSummaryLengthHard=800` caused legitimate compressions to always fail).

- **`maxSummaryLengthHard` default 800 → 3000.** The 800 ceiling was miscalibrated — real summaries routinely run 800–3000 chars, so the safety net was catching normal compression instead of pathological bloat. The soft target (`maxSummaryLength`) stays at 200 to keep summaries concise (now that `search_context` can retrieve compressed detail, over-long summaries are wasteful).
- **Fix the reject feedback.** On failure the message used to say "aim for <=200" (the soft target) — misleading at failure time. It now guides the model to trim under the actual ceiling and keep only essential detail (conclusions, file paths, decisions, exact values).

## Verification
- `tsc --noEmit`: clean
- Docker `node:20` full suite: 496 pass / 0 fail

## Notes
Tuning will be revisited once the compression-bundle feature lands; for now this unblocks users hitting the default.