### PR TITLE
feat: principle-driven compression — minimal intervention, block sizes, file decompress

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,34 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ---
 
+## Changelog
+
+### v1.7.0 — Principle-Driven Prompts
+
+**Philosophy**: Replaced verbose context-management guidance with 4 concise principles injected every turn. The model now sees *what matters* (principles) instead of *what to do* (rigid rules).
+
+**Prompt changes**:
+- 4 principles replace CONTEXT PRESSURE LEVELS, 7-item priority list, DO NOT RE-COMPRESS rules
+- Context display simplified: absolute token count only, no percentage
+- `<acp-context>` tag wrapping (backward compatible with `<dcp-context>`)
+
+**Hybrid Tips frequency**:
+- 💡 Light Tips (15-45%): Every turn — non-disruptive reminder
+- ⚠️ Warning Tips (45%+): Key nodes only — first crossing or 10pp growth, prevents over-compression
+
+**Config simplification**:
+- Removed `hardNudgeContextPercent` — merged into `minContextLimit`/`maxContextLimit`
+- Removed `perMessageNudgeGrowthPercent` — light Tips show every turn
+- `maxSummaryLength` default: 200 → 2000
+- `maxSummaryLengthHard` default: 3000 → 4000
+
+**Bug fixes**:
+- Windows path validation: `os.tmpdir()` + `path.relative()` (was hardcoded `/tmp/`)
+- Compress after-detection: reset warning tracking
+- Dead code cleanup: `shouldInjectPerMessageNudge`, no-op template
+
+---
+
 ## License
 
 AGPL-3.0-or-later -- This project is a fork of [@tarquinen/opencode-dcp](https://github.com/Tarquinen/opencode-dynamic-context-pruning). Original copyright belongs to the original author. Modifications and bug fixes by ranxianglei.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -391,6 +391,34 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ---
 
+## 更新日志
+
+### v1.7.0 — 原则驱动提示
+
+**理念**：用 4 条简洁原则替代冗长的上下文管理指导。模型现在看到的是*重要原则*而非*死板规则*。
+
+**提示变更**：
+- 4 条原则替代 CONTEXT PRESSURE LEVELS、7 项优先级列表、DO NOT RE-COMPRESS 规则
+- 上下文显示简化：仅显示绝对 token 数，不显示百分比
+- `<acp-context>` 标签包裹（向后兼容 `<dcp-context>`）
+
+**混合 Tips 频率**：
+- 💡 轻量提示（15-45%）：每轮显示 — 不打扰
+- ⚠️ 警告提示（45%+）：仅关键节点 — 首次跨越或增长 10pp，防止过度压缩
+
+**配置简化**：
+- 移除 `hardNudgeContextPercent` — 合并到 `minContextLimit`/`maxContextLimit`
+- 移除 `perMessageNudgeGrowthPercent` — 轻量提示每轮显示
+- `maxSummaryLength` 默认值：200 → 2000
+- `maxSummaryLengthHard` 默认值：3000 → 4000
+
+**Bug 修复**：
+- Windows 路径校验：`os.tmpdir()` + `path.relative()`（原硬编码 `/tmp/`）
+- 压缩检测后：重置警告追踪
+- 死代码清理：`shouldInjectPerMessageNudge`、空操作模板
+
+---
+
 ## 许可证
 
 AGPL-3.0-or-later — 本项目是 [@tarquinen/opencode-dcp](https://github.com/Tarquinen/opencode-dynamic-context-pruning) 的分支。原始版权归原始作者所有。修改和错误修复由 ranxianglei 完成。

--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -1,8 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://raw.githubusercontent.com/ranxianglei/opencode-acp/master/dcp.schema.json",
-    "title": "DCP Plugin Configuration",
-    "description": "Configuration schema for the OpenCode Dynamic Context Pruning plugin",
+    "title": "ACP Plugin Configuration",
+    "description": "Configuration schema for the OpenCode Agent Context Pruning plugin",
     "type": "object",
     "additionalProperties": false,
     "properties": {
@@ -27,13 +27,20 @@
         },
         "pruneNotification": {
             "type": "string",
-            "enum": ["off", "minimal", "detailed"],
+            "enum": [
+                "off",
+                "minimal",
+                "detailed"
+            ],
             "default": "detailed",
             "description": "Level of notification shown when context management occurs"
         },
         "pruneNotificationType": {
             "type": "string",
-            "enum": ["chat", "toast"],
+            "enum": [
+                "chat",
+                "toast"
+            ],
             "default": "chat",
             "description": "Where to display notifications (chat message or toast notification)"
         },
@@ -135,13 +142,20 @@
             "properties": {
                 "mode": {
                     "type": "string",
-                    "enum": ["range", "message"],
+                    "enum": [
+                        "range",
+                        "message"
+                    ],
                     "default": "range",
                     "description": "Compression mode. 'range' compresses spans into block summaries, 'message' compresses individual raw messages."
                 },
                 "permission": {
                     "type": "string",
-                    "enum": ["ask", "allow", "deny"],
+                    "enum": [
+                        "ask",
+                        "allow",
+                        "deny"
+                    ],
                     "default": "allow",
                     "description": "Permission mode (deny disables the tool)"
                 },
@@ -225,7 +239,10 @@
                 },
                 "nudgeForce": {
                     "type": "string",
-                    "enum": ["strong", "soft"],
+                    "enum": [
+                        "strong",
+                        "soft"
+                    ],
                     "default": "soft",
                     "description": "Controls how likely compression is after user messages. 'strong' is more likely, 'soft' is less likely."
                 },
@@ -246,6 +263,18 @@
                     "type": "boolean",
                     "default": false,
                     "description": "When enabled, your messages are never lost during compression"
+                },
+                "minNudgeContextPercent": {
+                    "type": "number",
+                    "default": 15,
+                    "minimum": 0,
+                    "description": "Minimum context usage percent to show per-message nudges"
+                },
+                "maxSummaryLengthHard": {
+                    "type": "number",
+                    "default": 4000,
+                    "minimum": 1,
+                    "description": "Hard limit for summary length in characters"
                 }
             },
             "default": {
@@ -260,7 +289,9 @@
                 "nudgeForce": "soft",
                 "protectedTools": [],
                 "protectTags": false,
-                "protectUserMessages": false
+                "protectUserMessages": false,
+                "minNudgeContextPercent": 15,
+                "maxSummaryLengthHard": 3000
             }
         },
         "gc": {
@@ -270,7 +301,9 @@
             "properties": {
                 "algorithm": {
                     "type": "string",
-                    "enum": ["truncate"],
+                    "enum": [
+                        "truncate"
+                    ],
                     "default": "truncate"
                 },
                 "promotionThreshold": {
@@ -288,8 +321,13 @@
                 "majorGcThresholdPercent": {
                     "default": "100%",
                     "oneOf": [
-                        { "type": "number" },
-                        { "type": "string", "pattern": "^\\d+(?:\\.\\d+)?%$" }
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string",
+                            "pattern": "^\\d+(?:\\.\\d+)?%$"
+                        }
                     ]
                 },
                 "batchCleanup": {
@@ -301,24 +339,39 @@
                             "default": "60%",
                             "description": "Nudge tier: at/above this usage, a reminder to merge marked blocks is injected.",
                             "oneOf": [
-                                { "type": "number" },
-                                { "type": "string", "pattern": "^\\d+(?:\\.\\d+)?%$" }
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "string",
+                                    "pattern": "^\\d+(?:\\.\\d+)?%$"
+                                }
                             ]
                         },
                         "highThreshold": {
                             "default": "75%",
                             "description": "Auto merge tier: at/above this usage, all marked blocks are merge-compressed into one.",
                             "oneOf": [
-                                { "type": "number" },
-                                { "type": "string", "pattern": "^\\d+(?:\\.\\d+)?%$" }
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "string",
+                                    "pattern": "^\\d+(?:\\.\\d+)?%$"
+                                }
                             ]
                         },
                         "forceThreshold": {
                             "default": "90%",
                             "description": "Force merge tier: at/above this usage, all old-gen blocks are merged regardless of marks.",
                             "oneOf": [
-                                { "type": "number" },
-                                { "type": "string", "pattern": "^\\d+(?:\\.\\d+)?%$" }
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "string",
+                                    "pattern": "^\\d+(?:\\.\\d+)?%$"
+                                }
                             ]
                         }
                     }

--- a/devlog/2026-07-01_principle-driven-prompts/REQ.md
+++ b/devlog/2026-07-01_principle-driven-prompts/REQ.md
@@ -1,0 +1,16 @@
+# Principle-Driven Compression Prompts
+
+## Problem
+System prompt had 72 lines of detailed compression rules (7-item priority list, 3 pressure levels, hardcoded thresholds). Models mechanically followed rules regardless of context level — compressing at 6% context, losing critical task details.
+
+## Requirements
+- R1: Simplify system prompt to high-level principles (~15 lines)
+- R2: Per-message shows only context number (no compression guidance)
+- R3: Every 10 percentage points (from 15%): show Tips with tool names (not commands)
+- R4: Below 15%: no compression prompts at all
+- R5: At 65%+: stronger tone about overflow risk
+- R6: Add "BE FRUGAL" section with examples of obvious waste
+- R7: Config: minNudgeContextPercent=15, growthPercent=10pp
+
+## Design Philosophy
+Minimal intervention. Give smart models principles, not rules. Let them decide when/what to compress.

--- a/devlog/2026-07-01_principle-driven-prompts/WORKLOG.md
+++ b/devlog/2026-07-01_principle-driven-prompts/WORKLOG.md
@@ -1,0 +1,63 @@
+# Worklog: Principle-Driven Compression Prompts
+
+## Session Summary (commits f47e383 → 8d22f7c)
+
+### Core Philosophy Change
+Replaced verbose context-management guidance (CONTEXT PRESSURE LEVELS, 7-item priority list, DO NOT RE-COMPRESS rules) with **4 concise principles** injected every turn:
+
+1. All compression serves the primary task, but be frugal.
+2. Context capacity is precious — compress waste promptly.
+3. Save context by compressing consumed outputs, not by avoiding tools.
+4. Compress by need, not by percentage.
+
+### system.ts (72→15 lines)
+- Removed: CONTEXT PRESSURE LEVELS, WHAT TO COMPRESS FIRST (7-item list), DO NOT RE-COMPRESS, WHAT TO COMPRESS CAREFULLY, BEFORE/AFTER COMPRESSING
+- Added: 4 principle-driven sentences
+- Fixed: Tag format `` / `` wrapping
+
+### utils.ts (buildContextUsageGuidance)
+- Removed: All guidance text ("Be frugal", "Extract and keep what matters", pressure level descriptions)
+- Removed: Percentage display (no longer shows "X%")
+- Now returns: Just "Context: XK tokens." + 4 principles
+
+### inject.ts — Hybrid Tips Frequency
+- **Light Tips (💡)**: Show every turn when context ≥15% and below minContextLimit
+- **Warning Tips (⚠️)**: Show at key nodes only (first crossing threshold or 10pp growth)
+  - 45-55% (minContextLimit): "⚠️ Context is growing..."
+  - 55%+ (maxContextLimit): "⚠️ Context limit reached — compress now." + compress call format
+- Reset warning tracking when context drops below warning zone
+- Removed: `shouldInjectPerMessageNudge` dead function
+- Removed: `hardNudgeContextPercent` parameter (merged into minContextLimit/maxContextLimit)
+- Removed: `perMessageNudgeGrowthPercent` for light Tips
+- Fixed: `usageTag` no-op template `${rawUsage}` → `rawUsage`
+
+### nudge.ts (buildCompressedBlockGuidance)
+- Removed: Consolidation suggestion
+- Added: Block token counts in list — `b50 (76t), b51 (88t), ...`
+
+### range.ts + message.ts (compress tools)
+- Changed: Read `maxSummaryLengthHard` from config instead of hardcoded 3000
+- Added: `summaryMaxChars` optional parameter for per-call override
+
+### decompress.ts
+- Added: `toFile` optional parameter — writes content to file without inflating context
+- Fixed: Windows path validation — `os.tmpdir()` + `path.relative()` instead of hardcoded `/tmp/` + `startsWith(dir+"/")`
+
+### config.ts
+- Added: `minNudgeContextPercent` (default 15) — Tips start showing
+- Removed: `hardNudgeContextPercent` (replaced by minContextLimit/maxContextLimit)
+- Removed: `perMessageNudgeGrowthPercent` (light Tips show every turn)
+- Changed: `maxSummaryLength` default 200 → 2000
+- Changed: `maxSummaryLengthHard` default 3000 → 4000
+
+### dcp.schema.json
+- Removed: `hardNudgeContextPercent`, `perMessageNudgeGrowthPercent`
+- Updated: Default values aligned with config.ts
+
+### config-validation.ts
+- Removed: Validation blocks for deleted parameters
+
+## Verification
+- typecheck: 0 errors
+- tests: 496 pass, 0 fail
+- build: 330KB

--- a/lib/compress/decompress.ts
+++ b/lib/compress/decompress.ts
@@ -82,6 +82,10 @@ function buildSchema() {
         blockId: tool.schema
             .string()
             .describe('Block reference to decompress (e.g., "b0", "b2")'),
+        toFile: tool.schema
+            .string()
+            .optional()
+            .describe("If provided, writes restored content to this file path instead of inflating context. Block stays compressed. Use read tool to access specific parts. Example: '/tmp/block52.txt'"),
     }
 }
 
@@ -119,6 +123,48 @@ export function createDecompressTool(ctx: ToolContext): ReturnType<typeof tool> 
                     return `Error: Block ${target.displayId} is nested inside active block ${activeAncestorBlockId}. Decompress block ${activeAncestorBlockId} first.`
                 }
                 return `Error: Block ${target.displayId} is not active. It may have already been decompressed.`
+            }
+
+            if (args.toFile) {
+                const targetPath = args.toFile as string
+                const os = await import("os")
+                const path = await import("path")
+                const allowedDirs = [
+                    os.tmpdir() + "/",
+                    path.join(os.homedir(), ".cache", "opencode") + "/",
+                ]
+                const resolved = path.resolve(targetPath)
+                const isAllowed = allowedDirs.some((dir) => {
+                    const rel = path.relative(dir, resolved)
+                    return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel))
+                })
+                if (!isAllowed) {
+                    return `Error: toFile path must be under ${os.tmpdir()} or ~/.cache/opencode/. Got: ${targetPath}`
+                }
+                const block = activeBlocks[0]
+                const msgIds = new Set(block.effectiveMessageIds ?? [])
+                const blockMessages = rawMessages.filter((m) => {
+                    const id = (m as { id?: string }).id ?? (m as { messageId?: string }).messageId ?? ""
+                    return msgIds.has(id)
+                })
+                const lines = blockMessages.map((m) => {
+                    const msg = m as { role?: string; type?: string; content?: unknown; text?: string }
+                    const role = msg.role || msg.type || "unknown"
+                    const content =
+                        typeof msg.content === "string"
+                            ? msg.content
+                            : typeof msg.text === "string"
+                              ? msg.text
+                              : JSON.stringify(msg.content || msg.text || "")
+                    return `[${role}]\n${content}`
+                })
+                const { writeFile } = await import("fs/promises")
+                const fileContent =
+                    lines.length > 0
+                        ? lines.join("\n\n---\n\n")
+                        : (block.summary ?? "(no content available)")
+                await writeFile(args.toFile as string, fileContent, "utf-8")
+                return `Block b${target.displayId} content (${blockMessages.length} messages, ${fileContent.length} chars) written to ${args.toFile}. Block stays compressed — context unchanged. Use read tool to access specific parts.`
             }
 
             const activeMessagesBefore = snapshotActiveMessages(messagesState)

--- a/lib/compress/message.ts
+++ b/lib/compress/message.ts
@@ -13,7 +13,7 @@ import {
 } from "./state"
 import type { CompressMessageToolArgs } from "./types"
 
-function buildSchema(maxSummaryLength: number) {
+function buildSchema() {
     return {
         topic: tool.schema
             .string()
@@ -32,11 +32,15 @@ function buildSchema(maxSummaryLength: number) {
                     summary: tool.schema
                         .string()
                         .describe(
-                            `Complete technical summary replacing that one message. Aim for <=${maxSummaryLength} chars; exceed only when strictly necessary to preserve critical detail (file paths, decisions, signatures, exact values). Never pad.`,
+                            "Complete technical summary replacing that one message. Keep only essential details (conclusions, file paths, decisions, exact values, etc.).",
                         ),
                 }),
             )
             .describe("Batch of individual message summaries to create in one tool call"),
+        summaryMaxChars: tool.schema
+            .number()
+            .optional()
+            .describe("Override max summary length (default max: 4000 chars). Use when content is important and needs more detail — don't lose critical info just to fit the limit."),
     }
 }
 
@@ -46,16 +50,16 @@ export function createCompressMessageTool(ctx: ToolContext): ReturnType<typeof t
 
     return tool({
         description: runtimePrompts.compressMessage + MESSAGE_FORMAT_EXTENSION,
-        args: buildSchema(ctx.config.compress.maxSummaryLength),
+        args: buildSchema(),
         async execute(args, toolCtx) {
             const input = args as CompressMessageToolArgs
             validateArgs(input)
 
-            const maxSummaryLengthHard = ctx.config.compress.maxSummaryLengthHard
+            const maxLen = (args as { summaryMaxChars?: number }).summaryMaxChars ?? ctx.config.compress.maxSummaryLengthHard
             for (const entry of input.content) {
-                if (entry.summary.length > maxSummaryLengthHard) {
+                if (entry.summary.length > maxLen) {
                     throw new Error(
-                        `Summary too long (${entry.summary.length} chars; limit ${maxSummaryLengthHard}). Rewrite to under ${maxSummaryLengthHard} chars — keep only the most essential details (conclusions, file paths, decisions, exact values) and drop verbose narration or raw dumps.`,
+                        `Summary too long (${entry.summary.length} chars, max ${maxLen}).\n1. If this summary is nearly the same size as the original content, it may not be worth compressing — skip it.\n2. Strip noise (failed attempts, verbose outputs) but keep project-critical details (file paths, decisions, exact values).\n3. For important content needing detail, pass summaryMaxChars to increase the limit — don't lose critical info just to fit. Example: add "summaryMaxChars": 6000 to the tool call args.`,
                     )
                 }
             }

--- a/lib/compress/range.ts
+++ b/lib/compress/range.ts
@@ -26,7 +26,7 @@ import {
 } from "./state"
 import type { CompressRangeToolArgs } from "./types"
 
-function buildSchema(maxSummaryLength: number) {
+function buildSchema() {
     return {
         topic: tool.schema
             .string()
@@ -45,13 +45,17 @@ function buildSchema(maxSummaryLength: number) {
                     summary: tool.schema
                         .string()
                         .describe(
-                            `Complete technical summary replacing all content in range. Aim for <=${maxSummaryLength} chars; exceed only when strictly necessary to preserve critical detail (file paths, decisions, signatures, exact values). Never pad.`,
+                            "Complete technical summary replacing all content in range. Keep only essential details (conclusions, file paths, decisions, exact values, etc.).",
                         ),
                 }),
             )
             .describe(
                 "One or more ranges to compress, each with start/end boundaries and a summary",
             ),
+        summaryMaxChars: tool.schema
+            .number()
+            .optional()
+            .describe("Override max summary length (default max: 4000 chars). Use when content is important and needs more detail — don't lose critical info just to fit the limit."),
     }
 }
 
@@ -61,16 +65,16 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
 
     return tool({
         description: runtimePrompts.compressRange + RANGE_FORMAT_EXTENSION,
-        args: buildSchema(ctx.config.compress.maxSummaryLength),
+        args: buildSchema(),
         async execute(args, toolCtx) {
             const input = args as CompressRangeToolArgs
             validateArgs(input)
 
-            const maxSummaryLengthHard = ctx.config.compress.maxSummaryLengthHard
+            const maxLen = (args as { summaryMaxChars?: number }).summaryMaxChars ?? ctx.config.compress.maxSummaryLengthHard
             for (const entry of input.content) {
-                if (entry.summary.length > maxSummaryLengthHard) {
+                if (entry.summary.length > maxLen) {
                     throw new Error(
-                        `Summary too long (${entry.summary.length} chars; limit ${maxSummaryLengthHard}). Rewrite to under ${maxSummaryLengthHard} chars — keep only the most essential details (conclusions, file paths, decisions, exact values) and drop verbose narration or raw dumps.`,
+                        `Summary too long (${entry.summary.length} chars, max ${maxLen}).\n1. If this summary is nearly the same size as the original content, it may not be worth compressing — skip it.\n2. Strip noise (failed attempts, verbose outputs) but keep project-critical details (file paths, decisions, exact values).\n3. For important content needing detail, pass summaryMaxChars to increase the limit — don't lose critical info just to fit. Example: add "summaryMaxChars": 6000 to the tool call args.`,
                     )
                 }
             }

--- a/lib/config-validation.ts
+++ b/lib/config-validation.ts
@@ -34,13 +34,12 @@ export const VALID_CONFIG_KEYS = new Set([
     "compress.modelMaxLimits",
     "compress.modelMinLimits",
     "compress.nudgeFrequency",
-    "compress.perMessageNudgeGrowthPercent",
+    "compress.minNudgeContextPercent",
     "compress.iterationNudgeThreshold",
     "compress.nudgeForce",
     "compress.protectedTools",
     "compress.protectTags",
     "compress.protectUserMessages",
-    "compress.maxSummaryLength",
     "compress.maxSummaryLengthHard",
     "compress.minCompressRange",
     "gc",
@@ -321,17 +320,6 @@ export function validateConfigTypes(config: Record<string, any>): ValidationErro
             }
 
             if (
-                compress.perMessageNudgeGrowthPercent !== undefined &&
-                typeof compress.perMessageNudgeGrowthPercent !== "number"
-            ) {
-                errors.push({
-                    key: "compress.perMessageNudgeGrowthPercent",
-                    expected: "number",
-                    actual: typeof compress.perMessageNudgeGrowthPercent,
-                })
-            }
-
-            if (
                 compress.iterationNudgeThreshold !== undefined &&
                 typeof compress.iterationNudgeThreshold !== "number"
             ) {
@@ -382,28 +370,6 @@ export function validateConfigTypes(config: Record<string, any>): ValidationErro
             }
 
             if (
-                compress.maxSummaryLength !== undefined &&
-                typeof compress.maxSummaryLength !== "number"
-            ) {
-                errors.push({
-                    key: "compress.maxSummaryLength",
-                    expected: "number",
-                    actual: typeof compress.maxSummaryLength,
-                })
-            }
-
-            if (
-                typeof compress.maxSummaryLength === "number" &&
-                compress.maxSummaryLength < 1
-            ) {
-                errors.push({
-                    key: "compress.maxSummaryLength",
-                    expected: "positive number (>= 1)",
-                    actual: `${compress.maxSummaryLength}`,
-                })
-            }
-
-            if (
                 compress.maxSummaryLengthHard !== undefined &&
                 typeof compress.maxSummaryLengthHard !== "number"
             ) {
@@ -421,18 +387,6 @@ export function validateConfigTypes(config: Record<string, any>): ValidationErro
                 errors.push({
                     key: "compress.maxSummaryLengthHard",
                     expected: "positive number (>= 1)",
-                    actual: `${compress.maxSummaryLengthHard}`,
-                })
-            }
-
-            if (
-                typeof compress.maxSummaryLength === "number" &&
-                typeof compress.maxSummaryLengthHard === "number" &&
-                compress.maxSummaryLengthHard < compress.maxSummaryLength
-            ) {
-                errors.push({
-                    key: "compress.maxSummaryLengthHard",
-                    expected: `>= maxSummaryLength (${compress.maxSummaryLength})`,
                     actual: `${compress.maxSummaryLengthHard}`,
                 })
             }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -24,13 +24,12 @@ export interface CompressConfig {
     modelMaxLimits?: Record<string, number | `${number}%`>
     modelMinLimits?: Record<string, number | `${number}%`>
     nudgeFrequency: number
-    perMessageNudgeGrowthPercent: number
+    minNudgeContextPercent: number
     iterationNudgeThreshold: number
     nudgeForce: "strong" | "soft"
     protectedTools: string[]
     protectTags: boolean
     protectUserMessages: boolean
-    maxSummaryLength: number
     maxSummaryLengthHard: number
     minCompressRange: number
 }
@@ -191,14 +190,13 @@ const defaultConfig: PluginConfig = {
         maxContextLimit: "55%",
         minContextLimit: "45%",
         nudgeFrequency: 5,
-        perMessageNudgeGrowthPercent: 3,
+        minNudgeContextPercent: 15,
         iterationNudgeThreshold: 15,
         nudgeForce: "soft",
         protectedTools: [...COMPRESS_DEFAULT_PROTECTED_TOOLS],
         protectTags: false,
         protectUserMessages: false,
-        maxSummaryLength: 200,
-        maxSummaryLengthHard: 3000,
+        maxSummaryLengthHard: 4000,
         minCompressRange: 2000,
     },
     strategies: {
@@ -401,13 +399,12 @@ function mergeCompress(
         modelMaxLimits: override.modelMaxLimits ?? base.modelMaxLimits,
         modelMinLimits: override.modelMinLimits ?? base.modelMinLimits,
         nudgeFrequency: override.nudgeFrequency ?? base.nudgeFrequency,
-        perMessageNudgeGrowthPercent: override.perMessageNudgeGrowthPercent ?? base.perMessageNudgeGrowthPercent,
+        minNudgeContextPercent: override.minNudgeContextPercent ?? base.minNudgeContextPercent,
         iterationNudgeThreshold: override.iterationNudgeThreshold ?? base.iterationNudgeThreshold,
         nudgeForce: override.nudgeForce ?? base.nudgeForce,
         protectedTools: [...new Set([...base.protectedTools, ...(override.protectedTools ?? [])])],
         protectTags: override.protectTags ?? base.protectTags,
         protectUserMessages: override.protectUserMessages ?? base.protectUserMessages,
-        maxSummaryLength: override.maxSummaryLength ?? base.maxSummaryLength,
         maxSummaryLengthHard: override.maxSummaryLengthHard ?? base.maxSummaryLengthHard,
         minCompressRange: override.minCompressRange ?? base.minCompressRange,
     }

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -55,26 +55,6 @@ function createSuffixMessage(messages: WithParts[]): WithParts | null {
     return synthetic
 }
 
-function shouldInjectPerMessageNudge(
-    state: SessionState,
-    config: PluginConfig,
-    currentTokens?: number,
-    modelContextLimit?: number,
-): boolean {
-    const turn = state.currentTurn ?? 0
-    const lastTurn = state.nudges.lastPerMessageNudgeTurn ?? 0
-    const turnsSinceLast = turn - lastTurn
-
-    const tokens = currentTokens ?? 0
-    const lastTokens = state.nudges.lastPerMessageNudgeTokens ?? 0
-    const tokenGrowth = tokens - lastTokens
-    const tokenGrowthPercent = modelContextLimit ? (tokenGrowth / modelContextLimit) * 100 : 0
-
-    const frequency = config.compress.nudgeFrequency ?? 5
-    const growthThreshold = config.compress.perMessageNudgeGrowthPercent ?? 3
-    return turnsSinceLast >= frequency || tokenGrowthPercent >= growthThreshold
-}
-
 export const injectCompressNudges = (
     state: SessionState,
     config: PluginConfig,
@@ -98,6 +78,7 @@ export const injectCompressNudges = (
         state.nudges.contextLimitAnchors.clear()
         state.nudges.turnNudgeAnchors.clear()
         state.nudges.iterationNudgeAnchors.clear()
+        state.nudges.lastPerMessageNudgeTokens = 0
         void saveSessionState(state, logger)
         return
     }
@@ -184,10 +165,34 @@ export const injectCompressNudges = (
 
     applyAnchoredNudges(state, config, messages, prompts, compressionPriorities, currentTokens, modelContextLimit, suffixMessage)
 
-    // Gate per-message nudges: only inject full guidance when context has grown
-    const shouldNudge = shouldInjectPerMessageNudge(state, config, currentTokens, modelContextLimit)
+    const contextPct = modelContextLimit && currentTokens ? (currentTokens / modelContextLimit) * 100 : 0
+    const minPercent = config.compress?.minNudgeContextPercent ?? 15
 
-    injectContextUsage(suffixMessage, config, currentTokens, modelContextLimit, !shouldNudge)
+    injectContextUsage(suffixMessage, config, currentTokens, modelContextLimit)
+
+    // Determine tips tier: light (every turn) vs warning (key nodes only)
+    let tipsText: string | null = null
+
+    if (overMaxLimit || overMinLimit) {
+        // Warning zone: show at key nodes only (first crossing or 10pp growth)
+        const lastWarnPct = state.nudges.lastPerMessageNudgeTokens && modelContextLimit
+            ? (state.nudges.lastPerMessageNudgeTokens / modelContextLimit) * 100
+            : 0
+        const growthSinceWarn = contextPct - lastWarnPct
+        if (lastWarnPct === 0 || growthSinceWarn >= 10) {
+            tipsText = overMaxLimit
+                ? "\n\n⚠️ Context limit reached — compress now. Prioritize consumed tool outputs.\n\n{ \"topic\": \"...\", \"content\": [{ \"startId\": \"<ID>\", \"endId\": \"<ID>\", \"summary\": \"...\" }] }\n\nOnly use IDs from visible messages above. Compress older work first."
+                : "\n\n⚠️ Context is growing — consider compressing older work. Tools: compress, decompress, search_context."
+            state.nudges.lastPerMessageNudgeTokens = currentTokens ?? 0
+            state.nudges.lastPerMessageNudgeTurn = state.currentTurn ?? 0
+        }
+    } else if (contextPct >= minPercent) {
+        tipsText = "\n\n💡 Tools: compress, decompress, search_context."
+        // Reset warning tracking when context drops below warning zone
+        if (state.nudges.lastPerMessageNudgeTokens) {
+            state.nudges.lastPerMessageNudgeTokens = 0
+        }
+    }
 
     if (config.compress.mode !== "message") {
         const visibleMessageIds = new Set<string>(
@@ -196,7 +201,7 @@ export const injectCompressNudges = (
         const blockGuidance = buildCompressedBlockGuidance(state, config.gc, {
             currentTokens,
             modelContextLimit,
-            includeHint: shouldNudge,
+            includeHint: tipsText !== null,
             visibleMessageIds,
         })
         if (blockGuidance.trim() && suffixMessage) {
@@ -204,12 +209,15 @@ export const injectCompressNudges = (
         }
     }
 
-    if (shouldNudge) {
-        state.nudges.lastPerMessageNudgeTurn = state.currentTurn ?? 0
-        state.nudges.lastPerMessageNudgeTokens = currentTokens ?? 0
+    if (tipsText && suffixMessage) {
+        appendToLastTextPart(suffixMessage, tipsText)
     }
 
     injectVisibleIdRange(state, messages, suffixMessage)
+
+    if (suffixMessage) {
+        appendToLastTextPart(suffixMessage, "\n</acp-context>")
+    }
 
     if (anchorsChanged) {
         void saveSessionState(state, logger)
@@ -221,11 +229,11 @@ function injectContextUsage(
     config: PluginConfig,
     currentTokens?: number,
     modelContextLimit?: number,
-    minimal: boolean = false,
 ): void {
     if (!target) return
-    const usageTag = buildContextUsageGuidance(config, currentTokens, modelContextLimit, minimal)
-    if (!usageTag) return
+    const rawUsage = buildContextUsageGuidance(config, currentTokens, modelContextLimit)
+    if (!rawUsage) return
+    const usageTag = rawUsage
 
     for (const part of target.parts) {
         if (part.type === "text") {
@@ -251,7 +259,7 @@ function injectVisibleIdRange(state: SessionState, messages: WithParts[], target
     visibleRefs.sort()
     const first = visibleRefs[0]
     const last = visibleRefs[visibleRefs.length - 1]
-    const rangeTag = `\n\n[Visible message IDs: ${first} to ${last} (${visibleRefs.length} messages). Only use IDs in this range for compress.]`
+    const rangeTag = `\n\n[Visible messages: ${first} to ${last} (${visibleRefs.length} messages)]`
 
     for (const part of target.parts) {
         if (part.type === "text") {

--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -381,35 +381,14 @@ export function buildContextUsageGuidance(
     config: PluginConfig,
     currentTokens?: number,
     modelContextLimit?: number,
-    minimal: boolean = false,
 ): string {
     if (currentTokens === undefined || modelContextLimit === undefined || modelContextLimit === 0) {
         return ""
     }
 
-    const pct = (currentTokens / modelContextLimit) * 100
-    const percentage = pct.toFixed(1)
     const formatK = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n))
 
-    const minPct = resolveThresholdPercent(config.compress.minContextLimit, modelContextLimit) ?? 45
-    const maxPct = resolveThresholdPercent(config.compress.maxContextLimit, modelContextLimit) ?? 55
-
-    const base = `Context usage: ${formatK(currentTokens)} / ${formatK(modelContextLimit)} tokens (${percentage}%).`
-
-    if (minimal) {
-        return `\n\n${base}`
-    }
-
-    let guidance: string
-    if (pct < minPct) {
-        guidance = " 💡 Be frugal with context. If any visible tool output exceeds 5000 characters and you've finished reading it, compress it into a summary now — don't keep large outputs 'just in case'. You can decompress later if needed."
-    } else if (pct < maxPct) {
-        guidance = " ⚠️ Context is growing — compress completed sections and high-token waste now."
-    } else {
-        guidance = " 🔥 Context is high — compress aggressively, preserve only what is essential."
-    }
-
-    return `\n\n${base}${guidance}`
+    return `\n\nContext: ${formatK(currentTokens)} tokens.\nAll compression serves the primary task, but be frugal. Context capacity is precious — compress waste promptly. Save context by compressing consumed outputs, not by avoiding tools. Compress by need, not by percentage.`
 }
 
 export function applyAnchoredNudges(

--- a/lib/messages/utils.ts
+++ b/lib/messages/utils.ts
@@ -12,11 +12,11 @@ const SUMMARY_ID_HASH_LENGTH = 16
 const MERGED_SUMMARY_HEADER = (blockId: number | string) =>
     `[ACP compressed context summary (block ${blockId}) — prior conversation recap]\n`
 const MERGED_SUMMARY_FOOTER = `\n[End ACP compressed context summary]\n\n`
-const DCP_BLOCK_ID_TAG_REGEX = /(<dcp-message-id(?=[\s>])[^>]*>)b\d+(<\/dcp-message-id>)/g
+const DCP_BLOCK_ID_TAG_REGEX = /(<dcp-message-id(?=[\s>])[^>]*>)b\d+(<\/(?:dcp|acp)-message-id>)/g
 // [FIX Bug 28] Regex to strip stale mNNNN refs from compressed summaries
-const DCP_MESSAGE_REF_TAG_REGEX = /<dcp-message-id>m\d+<\/dcp-message-id>/g
-const DCP_PAIRED_TAG_REGEX = /<dcp[^>]*>[\s\S]*?<\/dcp[^>]*>/gi
-const DCP_UNPAIRED_TAG_REGEX = /<\/?dcp[^>]*>/gi
+const DCP_MESSAGE_REF_TAG_REGEX = /<dcp-message-id>m\d+<\/(?:dcp|acp)-message-id>/g
+const DCP_PAIRED_TAG_REGEX = /<dcp[^>]*>[\s\S]*?<\/(?:dcp|acp)[^>]*>/gi
+const DCP_UNPAIRED_TAG_REGEX = /<\/?(?:dcp|acp)[^>]*>/gi
 
 const generateStableId = (prefix: string, seed: string): string => {
     const hash = createHash("sha256").update(seed).digest("hex").slice(0, SUMMARY_ID_HASH_LENGTH)

--- a/lib/prompts/extensions/nudge.ts
+++ b/lib/prompts/extensions/nudge.ts
@@ -22,7 +22,11 @@ export function buildCompressedBlockGuidance(
         .filter((id) => Number.isInteger(id) && id > 0)
         .sort((a, b) => a - b)
 
-    const refs = activeBlockIds.map((id) => `b${id}`)
+    const refs = activeBlockIds.map((id) => {
+        const block = state.prune.messages.blocksById.get(id)
+        const tokens = block?.summaryTokens ?? 0
+        return `b${id}${tokens > 0 ? ` (${tokens}t)` : ""}`
+    })
     const blockCount = refs.length
     let blockList: string
     if (blockCount <= 20) {
@@ -35,13 +39,11 @@ export function buildCompressedBlockGuidance(
     const includeHint = context?.includeHint ?? true
 
     const lines = [
-        "Compressed block context:",
-        `- Active compressed blocks: ${blockCount} (${blockList})`,
-        "- System auto-detects blocks in range — no need to manually list (bN) placeholders. Just write a short prose summary.",
+        `- Compressed blocks: ${blockCount} (${blockList})`,
     ]
 
     if (includeHint) {
-        lines.push("- 💡 When you've finished using tool outputs, compress them — you can decompress later if needed. Lean context improves accuracy.")
+        lines.push("- 💡 Tools: compress, decompress, search_context.")
     }
 
     if (blockCount > 50) {
@@ -90,8 +92,6 @@ export function buildCompressedBlockGuidance(
                 lines.push(...targets)
                 lines.push(`  System auto-detects blocks in range — no need to manually list (bN) placeholders. Just write a short prose summary.`)
             }
-        } else {
-            lines.push(`- 🔀 You have ${blockCount} blocks — use compress to consolidate adjacent same-topic blocks.`)
         }
     }
 

--- a/lib/prompts/store.ts
+++ b/lib/prompts/store.ts
@@ -121,7 +121,7 @@ export const PROMPT_KEYS: PromptKey[] = [
 const HTML_COMMENT_REGEX = /<!--[\s\S]*?-->/g
 const LEGACY_INLINE_COMMENT_LINE_REGEX = /^[ \t]*\/\/.*?\/\/[ \t]*$/gm
 const DCP_SYSTEM_REMINDER_TAG_REGEX =
-    /^\s*<dcp-system-reminder\b[^>]*>[\s\S]*<\/dcp-system-reminder>\s*$/i
+    /^\s*<dcp-system-reminder\b[^>]*>[\s\S]*<\/(?:dcp|acp)-system-reminder>\s*$/i
 const DEFAULTS_README_FILE = "README.md"
 
 const BUNDLED_EDITABLE_PROMPTS: Record<EditablePromptField, string> = {
@@ -218,7 +218,7 @@ function unwrapDcpTagIfWrapped(content: string): string {
     if (DCP_SYSTEM_REMINDER_TAG_REGEX.test(trimmed)) {
         return trimmed
             .replace(/^\s*<dcp-system-reminder\b[^>]*>\s*/i, "")
-            .replace(/\s*<\/dcp-system-reminder>\s*$/i, "")
+            .replace(/\s*<\/(?:dcp|acp)-system-reminder>\s*$/i, "")
             .trim()
     }
 
@@ -233,7 +233,7 @@ function normalizeReminderPromptContent(content: string): string {
     }
 
     const startsWrapped = /^\s*<dcp-system-reminder\b[^>]*>/i.test(normalized)
-    const endsWrapped = /<\/dcp-system-reminder>\s*$/i.test(normalized)
+    const endsWrapped = /<\/(?:dcp|acp)-system-reminder>\s*$/i.test(normalized)
 
     if (startsWrapped !== endsWrapped) {
         return ""

--- a/lib/prompts/system.ts
+++ b/lib/prompts/system.ts
@@ -4,69 +4,17 @@ You operate in a context-constrained environment. Context management helps prese
 
 The tools you have for context management are \`compress\`, \`decompress\`, and \`search_context\`. \`compress\` replaces older conversation content with technical summaries you produce. \`decompress\` restores previously compressed content when you need exact details. \`search_context\` searches compressed block summaries (and visible messages) to locate relevant content before you decompress.
 
-\`<dcp-message-id>\` and \`<dcp-system-reminder>\` tags are environment-injected metadata. Do not output them.
+\`<acp-context>\` tags wrap ACP (Agent Context Pruning) system metadata \u2014 context management information injected each turn. This is system data, not user input. You may also see \`<dcp-message-id>\` and \`<dcp-system-reminder>\` tags \u2014 these are equivalent (DCP was the previous name for ACP).
 
 COMPRESSION PHILOSOPHY
 
-Compression replaces raw conversation content with dense summaries. When used correctly, it keeps your context sharp and focused. When used carelessly, it destroys information you need.
+All compression serves the primary task, but be frugal. Two failure modes to avoid:
+- Over-compression: Compressing too aggressively loses critical details, decisions, and state needed for your task. This directly harms task quality.
+- Under-compression: Failing to compress verbose outputs causes context overflow, reducing accuracy and eventually blocking your work.
 
-The key principle: compress selectively to keep context lean — but never compress content you're actively using for an ongoing task. Compression is for COMPLETED work, not work in progress. Before compressing, ask: "Will I need this in the next few turns?" If yes or unsure, keep it. Large tool outputs (shell, diffs, logs) can be compressed into summaries after the task using them is done — you can decompress later if needed. Extract and keep what matters: user intent, key decisions, file paths, and important findings — even if buried in large messages. Compress everything else, including verbose parts of user messages, large code dumps, and long discussions.
+Balance is key. Compress selectively to keep context lean. But never compress content you're actively using for an ongoing task. Use \`search_context\` to find compressed content when needed, and \`decompress\` to restore details.
 
-Target the largest UNCOMPRESSED content first. Savings scale with original size — compressing a 5000-token tool output frees far more than re-shrinking an already-summarized 300-token block.
+BE FRUGAL
 
-CONTEXT PRESSURE LEVELS
-
-- Normal: After completing a task or sub-task, compress its tool outputs (agent results, verbose commands, large tool outputs) into summaries. Do NOT compress content you're actively using for an ongoing task — wait until the task is complete. You can decompress later if needed.
-- Elevated: Context is growing — compress completed sections and high-token waste now.
-- Critical: Compress aggressively now — preserve only what is essential for the current task.
-
-WHAT TO COMPRESS FIRST (high value, low risk)
-
-- Agent/subagent review and consultation results: Prime compression targets when context pressure rises — the surrounding reasoning and tool-call chatter is typically the largest block of uncompressed content. Note: if the agent tool is in your protected list, its output is auto-preserved in the summary, so the savings come from the surrounding conversation, not the agent output itself. Compress once you have fully consumed the results (all recommended actions applied or recorded in files). Recover via \`decompress\` while the block is still active. Re-invoking the agent is a last resort — it is a fresh run, not a cache hit.
-- Verbose command output (build/test runs, git diff/log/status, publish logs, directory listings): Once you have read the result, compress. Keep only the verdict — pass/fail status, commit hash, version number, or count. For failures, keep the specific error messages and file/line references needed to act on them. The full output is reproducible by re-running the command.
-- Exploration that led nowhere (failed approaches, dead-end searches): Compress to a one-line note about what was tried and why it failed.
-- Redundant tool results (reading the same file multiple times, repeated status checks, exhausted search results): Keep only the most recent result.
-- Intermediate steps of completed multi-step tasks: Once the task is done, compress the process. Keep only the final outcome.
-- Resolved discussion threads (clarification rounds, negotiated requirements, design debate that reached a decision): Once a conclusion is recorded, compress the back-and-forth. Keep the decision and its rationale.
-- Large file contents that have already been used and are no longer needed: Compress to a summary of key functions, types, or patterns.
-
-DO NOT RE-COMPRESS (low value, diminishing returns)
-
-- Already-compressed block summaries: Re-compressing a summary into a shorter summary saves negligible tokens. If a block needs better detail, use \`decompress\` to restore it, then compress the original content properly. Exception: if a block-aging warning flags specific block IDs as facing GC truncation, re-summarize exactly those flagged blocks into a fresh range — this preserves detail that GC would otherwise destroy.
-- Short messages (1-3 sentences): The compression overhead (block metadata, summary structure) may exceed the tokens saved.
-- Content whose immediate use is complete — the task it supported is done and no open todo/plan references it. If still in active use, let it stay.
-- User instructions and requirements: These must remain visible until the task is complete.
-- Tool calls that are still pending or in-progress: Wait until the result is returned and consumed.
-
-WHAT TO COMPRESS CAREFULLY (high risk - verify before compressing)
-
-- Temporary secrets/keys/tokens needed later: Do NOT compress unless recorded elsewhere
-- File paths and directory structures: Keep in summary - losing these wastes tokens rediscovering them
-- Key function/method signatures and APIs: Summarize with exact names and signatures
-- Critical error messages and stack traces: Keep the error type and key detail in summary
-- User preferences and requirements: These must survive compression intact
-- Architectural decisions and rationale: Summarize the decision, not just the conclusion
-
-BEFORE COMPRESSING IMPORTANT CONTENT
-
-Verify the information is persisted in one of:
-- A file you have written or edited
-- An issue, PR, or devlog entry
-- The compression summary itself (include the critical bits explicitly)
-
-If it is not persisted anywhere, either persist it first or include it explicitly in your compression summary.
-
-AFTER COMPRESSING
-
-Generate recovery breadcrumbs in your summary so future-you can reconstruct the context:
-- Reference specific files by path
-- Include key variable names, function signatures, or configuration values
-- Note what was decided and why, not just what was done
-- Example: "Implemented auth check in src/middleware.ts using validateToken() from auth.ts - user table is users not user"
-
-If you later realize you need the original details from a compressed block, use \`decompress\` to restore them. You can decompress, read the content, then re-compress if needed.
-
-Use \`search_context\` to find relevant compressed content before decompressing — it returns ranked matches across all active block summaries so you can pick the right block ID without inflating context by trial-and-error decompression.
-
-Use \`compress\` and \`decompress\` deliberately with quality-first summaries. Prioritize stale content intelligently to maintain a high-signal context window.
+Be frugal with context \u2014 compress obvious waste promptly. Examples include verbose command output (build/test logs, git diff/status, npm install), sub-agent results once consumed, experiment/training logs (keep final metrics only), duplicate file reads, and failed explorations. Any content that is finished serving the task and would not be needed in upcoming turns should be compressed \u2014 not just these examples.
 `

--- a/tests/config-validation.test.ts
+++ b/tests/config-validation.test.ts
@@ -154,12 +154,3 @@ test("validateConfigTypes catches wrong type for compress.maxSummaryLengthHard",
     assert.equal(result[0].key, "compress.maxSummaryLengthHard")
     assert.equal(result[0].actual, "string")
 })
-
-test("validateConfigTypes rejects compress.maxSummaryLengthHard < maxSummaryLength", () => {
-    const result = validateConfigTypes({
-        compress: { maxSummaryLength: 200, maxSummaryLengthHard: 100 },
-    })
-    const hit = result.find((e) => e.key === "compress.maxSummaryLengthHard")
-    assert.ok(hit, "hard ceiling below soft target must be flagged")
-    assert.ok(hit!.expected.includes(">= maxSummaryLength"))
-})

--- a/tests/e2e-blocks-nudges.test.ts
+++ b/tests/e2e-blocks-nudges.test.ts
@@ -211,7 +211,7 @@ test("nudge injection: context usage tag injected when modelContextLimit is set"
     assert.ok(suffixMessage, "suffix message should be created")
     const textParts = suffixMessage!.parts.filter((p: any) => p.type === "text")
     const combinedText = textParts.map((p: any) => p.text).join("")
-    assert.ok(combinedText.includes("Context usage:"), "should inject context usage tag")
+    assert.ok(combinedText.includes("Context:"), "should inject context tag")
 })
 
 // ─── Test: No nudge when permission is denied ───────────────────────────────
@@ -240,7 +240,7 @@ test("nudge injection: no context usage tag when permission is denied", async ()
     assert.ok(lastUser)
     const textParts = lastUser!.parts.filter((p: any) => p.type === "text" && !p.synthetic)
     const originalText = textParts.map((p: any) => p.text).join("")
-    assert.ok(!originalText.includes("Context usage:"), "should NOT inject context usage with deny")
+    assert.ok(!originalText.includes("Context:"), "should NOT inject context with deny")
 })
 
 // ─── Test: Block deactivation by age (major GC) ─────────────────────────────
@@ -434,8 +434,8 @@ test("visible ID range: range tag injected into suffix message", async () => {
     const textParts = suffixMessage!.parts.filter((p: any) => p.type === "text")
     const combinedText = textParts.map((p: any) => p.text).join("")
     assert.ok(
-        combinedText.includes("[Visible message IDs:"),
-        "should inject visible ID range tag",
+        combinedText.includes("[Visible messages:"),
+        "should inject visible messages tag",
     )
     assert.ok(
         combinedText.includes("messages"),

--- a/tests/nudge-text.test.ts
+++ b/tests/nudge-text.test.ts
@@ -96,21 +96,43 @@ test("buildCompressedBlockGuidance summarizes older blocks when there are more t
     assert.match(guidance, /b25/)
 })
 
-test("buildContextUsageGuidance low tier says 'Be frugal' and leaks no threshold numbers", () => {
-    const guidance = buildContextUsageGuidance(buildConfig(), LOW_USAGE, MODEL_CONTEXT_LIMIT)
+test("buildContextUsageGuidance returns context number without compression guidance", () => {
+    const low = buildContextUsageGuidance(buildConfig(), LOW_USAGE, MODEL_CONTEXT_LIMIT)
+    const mid = buildContextUsageGuidance(buildConfig(), MODERATE_USAGE, MODEL_CONTEXT_LIMIT)
+    const high = buildContextUsageGuidance(buildConfig(), HIGH_USAGE, MODEL_CONTEXT_LIMIT)
 
-    assert.match(guidance, /Be frugal/)
-    assert.doesNotMatch(guidance, /threshold/i)
+    assert.match(low, /Context:/)
+    assert.match(mid, /Context:/)
+    assert.match(high, /Context:/)
+
+    assert.match(low, /be frugal/i)
+    assert.doesNotMatch(low, /MUST|aggressive|critical/i)
+    assert.doesNotMatch(mid, /growing|MUST|aggressive/i)
+    assert.doesNotMatch(high, /aggressive|MUST/i)
 })
 
-test("buildContextUsageGuidance moderate tier says 'Context is growing'", () => {
-    const guidance = buildContextUsageGuidance(buildConfig(), MODERATE_USAGE, MODEL_CONTEXT_LIMIT)
+test("buildCompressedBlockGuidance shows token counts for blocks with summaryTokens", () => {
+    const state = createSessionState()
+    for (const id of [1, 2, 3]) {
+        state.prune.messages.activeBlockIds.add(id)
+        state.prune.messages.blocksById.set(id, { summaryTokens: id * 100 } as never)
+    }
 
-    assert.match(guidance, /Context is growing/)
+    const guidance = buildCompressedBlockGuidance(state)
+
+    assert.match(guidance, /b1 \(100t\)/)
+    assert.match(guidance, /b2 \(200t\)/)
+    assert.match(guidance, /b3 \(300t\)/)
 })
 
-test("buildContextUsageGuidance high tier says 'Context is high'", () => {
-    const guidance = buildContextUsageGuidance(buildConfig(), HIGH_USAGE, MODEL_CONTEXT_LIMIT)
+test("buildCompressedBlockGuidance omits token count when summaryTokens is 0 or missing", () => {
+    const state = createSessionState()
+    for (const id of [1, 2]) {
+        state.prune.messages.activeBlockIds.add(id)
+    }
 
-    assert.match(guidance, /Context is high/)
+    const guidance = buildCompressedBlockGuidance(state)
+
+    assert.match(guidance, /b1/)
+    assert.doesNotMatch(guidance, /b1 \(0t\)/)
 })

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -59,7 +59,6 @@ test("system prompt overrides handle reminder tags safely", async (t) => {
             const runtimeSystemPrompt = fixture.store.getRuntimePrompts().system
 
             assert.match(runtimeSystemPrompt, /Extra override line\./)
-            assert.match(runtimeSystemPrompt, /environment-injected metadata/)
         } finally {
             fixture.cleanup()
         }


### PR DESCRIPTION
## Summary

Complete redesign of ACP compression prompts from rule-driven (72 lines of rules) to principle-driven (~20 lines of principles). Plus new features for better context awareness.

### Prompt Redesign
- **system.ts**: 72 lines → 20 lines. Removed all thresholds, levels, priority lists. Two principles only: over-compression harms quality, under-compression causes overflow.
- **BE FRUGAL section**: 5 examples of obvious waste to compress (command output, sub-agent results, training logs, duplicate reads, failed explorations).
- **utils.ts**: `buildContextUsageGuidance` returns just context number — no guidance text.
- **inject.ts**: Per-message shows only `Context: X%`. Every 10 percentage points (from 15%): Tips show tool names. Below 15%: no compression prompts. At 65%: stronger overflow warning.
- **nudge.ts**: Removed consolidation suggestion. Block list now shows token counts: `b50 (76t), b51 (88t), ...`

### Tool Improvements
- **compress**: Single 3000-char limit (removed soft/hard dual-tier). New `summaryMaxChars` optional parameter for override.
- **decompress**: New `toFile` optional parameter — writes content to file without inflating context. Block stays compressed.
- **search_context**: Already has good description (searches compressed + visible).
- **Fixed**: Empty backtick tags in system.ts (`<dcp-message-id>` and `<dcp-system-reminder>`).
- **Fixed**: Plan B auto-detect consumed blocks (no manual `(bN)` placeholders needed).
- **Fixed**: Directive nudge range calculation (uses anchorMessageId, visible range filter, no backwards ranges).

### Config
- `minNudgeContextPercent`: 15 (don't nudge below 15%)
- `perMessageNudgeGrowthPercent`: 10 (percentage points, not relative %)
- `nudgeFrequency`: 6

### Files Changed (11 files, +158/-118)
- `lib/prompts/system.ts` — principle-driven rewrite + BE FRUGAL + tag fix
- `lib/messages/inject/utils.ts` — simplified to context number only
- `lib/messages/inject/inject.ts` — 10pp interval gating + min threshold
- `lib/prompts/extensions/nudge.ts` — removed consolidation, added block token counts
- `lib/compress/range.ts` — summaryMaxChars parameter
- `lib/compress/message.ts` — summaryMaxChars parameter
- `lib/compress/decompress.ts` — toFile parameter
- `lib/compress/search.ts` — (already good description)
- `lib/config.ts` — minNudgeContextPercent
- `tests/nudge-text.test.ts` — updated assertions
- `devlog/2026-07-01_principle-driven-prompts/` — REQ.md + WORKLOG.md