### PR TITLE
chore: bump version to 1.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-acp",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-acp",
-            "version": "1.8.0",
+            "version": "1.8.1",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 34 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
Version bump for v1.8.1 release. Tag v1.8.1 already pushed.