### PR TITLE
fix: always inject system prompt — revert gating that caused binge compression

### DIFF
--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -105,12 +105,6 @@ export function createSystemPromptHandler(
             return
         }
 
-        // 1-turn lag: system hook runs before messages hook, so shouldInjectThisTurn
-        // reflects the previous request's nudge decision. undefined = first turn.
-        if (state.nudges.shouldInjectThisTurn === false && !state.manualMode) {
-            return
-        }
-
         prompts.reload()
         const runtimePrompts = prompts.getRuntimePrompts()
         const newPrompt = renderSystemPrompt(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-acp",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-acp",
-            "version": "1.8.0",
+            "version": "1.8.1",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 34 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Problem

System prompt gating (commit 24bbb1f) made ACP system prompt disappear between nudges. Since ACP injections are ephemeral (not persisted to DB — re-injected fresh each request), the model completely forgot compression tools existed between nudges.

When nudge fired after 50K growth, model saw accumulated waste → panicked → 95-call binge compress.

## Fix

Remove `shouldInjectThisTurn` gate from `createSystemPromptHandler` (hooks.ts:108-112).

- **System prompt** (system.ts + extensions): ✅ always inject every turn
- **Suffix** (context level/blocks/Tips): remains gated at nudgeGrowthTokens frequency

## Test

523/523 pass. Build 328K. Deployed.