### PR TITLE
chore: bump version to 1.9.0 (published)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.8.2",
+    "version": "1.9.0",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 34 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Version bump `1.8.2` → `1.9.0` to record the release of **opencode-acp@1.9.0** (already published to npm).

The release ships **PR #55** — visible range guidance & compression failure recovery (#9):
- system prompt: visible-range guidance, CONTEXT BREAKDOWN section, task-phase-end compress trigger
- compress tool: clamp out-of-range boundary refs (fault tolerance), 8000→10000 summary cap, soften "compress≠delete" wording
- inject: fix code-token double-count (added `textTokens`)
- search: registered-but-consumed ID failures keep recovery hint
- remove dead `MODEL_CONTEXT_LIMITS` table (38 entries) — sole source now `input.model.limit.context`

## npm release

- ✅ `npm view opencode-acp version` → `1.9.0`
- ✅ `dist-tags.latest` → `1.9.0`
- ✅ Tag `v1.9.0` pushed (github + gitea)
- Pre-publish checks (AGENTS.md §5.4): Step 1 check:package PASS · Step 2 privacy audit CLEAN · Step 3 content review CLEAN

## Why a PR?

`master` is branch-protected, so the version-bump commit (`2cbec60`) couldn't be pushed directly. The npm publish itself runs from the local working tree and already succeeded. This PR lands the commit + tag onto master for traceability.

## Notes

- Diff is a single line: `package.json` version field.
- No source changes in this PR (all source shipped via #55).