### PR TITLE
fix: disjoint visible-id segments (issue #9 root cause)

### DIFF
--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -276,6 +276,12 @@
                     "minimum": 1,
                     "description": "Hard limit for summary length in characters"
                 },
+                "maxVisibleSegments": {
+                    "type": "number",
+                    "default": 50,
+                    "minimum": 1,
+                    "description": "Maximum number of disjoint visible-id segments to show the model. When visible messages span more segments (due to compression holes), only the largest tool-bearing/high-token segments are shown, with a '+N omitted' note. Prevents the model from picking compressed-away refs."
+                },
                 "nudgeGrowthTokens": {
                     "type": "number",
                     "description": "Token growth required between per-message nudges (absolute, not percentage). Shows Tips only after context grows by this many tokens. If unset, default is adaptive: 5% of modelContextLimit, clamped to [6000, 50000] — e.g. 128K→6.4K, 200K→10K, 1M→50K. Must be unset (not 6000) for adaptive default to work."
@@ -295,7 +301,8 @@
                 "protectTags": false,
                 "protectUserMessages": false,
                 "minNudgeContextPercent": 15,
-                "maxSummaryLengthHard": 3000
+                "maxSummaryLengthHard": 3000,
+                "maxVisibleSegments": 50
             }
         },
         "gc": {

--- a/devlog/2026-07-06_visible-segments/DESIGN.md
+++ b/devlog/2026-07-06_visible-segments/DESIGN.md
@@ -1,0 +1,90 @@
+# DESIGN — Visible-ID Segment Guidance
+
+## Problem
+
+The injected visible-id guidance was a single contiguous span. Compression creates
+holes; the span hid them. The model selected refs inside holes and `compress` failed.
+
+## Design
+
+### Data model
+
+```ts
+interface VisibleSegment {
+    startRef: string      // "m00003"
+    endRef: string        // "m00007" (== startRef for single-message segments)
+    count: number         // messages in this contiguous run
+    tokens: number        // summed len/4 token estimate across the run
+    hasTool: boolean      // true if any message in the run carries a non-text part
+}
+```
+
+Segments are **disjoint** and **exhaustive** over surviving (ref-bearing) messages.
+A hole between two segments = messages consumed by a compression block; those refs are
+NOT in any segment, so the model cannot pick them.
+
+### Pipeline
+
+```
+messages ──► buildVisibleSegments ──► VisibleSegment[] ──► formatVisibleGuidance ──► string
+                                         (ascending)            (truncate if > cap)
+```
+
+Both functions are pure and exported for unit testing. `injectVisibleIdRange` is now a
+thin wrapper that appends the formatted string to the suffix message.
+
+### Token / hasTool estimation
+
+Reuses the same `len/4` heuristic as `estimateContextComposition` (utils.ts). A part
+with `type !== "text" && type !== "reasoning"` counts as a tool part and sets
+`hasTool=true`. This keeps segment heuristics consistent with the Breakdown line
+emitted in the same hook.
+
+### Truncation strategy
+
+When `segments.length > maxVisibleSegments`:
+
+1. Rank a copy: `hasTool DESC` then `tokens DESC`.
+2. Take top `maxVisibleSegments` into a keep-set (by object identity).
+3. Re-filter the **original ascending** array through the keep-set → preserves timeline
+   order in the output.
+4. Emit `+N omitted (~K tokens, M msgs)` so the model knows the elision happened.
+
+Why `hasTool` first: tool-bearing segments are the high-value compression targets, and
+dropping them would hide exactly the ranges the model most needs to see. Token magnitude
+breaks ties among same-category segments.
+
+Why ascending display order (not priority order): the Breakdown line (already emitted
+in the same hook) highlights largest tool/code/text ranges with token counts — that is
+the "what to compress" signal. The Visible line's job is "which refs are valid"; for
+that, timeline order is clearer and avoids confusing the model about causality.
+
+### Config
+
+`compress.maxVisibleSegments: number` (default 50). Plumbed through:
+- `CompressConfig` interface (config.ts)
+- default config (config.ts)
+- `mergeConfig` (config.ts)
+- allowed keys + type/range validation (config-validation.ts)
+- JSON schema (dcp.schema.json)
+
+### Backward compatibility
+
+No persisted-state change. The injected string format changed
+(`[Visible messages: first to last (N)]` → `[Visible: seg, seg, … (N msgs, M segments)]`),
+but this string is ephemeral (regenerated every transform) and never persisted. No
+migration needed.
+
+### Cost
+
+`buildVisibleSegments` is O(messages × parts) — same order as the existing
+`estimateContextComposition` already running in this hook. `formatVisibleGuidance`
+truncation sort is O(segments log segments); segments ≤ messages, typically << 100.
+Net hook cost increase is negligible.
+
+### What is NOT changed
+
+- `compress/search.ts` rejection logic — still correctly refuses consumed refs. The fix
+  is purely on the *guidance* side: stop advertising consumed refs as valid.
+- Breakdown line, Top blocks hint, nudge text — untouched.
+- `injectMessageIds` (per-message mNNNNN tagging) — untouched.

--- a/devlog/2026-07-06_visible-segments/REQ.md
+++ b/devlog/2026-07-06_visible-segments/REQ.md
@@ -1,0 +1,58 @@
+# REQ — Visible-ID Segment Guidance
+
+## Background
+
+Issue #9 ("调查这个压缩失败可能原因" / investigate possible compress-failure causes)
+identified that the `compress` tool frequently fails because the model picks a
+message ref that lives inside an already-compressed hole.
+
+Root cause: `injectVisibleIdRange` (lib/messages/inject/inject.ts) emitted a single
+contiguous span `[Visible messages: m00001 to m00950 (810 messages)]`. When compression
+blocks consumed messages in the middle of that span, the injected span still advertised
+the consumed refs as valid. The model, trusting the span, requested
+`startId/endId` inside a hole. `compress/search.ts` then rejected the call
+("message m00xxx is already consumed by block bN"), and compression aborted.
+
+## Reproduction
+
+1. Run a long session until at least one compression block exists mid-conversation.
+2. Observe the suffix-message tag: `[Visible messages: m00001 to m00950 (810 messages)]`.
+3. When the model is nudged to compress, it picks refs from the advertised span.
+4. ~half the time the picked range overlaps a compressed hole → compress fails.
+
+## Constraints
+
+- Must NOT change persisted state format (backward compat, AGENTS.md §2.6).
+- Must NOT change the `compress` tool schema or search semantics.
+- Token cost of the new guidance must stay bounded even with hundreds of segments.
+- Output format must remain machine-scannable and model-legible.
+- No `as any` / `@ts-ignore` (AGENTS.md hard blocks).
+
+## Acceptance Criteria
+
+- [x] Visible-id guidance shows **disjoint segments**, never a single span that
+      crosses a compression hole.
+- [x] Segments are rendered in ascending ref order (timeline clarity).
+- [x] When segments exceed a configurable cap, only the highest-value (tool-bearing /
+      high-token) are shown; the rest are summarized as `+N omitted`.
+- [x] New config `compress.maxVisibleSegments` (default 50) with validation + schema.
+- [x] Pure-function unit tests for segment building, formatting, truncation, ordering.
+- [x] Existing e2e test updated to the new format; full suite green (modulo known
+      pre-existing bun-incompat in prompts.test.ts).
+- [x] `tsc --noEmit` clean. `tsup` build succeeds.
+
+## Approach
+
+Rewrite `injectVisibleIdRange` into three pure, unit-testable pieces:
+
+1. `buildVisibleSegments(state, messages)` — walk surviving messages, map each to its
+   ref + token/hasTool signature, sort refs numerically, fold contiguous refs into
+   maximal segments.
+2. `formatVisibleGuidance(segments, maxSegs)` — render the `[Visible: ...]` string.
+   When `segments.length <= maxSegs`, show all in ascending order. Otherwise rank by
+   `hasTool DESC, tokens DESC`, keep the top `maxSegs`, and re-project the kept set
+   back into ascending order for display (drops the smallest, preserves timeline).
+3. `injectVisibleIdRange` — thin wrapper that wires (1)+(2) to the suffix message.
+
+Config plumbing: `CompressConfig.maxVisibleSegments`, default in `config.ts`, merge in
+`mergeConfig`, validation in `config-validation.ts`, JSON schema in `dcp.schema.json`.

--- a/devlog/2026-07-06_visible-segments/WORKLOG.md
+++ b/devlog/2026-07-06_visible-segments/WORKLOG.md
@@ -1,0 +1,72 @@
+# WORKLOG — Visible-ID Segment Guidance
+
+## Summary
+
+Fixed the root cause of compress-tool failures reported in issue #9: the injected
+visible-id guidance advertised a single contiguous span that crossed compression
+holes, causing the model to pick already-consumed refs. Rewrote the guidance to emit
+**disjoint segments** in ascending order, with bounded truncation when the segment
+count exceeds a configurable cap.
+
+## ChangeLog
+
+| Commit | File(s) | Change |
+|--------|---------|--------|
+| (this PR) | lib/config.ts | Add `CompressConfig.maxVisibleSegments` (default 50) + default + merge |
+| (this PR) | lib/config-validation.ts | Allow `compress.maxVisibleSegments` key + type/range validation (>=1) |
+| (this PR) | dcp.schema.json | Add `maxVisibleSegments` property + default |
+| (this PR) | lib/messages/inject/inject.ts | Rewrite `injectVisibleIdRange` → `buildVisibleSegments` + `formatVisibleGuidance` (pure, exported) + thin wrapper |
+| (this PR) | tests/visible-segments.test.ts | NEW — 17 unit tests: segment merge/sort/tool/tokens + format/truncate/order/K-suffix |
+| (this PR) | tests/e2e-blocks-nudges.test.ts | Update visible-tag assertion to new `[Visible: … (N msgs, M segments)]` format |
+
+## KeyFiles
+
+- `lib/messages/inject/inject.ts` — `buildVisibleSegments`, `formatVisibleGuidance`,
+  `injectVisibleIdRange`, `VisibleSegment` interface (all exported for testability)
+- `lib/config.ts` — `CompressConfig.maxVisibleSegments`, default, merge
+- `lib/config-validation.ts` — key allowlist + validation
+- `dcp.schema.json` — schema entry
+- `tests/visible-segments.test.ts` — pure-function coverage
+- `tests/e2e-blocks-nudges.test.ts` — integration assertion update
+
+## DesignNotes
+
+- Segments preserve **ascending ref order** in output (timeline clarity). Truncation
+  picks the highest-value segments (`hasTool DESC, tokens DESC`) but re-projects them
+  into ascending order for display.
+- `hasTool` ranked first because tool-bearing segments are the prime compression
+  targets; eliding them would hide exactly what the model needs.
+- Token heuristic (`len/4`) is identical to `estimateContextComposition` so segment
+  magnitudes stay consistent with the Breakdown line emitted in the same hook.
+- Both new functions are pure → fully unit-testable without message/state mocking.
+
+## Testing
+
+- `tests/visible-segments.test.ts`: **17 pass** (segment build: empty/single/contiguous/
+  hole/multi-hole/tool/tokens/skip-unmapped/ascending; format: empty/singular/plural/
+  exactly-cap/over-cap/keep-tool/ascending-order/K-suffix).
+- Full suite: **561 pass, 1 fail** — the 1 fail is the pre-existing bun-incompat in
+  `prompts.test.ts` (nested `test()`), unrelated to this change.
+- `tsc --noEmit`: clean.
+- `tsup` build: success (348.72 KB).
+
+## Risk
+
+- **Low**. The change is isolated to one guidance string in the message-transform hook.
+  No persisted-state format change. No tool-schema change. No search-logic change.
+- Worst case if the new format confuses a model: it falls back to per-message mNNNNN
+  refs (still injected by `injectMessageIds`) and asks `acp_status` — both still work.
+
+## Lessons
+
+- Ephemeral guidance strings that *describe* state must stay consistent with the *actual*
+  state, or the model trusts the description and mis-targets. A single "first–last" span
+  was a latent lie once compression introduced holes.
+- Extracting pure functions (`buildVisibleSegments`, `formatVisibleGuidance`) made the
+  truncation/ordering edge cases trivially testable — worth the small refactor.
+
+## Followups
+
+- Consider promoting the `+N omitted` count into the periodic `[ACP] Context:` status
+  line (prompts/system.ts:51) so the model sees segment density even outside nudges.
+- If real sessions routinely exceed 50 segments, revisit the default cap with data.

--- a/lib/config-validation.ts
+++ b/lib/config-validation.ts
@@ -43,6 +43,7 @@ export const VALID_CONFIG_KEYS = new Set([
     "compress.protectUserMessages",
     "compress.maxSummaryLengthHard",
     "compress.minCompressRange",
+    "compress.maxVisibleSegments",
     "gc",
     "gc.algorithm",
     "gc.promotionThreshold",
@@ -411,6 +412,28 @@ export function validateConfigTypes(config: Record<string, any>): ValidationErro
                     key: "compress.minCompressRange",
                     expected: "non-negative number (>= 0)",
                     actual: `${compress.minCompressRange}`,
+                })
+            }
+
+            if (
+                compress.maxVisibleSegments !== undefined &&
+                typeof compress.maxVisibleSegments !== "number"
+            ) {
+                errors.push({
+                    key: "compress.maxVisibleSegments",
+                    expected: "number",
+                    actual: typeof compress.maxVisibleSegments,
+                })
+            }
+
+            if (
+                typeof compress.maxVisibleSegments === "number" &&
+                compress.maxVisibleSegments < 1
+            ) {
+                errors.push({
+                    key: "compress.maxVisibleSegments",
+                    expected: "positive number (>= 1)",
+                    actual: `${compress.maxVisibleSegments}`,
                 })
             }
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -34,6 +34,7 @@ export interface CompressConfig {
     protectUserMessages: boolean
     maxSummaryLengthHard: number
     minCompressRange: number
+    maxVisibleSegments: number
 }
 
 export interface Commands {
@@ -200,6 +201,7 @@ const defaultConfig: PluginConfig = {
         protectUserMessages: false,
         maxSummaryLengthHard: 10000,
         minCompressRange: 2000,
+        maxVisibleSegments: 50,
     },
     strategies: {
         deduplication: {
@@ -410,6 +412,7 @@ function mergeCompress(
         protectUserMessages: override.protectUserMessages ?? base.protectUserMessages,
         maxSummaryLengthHard: override.maxSummaryLengthHard ?? base.maxSummaryLengthHard,
         minCompressRange: override.minCompressRange ?? base.minCompressRange,
+        maxVisibleSegments: override.maxVisibleSegments ?? base.maxVisibleSegments,
     }
 }
 

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -420,7 +420,7 @@ export function formatVisibleGuidance(segments: VisibleSegment[], maxSegs: numbe
     const omitted = segments.filter((s) => !keepSet.has(s))
     const omittedTokens = omitted.reduce((sum, s) => sum + s.tokens, 0)
     const omittedMsgs = omitted.reduce((sum, s) => sum + s.count, 0)
-    return `[Visible (top ${shown.length} of ${totalSegs} segments, ${totalMsgs} msgs): ${shown.map(formatSegment).join(", ")} | +${omitted.length} smaller segment${omitted.length === 1 ? "" : "s"} (~${fmt(omittedTokens)} tokens, ${omittedMsgs} msgs) omitted]`
+    return `[Visible (top ${shown.length} of ${totalSegs} segments, ${totalMsgs} msgs): ${shown.map(formatSegment).join(", ")} | +${omitted.length} smaller segment${omitted.length === 1 ? "" : "s"} (~${fmt(omittedTokens)} tokens, ${omittedMsgs} msg${omittedMsgs === 1 ? "" : "s"}) omitted]`
 }
 
 function injectVisibleIdRange(

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -278,7 +278,7 @@ export const injectCompressNudges = (
             appendToLastTextPart(suffixMessage, tipsText)
         }
 
-        injectVisibleIdRange(state, messages, suffixMessage)
+        injectVisibleIdRange(state, config, messages, suffixMessage)
     }
 
     if (toolOutputReminder && suffixMessage) {
@@ -330,22 +330,110 @@ function injectContextUsage(
     target.parts.push(createSyntheticTextPart(target, usageTag))
 }
 
-function injectVisibleIdRange(state: SessionState, messages: WithParts[], target: WithParts | null): void {
-    if (!target) return
-    const visibleRefs: string[] = []
-    for (const message of messages) {
-        const ref = state.messageIds.byRawId.get(message.info.id)
-        if (ref) {
-            visibleRefs.push(ref)
+export interface VisibleSegment {
+    startRef: string
+    endRef: string
+    count: number
+    tokens: number
+    hasTool: boolean
+}
+
+function refNumber(ref: string): number {
+    const n = parseInt(ref.slice(1), 10)
+    return Number.isNaN(n) ? -1 : n
+}
+
+/**
+ * Build disjoint visible-id segments from the surviving messages.
+ *
+ * Each segment is a maximal run of contiguous refs (e.g. m00003–m00007).
+ * Holes between segments correspond to messages already consumed by a
+ * compression block — those refs are NOT safe to target. Surfacing the
+ * segments (instead of a single `first–last` span) stops the model from
+ * picking a ref that lives inside a compressed hole.
+ */
+export function buildVisibleSegments(state: SessionState, messages: WithParts[]): VisibleSegment[] {
+    const refInfo = new Map<string, { tokens: number; hasTool: boolean }>()
+    for (const msg of messages) {
+        const ref = state.messageIds.byRawId.get(msg.info.id)
+        if (!ref) continue
+        let tokens = 0
+        let hasTool = false
+        for (const part of msg.parts || []) {
+            if (part.type === "text" && typeof (part as any).text === "string") {
+                tokens += Math.round(((part as any).text as string).length / 4)
+            } else if (part.type !== "text" && part.type !== "reasoning") {
+                tokens += Math.round(JSON.stringify(part).length / 4)
+                hasTool = true
+            }
         }
+        refInfo.set(ref, { tokens, hasTool })
     }
+    if (refInfo.size === 0) return []
 
-    if (visibleRefs.length === 0) return
+    const refs = Array.from(refInfo.keys()).sort((a, b) => refNumber(a) - refNumber(b))
+    const segments: VisibleSegment[] = []
+    let cur: VisibleSegment | null = null
+    let prevNum = -2
+    for (const ref of refs) {
+        const num = refNumber(ref)
+        const info = refInfo.get(ref)!
+        if (cur && num === prevNum + 1) {
+            cur.endRef = ref
+            cur.count++
+            cur.tokens += info.tokens
+            if (info.hasTool) cur.hasTool = true
+        } else {
+            if (cur) segments.push(cur)
+            cur = { startRef: ref, endRef: ref, count: 1, tokens: info.tokens, hasTool: info.hasTool }
+        }
+        prevNum = num
+    }
+    if (cur) segments.push(cur)
+    return segments
+}
 
-    visibleRefs.sort()
-    const first = visibleRefs[0]
-    const last = visibleRefs[visibleRefs.length - 1]
-    const rangeTag = `\n\n[Visible messages: ${first} to ${last} (${visibleRefs.length} messages)]`
+function formatSegment(seg: VisibleSegment): string {
+    return seg.startRef === seg.endRef ? seg.startRef : `${seg.startRef}–${seg.endRef}`
+}
+
+export function formatVisibleGuidance(segments: VisibleSegment[], maxSegs: number): string {
+    if (segments.length === 0) return ""
+    const totalMsgs = segments.reduce((s, seg) => s + seg.count, 0)
+    const totalSegs = segments.length
+    const fmt = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n))
+
+    if (totalSegs <= maxSegs) {
+        return `[Visible: ${segments.map(formatSegment).join(", ")} (${totalMsgs} msg${totalMsgs === 1 ? "" : "s"}, ${totalSegs} segment${totalSegs === 1 ? "" : "s"})]`
+    }
+    // Keep the largest tool-bearing/high-token segments, drop the smallest,
+    // but preserve ascending ref order for what gets shown.
+    const keepSet = new Set(
+        [...segments]
+            .sort((a, b) => {
+                if (a.hasTool !== b.hasTool) return a.hasTool ? -1 : 1
+                return b.tokens - a.tokens
+            })
+            .slice(0, maxSegs),
+    )
+    const shown = segments.filter((s) => keepSet.has(s))
+    const omitted = segments.filter((s) => !keepSet.has(s))
+    const omittedTokens = omitted.reduce((sum, s) => sum + s.tokens, 0)
+    const omittedMsgs = omitted.reduce((sum, s) => sum + s.count, 0)
+    return `[Visible (top ${shown.length} of ${totalSegs} segments, ${totalMsgs} msgs): ${shown.map(formatSegment).join(", ")} | +${omitted.length} smaller segment${omitted.length === 1 ? "" : "s"} (~${fmt(omittedTokens)} tokens, ${omittedMsgs} msgs) omitted]`
+}
+
+function injectVisibleIdRange(
+    state: SessionState,
+    config: PluginConfig,
+    messages: WithParts[],
+    target: WithParts | null,
+): void {
+    if (!target) return
+    const segments = buildVisibleSegments(state, messages)
+    if (segments.length === 0) return
+    const maxSegs = config.compress?.maxVisibleSegments ?? 50
+    const rangeTag = "\n\n" + formatVisibleGuidance(segments, maxSegs)
 
     for (const part of target.parts) {
         if (part.type === "text") {

--- a/tests/e2e-blocks-nudges.test.ts
+++ b/tests/e2e-blocks-nudges.test.ts
@@ -438,12 +438,12 @@ test("visible ID range: range tag injected into suffix message when shouldNudge 
     const textParts = suffixMessage!.parts.filter((p: any) => p.type === "text")
     const combinedText = textParts.map((p: any) => p.text).join("")
     assert.ok(
-        combinedText.includes("[Visible messages:"),
-        "should inject visible messages tag",
+        combinedText.includes("[Visible:"),
+        "should inject visible segments tag",
     )
     assert.ok(
-        combinedText.includes("messages"),
-        "range tag should mention message count",
+        /msgs?, \d+ segments?/.test(combinedText),
+        "range tag should mention message and segment counts",
     )
 })
 

--- a/tests/visible-segments.test.ts
+++ b/tests/visible-segments.test.ts
@@ -1,0 +1,241 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import type { WithParts } from "../lib/state"
+import type { SessionState } from "../lib/state"
+import { buildVisibleSegments, formatVisibleGuidance } from "../lib/messages/inject/inject"
+
+function mkText(id: string, text: string): WithParts {
+    return { info: { id } as any, parts: [{ type: "text", text, id: `${id}-p`, sessionID: "s", messageID: id }] as any }
+}
+
+function mkTool(id: string, raw: string): WithParts {
+    return { info: { id } as any, parts: [{ type: "tool", tool: raw } as any] }
+}
+
+function mkState(pairs: [rawId: string, ref: string][]): SessionState {
+    return { messageIds: { byRawId: new Map(pairs), byRef: new Map(), nextRef: 1 } } as any as SessionState
+}
+
+// ---------------- buildVisibleSegments ----------------
+
+test("buildVisibleSegments: empty messages returns []", () => {
+    assert.deepEqual(buildVisibleSegments(mkState([]), []), [])
+})
+
+test("buildVisibleSegments: single message -> one segment", () => {
+    const state = mkState([["raw-1", "m00001"]])
+    const segs = buildVisibleSegments(state, [mkText("raw-1", "hello")])
+    assert.equal(segs.length, 1)
+    assert.equal(segs[0].startRef, "m00001")
+    assert.equal(segs[0].endRef, "m00001")
+    assert.equal(segs[0].count, 1)
+    assert.equal(segs[0].hasTool, false)
+})
+
+test("buildVisibleSegments: contiguous refs merge into one segment", () => {
+    const state = mkState([
+        ["raw-1", "m00001"],
+        ["raw-2", "m00002"],
+        ["raw-3", "m00003"],
+    ])
+    const segs = buildVisibleSegments(state, [
+        mkText("raw-1", "a"),
+        mkText("raw-2", "b"),
+        mkText("raw-3", "c"),
+    ])
+    assert.equal(segs.length, 1)
+    assert.equal(segs[0].startRef, "m00001")
+    assert.equal(segs[0].endRef, "m00003")
+    assert.equal(segs[0].count, 3)
+})
+
+test("buildVisibleSegments: hole between refs splits into two segments", () => {
+    const state = mkState([
+        ["raw-1", "m00001"],
+        ["raw-3", "m00003"],
+    ])
+    const segs = buildVisibleSegments(state, [mkText("raw-1", "a"), mkText("raw-3", "c")])
+    assert.equal(segs.length, 2)
+    assert.equal(segs[0].startRef, "m00001")
+    assert.equal(segs[0].endRef, "m00001")
+    assert.equal(segs[1].startRef, "m00003")
+    assert.equal(segs[1].endRef, "m00003")
+})
+
+test("buildVisibleSegments: hole with multi-msg segments on both sides", () => {
+    const state = mkState([
+        ["raw-1", "m00001"],
+        ["raw-2", "m00002"],
+        ["raw-5", "m00005"],
+        ["raw-6", "m00006"],
+        ["raw-7", "m00007"],
+    ])
+    const segs = buildVisibleSegments(
+        state,
+        [
+            mkText("raw-1", "a"),
+            mkText("raw-2", "b"),
+            mkText("raw-5", "e"),
+            mkText("raw-6", "f"),
+            mkText("raw-7", "g"),
+        ],
+    )
+    assert.equal(segs.length, 2)
+    assert.equal(segs[0].startRef, "m00001")
+    assert.equal(segs[0].endRef, "m00002")
+    assert.equal(segs[0].count, 2)
+    assert.equal(segs[1].startRef, "m00005")
+    assert.equal(segs[1].endRef, "m00007")
+    assert.equal(segs[1].count, 3)
+})
+
+test("buildVisibleSegments: tool part marks segment hasTool=true", () => {
+    const state = mkState([["raw-1", "m00001"]])
+    const segs = buildVisibleSegments(state, [mkTool("raw-1", '{"output":"big result"}')])
+    assert.equal(segs.length, 1)
+    assert.equal(segs[0].hasTool, true)
+})
+
+test("buildVisibleSegments: tokens accumulate across messages in a segment", () => {
+    const state = mkState([
+        ["raw-1", "m00001"],
+        ["raw-2", "m00002"],
+    ])
+    const segs = buildVisibleSegments(state, [
+        mkText("raw-1", "x".repeat(400)),
+        mkText("raw-2", "y".repeat(800)),
+    ])
+    assert.equal(segs.length, 1)
+    assert.equal(segs[0].tokens, 100 + 200)
+})
+
+test("buildVisibleSegments: message without a ref is skipped", () => {
+    const state = mkState([["raw-1", "m00001"]])
+    const segs = buildVisibleSegments(state, [
+        mkText("raw-1", "a"),
+        mkText("raw-unmapped", "b"),
+    ])
+    assert.equal(segs.length, 1)
+    assert.equal(segs[0].startRef, "m00001")
+})
+
+test("buildVisibleSegments: segments emitted in ascending ref order", () => {
+    const state = mkState([
+        ["raw-9", "m00009"],
+        ["raw-1", "m00001"],
+        ["raw-5", "m00005"],
+    ])
+    const segs = buildVisibleSegments(state, [
+        mkText("raw-9", "z"),
+        mkText("raw-1", "a"),
+        mkText("raw-5", "e"),
+    ])
+    assert.deepEqual(
+        segs.map((s) => s.startRef),
+        ["m00001", "m00005", "m00009"],
+    )
+})
+
+// ---------------- formatVisibleGuidance ----------------
+
+test("formatVisibleGuidance: empty segments returns empty string", () => {
+    assert.equal(formatVisibleGuidance([], 50), "")
+})
+
+test("formatVisibleGuidance: single segment singularizes msg/segment", () => {
+    const out = formatVisibleGuidance([{ startRef: "m00001", endRef: "m00001", count: 1, tokens: 10, hasTool: false }], 50)
+    assert.equal(out, "[Visible: m00001 (1 msg, 1 segment)]")
+})
+
+test("formatVisibleGuidance: multiple segments pluralizes and joins ranges", () => {
+    const out = formatVisibleGuidance(
+        [
+            { startRef: "m00001", endRef: "m00001", count: 1, tokens: 10, hasTool: false },
+            { startRef: "m00003", endRef: "m00005", count: 3, tokens: 30, hasTool: false },
+        ],
+        50,
+    )
+    assert.equal(out, "[Visible: m00001, m00003–m00005 (4 msgs, 2 segments)]")
+})
+
+test("formatVisibleGuidance: exactly maxSegs shows all (no truncation)", () => {
+    const segs = Array.from({ length: 50 }, (_, i) => ({
+        startRef: `m${String(i + 1).padStart(5, "0")}`,
+        endRef: `m${String(i + 1).padStart(5, "0")}`,
+        count: 1,
+        tokens: 10,
+        hasTool: false,
+    }))
+    const out = formatVisibleGuidance(segs, 50)
+    assert.ok(out.startsWith("[Visible:"))
+    assert.ok(!out.includes("omitted"), "should not truncate at exactly maxSegs")
+    assert.ok(out.includes("50 msgs, 50 segments"))
+})
+
+test("formatVisibleGuidance: over maxSegs truncates with omitted note", () => {
+    const segs = Array.from({ length: 60 }, (_, i) => ({
+        startRef: `m${String(i + 1).padStart(5, "0")}`,
+        endRef: `m${String(i + 1).padStart(5, "0")}`,
+        count: 1,
+        tokens: 10,
+        hasTool: false,
+    }))
+    const out = formatVisibleGuidance(segs, 50)
+    assert.ok(out.startsWith("[Visible (top 50 of 60 segments, 60 msgs):"))
+    assert.ok(out.includes("+10 smaller segments (~100 tokens, 10 msgs) omitted]"))
+})
+
+test("formatVisibleGuidance: truncation keeps tool-bearing segments, drops text-only small ones", () => {
+    // 3 tool-bearing segments (high priority) + many tiny text-only segments.
+    const toolSegs = [1, 5, 9].map((n) => ({
+        startRef: `m${String(n).padStart(5, "0")}`,
+        endRef: `m${String(n).padStart(5, "0")}`,
+        count: 1,
+        tokens: 5,
+        hasTool: true,
+    }))
+    const textSegs = Array.from({ length: 55 }, (_, i) => ({
+        startRef: `m${String(100 + i).padStart(5, "0")}`,
+        endRef: `m${String(100 + i).padStart(5, "0")}`,
+        count: 1,
+        tokens: 2,
+        hasTool: false,
+    }))
+    const out = formatVisibleGuidance([...toolSegs, ...textSegs], 50)
+    // All 3 tool segments survive; only 47 of 55 text segments fit.
+    assert.ok(out.includes("m00001"), "tool segment m00001 kept")
+    assert.ok(out.includes("m00005"), "tool segment m00005 kept")
+    assert.ok(out.includes("m00009"), "tool segment m00009 kept")
+    assert.ok(out.includes("top 50 of 58 segments"))
+    assert.ok(out.includes("+8 smaller segments"))
+})
+
+test("formatVisibleGuidance: truncation preserves ascending ref order in shown segments", () => {
+    // Build segments where the kept set is non-contiguous so order matters.
+    // Keep = large segments at refs 1,3,5; drop = tiny at ref 2,4.
+    const segs = [
+        { startRef: "m00001", endRef: "m00001", count: 1, tokens: 1000, hasTool: false },
+        { startRef: "m00002", endRef: "m00002", count: 1, tokens: 1, hasTool: false },
+        { startRef: "m00003", endRef: "m00003", count: 1, tokens: 1000, hasTool: false },
+        { startRef: "m00004", endRef: "m00004", count: 1, tokens: 1, hasTool: false },
+        { startRef: "m00005", endRef: "m00005", count: 1, tokens: 1000, hasTool: false },
+    ]
+    const out = formatVisibleGuidance(segs, 3)
+    // Shown order must be ascending: m00001, m00003, m00005 (not sorted by tokens).
+    assert.ok(out.startsWith("[Visible (top 3 of 5 segments"))
+    const shownPart = out.split(":")[1].split("|")[0].trim()
+    assert.equal(shownPart, "m00001, m00003, m00005")
+})
+
+test("formatVisibleGuidance: omitted tokens format with K suffix for large totals", () => {
+    const segs = Array.from({ length: 55 }, (_, i) => ({
+        startRef: `m${String(i + 1).padStart(5, "0")}`,
+        endRef: `m${String(i + 1).padStart(5, "0")}`,
+        count: 1,
+        tokens: 1000,
+        hasTool: false,
+    }))
+    const out = formatVisibleGuidance(segs, 50)
+    // 5 omitted * 1000 = 5000 tokens -> "5.0K"
+    assert.ok(out.includes("~5.0K tokens, 5 msgs) omitted]"))
+})

--- a/tests/visible-segments.test.ts
+++ b/tests/visible-segments.test.ts
@@ -239,3 +239,13 @@ test("formatVisibleGuidance: omitted tokens format with K suffix for large total
     // 5 omitted * 1000 = 5000 tokens -> "5.0K"
     assert.ok(out.includes("~5.0K tokens, 5 msgs) omitted]"))
 })
+
+test("formatVisibleGuidance: omitted note singularizes msg when exactly 1 message omitted", () => {
+    // 2 segments: big tool-bearing (kept) + tiny single-msg text (omitted at maxSegs=1).
+    const segs = [
+        { startRef: "m00001", endRef: "m00001", count: 1, tokens: 1000, hasTool: true },
+        { startRef: "m00003", endRef: "m00003", count: 1, tokens: 2, hasTool: false },
+    ]
+    const out = formatVisibleGuidance(segs, 1)
+    assert.ok(out.includes("+1 smaller segment (~2 tokens, 1 msg) omitted]"), "1 omitted msg should be singular")
+})


### PR DESCRIPTION
## Summary

- **Root cause of issue #9 compress failures**: `injectVisibleIdRange` advertised a single contiguous `[Visible messages: first to last (N)]` span that crossed compression holes. The model trusted the span, picked a ref inside a hole, and `compress/search.ts` rejected it → compress aborted.
- **Fix**: rewrite the guidance to emit **disjoint segments** in ascending ref order. When segment count exceeds `compress.maxVisibleSegments` (new config, default 50), keep the largest tool-bearing / high-token segments and elide the rest with a `+N omitted` note.
- Extracted `buildVisibleSegments` + `formatVisibleGuidance` as pure exported functions for direct unit testing.

## Changes

| Area | File | Change |
|------|------|--------|
| core | `lib/messages/inject/inject.ts` | `injectVisibleIdRange` → `buildVisibleSegments` + `formatVisibleGuidance` + thin wrapper; `VisibleSegment` interface |
| config | `lib/config.ts` | `CompressConfig.maxVisibleSegments` (default 50) + default + merge |
| config | `lib/config-validation.ts` | allow key + type/range (>=1) validation |
| config | `dcp.schema.json` | property + default |
| tests | `tests/visible-segments.test.ts` | NEW — 17 pure-function unit tests |
| tests | `tests/e2e-blocks-nudges.test.ts` | update assertion to new format |

## Verification

- `tsc --noEmit`: clean
- `tsup` build: success (348.72 KB)
- `bun test tests/`: **561 pass, 1 fail** — the 1 fail is the pre-existing bun nested-`test()` incompat in `prompts.test.ts`, unrelated to this change
- 17 new unit tests cover: segment merge (empty/single/contiguous/hole/multi-hole), tool detection, token accumulation, ref skipping, ascending order, format (singular/plural/exactly-cap/over-cap/keep-tool/ascending-projection/K-suffix)

## Backward compatibility

No persisted-state change. The injected guidance string is ephemeral (regenerated every transform) and never persisted. No migration needed. Internal `dcp` tag naming untouched (AGENTS.md §2.6).

## Devlog

`devlog/2026-07-06_visible-segments/{REQ,DESIGN,WORKLOG}.md` included.

Closes #9.