### PR TITLE
fix: nudge wording — size-caution + efficiency framing (issue #9)

### DIFF
--- a/devlog/2026-07-06_nudge-caution-wording/REQ.md
+++ b/devlog/2026-07-06_nudge-caution-wording/REQ.md
@@ -1,0 +1,37 @@
+# REQ — Nudge Caution & Efficiency Wording
+
+## Background
+
+Issue #9 follow-up: two prompt-wording refinements to the per-message nudge breakdown
+(injected by `injectCompressNudges` in lib/messages/inject/inject.ts when `shouldNudge`).
+
+## Problem
+
+1. **Over-compression of large ranges**: the breakdown lists the largest tool/code/text
+   ranges with token counts, then said only "compress the largest consumed ranges first".
+   The model sometimes read "largest" as the compression target and compressed a range
+   purely because it was big — even when the current step still needed its full content.
+
+2. **Growth-nudge misread as overflow**: the breakdown shows `(+X since last nudge)`.
+   Without context, the model could read a large growth delta as "context is about to
+   overflow" and compress rashly. The growth nudge is actually an **efficiency** prompt
+   (compress early to stay lean); a separate, stronger alert fires at maxLimit.
+
+## Acceptance Criteria
+
+- [x] After listing the largest ranges, the guidance tells the model that size alone is
+      not a reason to compress — ranges still needed in full must stay.
+- [x] Soft nudges (growth / minLimit) carry an explicit "efficiency nudge, not overflow"
+      clarification, pointing to the separate stronger alert at maxLimit.
+- [x] The maxLimit path (already has its own "Context limit reached" warning) does NOT
+      duplicate the efficiency note.
+- [x] No persisted-state, tool-schema, or API change.
+- [x] `tsc --noEmit` clean; full suite green (modulo known pre-existing bun-incompat).
+
+## Approach
+
+- Add an `efficiencyNote` string prepended to the breakdown when
+  `decision.tipsVariant !== "maxLimit"`.
+- Move the `💡 Compress incrementally …` line to AFTER the largest ranges list (so the
+  model sees the data first, then the guidance), and reword it to distinguish "consumed"
+  from "still needed".

--- a/devlog/2026-07-06_nudge-caution-wording/WORKLOG.md
+++ b/devlog/2026-07-06_nudge-caution-wording/WORKLOG.md
@@ -1,0 +1,59 @@
+# WORKLOG — Nudge Caution & Efficiency Wording
+
+## Summary
+
+Two prompt-wording refinements to the per-message nudge breakdown in `injectCompressNudges`
+(lib/messages/inject/inject.ts), requested in issue #9. (1) Added a "size ≠ compress"
+caution after the largest-ranges list so the model keeps ranges still needed in full.
+(2) Prefixed soft nudges with an efficiency-vs-overflow clarification so the
+`(+X since last nudge)` growth indicator is not misread as an overflow warning.
+
+## ChangeLog
+
+| File | Change |
+|------|--------|
+| lib/messages/inject/inject.ts | `efficiencyNote` prepended to breakdown when `tipsVariant !== "maxLimit"`; `💡 Compress incrementally …` line moved to after the largest ranges and reworded to distinguish consumed-vs-still-needed |
+
+## KeyFiles
+
+- `lib/messages/inject/inject.ts` (breakdown block inside `injectCompressNudges`, ~lines 226-254)
+
+## DesignNotes
+
+- **Gating**: `decision.tipsVariant !== "maxLimit"` selects soft nudges (growth / minLimit).
+  The maxLimit path already emits its own strong "⚠️ Context limit reached — compress now"
+  warning (line ~256), so the efficiency note is suppressed there to avoid contradiction.
+- **Ordering**: moved the `💡 …` guidance to AFTER the largest ranges so the model reads
+  the data first, then the framing. Previously it appeared between Top blocks and the
+  largest ranges.
+- **Wording**: "target the ranges above whose content you have already extracted for this
+  step. Size alone is not a reason to compress — if a large range is still needed in full,
+  keep it." — directly addresses the over-compression failure mode.
+
+## Testing
+
+- `tsc --noEmit`: clean.
+- Full suite: **544 pass, 1 fail** — the 1 fail is the pre-existing bun nested-`test()`
+  incompat in `prompts.test.ts`, unrelated.
+- `tsup` build: success (345.96 KB).
+- No new test added: the change is prompt wording only. The gating logic
+  (`tipsVariant !== "maxLimit"`) is trivially verifiable by reading the code, and pinning
+  exact wording in a test would defeat the purpose (wording is meant to iterate).
+
+## Risk
+
+- **Very low**. Ephemeral guidance string only; no state, schema, or API change. Worst
+  case if wording underperforms: iterate on the text.
+
+## Lessons
+
+- When listing "largest" items as compression candidates, the adjective "largest" alone
+  can be read as a directive. Guidance must explicitly separate "consumed" (compressible)
+  from "large" (not a criterion).
+- A growth indicator without a semantic frame gets read as a threat. Labeling the nudge
+  type (efficiency vs overflow) up front reframes the delta correctly.
+
+## Followups
+
+- Observe in real sessions whether the efficiency note reduces rash mid-task compression.
+- If the maxLimit overflow warning also needs wording polish, handle in a separate change.

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -231,7 +231,12 @@ export const injectCompressNudges = (
             const growthStr = growth > 0 ? ` (+${fmt(growth)} since last nudge)` : ""
 
             const plainTextTokens = composition.textTokens
-            let breakdown = `\nBreakdown: ${fmt(composition.toolTokens)} tool (${pct(composition.toolTokens)}%) | ${fmt(composition.summaryTokens)} summaries (${pct(composition.summaryTokens)}%) | ${fmt(composition.codeTokens)} code (${pct(composition.codeTokens)}%) | ${fmt(plainTextTokens)} text (${pct(plainTextTokens)}%)${growthStr}`
+            // Soft nudges (growth/min-limit) are efficiency prompts, not overflow
+            // warnings — a separate, stronger alert fires at maxLimit (below).
+            const efficiencyNote = decision.tipsVariant !== "maxLimit"
+                ? `\nThis is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.`
+                : ""
+            let breakdown = `${efficiencyNote}\nBreakdown: ${fmt(composition.toolTokens)} tool (${pct(composition.toolTokens)}%) | ${fmt(composition.summaryTokens)} summaries (${pct(composition.summaryTokens)}%) | ${fmt(composition.codeTokens)} code (${pct(composition.codeTokens)}%) | ${fmt(plainTextTokens)} text (${pct(plainTextTokens)}%)${growthStr}`
 
             const topBlocks = Array.from(state.prune.messages.blocksById.values())
                 .filter((b) => b.active)
@@ -240,7 +245,6 @@ export const injectCompressNudges = (
             if (topBlocks.length > 0) {
                 breakdown += `\nTop blocks: ${topBlocks.map((b) => `b${b.blockId} ${fmt(b.compressedTokens)}→${fmt(b.summaryTokens)}`).join(", ")}`
             }
-            breakdown += `\n💡 Compress incrementally — compress the largest consumed ranges first.`
             if (composition.largestToolRanges.length > 0) {
                 breakdown += `\nLargest tool outputs: ${composition.largestToolRanges.map((r) => `${r.ref} (${fmt(r.tokens)})`).join(", ")}`
             }
@@ -250,6 +254,7 @@ export const injectCompressNudges = (
             if (composition.largestMessageRanges.length > 0) {
                 breakdown += `\nLargest text messages: ${composition.largestMessageRanges.map((r) => `${r.ref} (${fmt(r.tokens)})`).join(", ")}`
             }
+            breakdown += `\n💡 Compress incrementally: target the ranges above whose content you have already extracted for this step. Size alone is not a reason to compress — if a large range is still needed in full, keep it.`
             appendToLastTextPart(suffixMessage, breakdown)
         }
 


### PR DESCRIPTION
## Summary

Two prompt-wording refinements to the per-message nudge breakdown (issue #9 follow-up):

1. **Size-caution**: moved the `💡 Compress incrementally …` guidance to AFTER the largest-ranges list and reworded it — size alone is not a reason to compress; ranges still needed in full must stay. Prevents the model from compressing a large range purely because it was listed as "largest".

2. **Efficiency framing**: soft nudges (growth / minLimit) now get a prefix clarifying this is an efficiency nudge to compress early, **not** an overflow warning — a separate, stronger alert fires at maxLimit. Stops the model misreading `(+X since last nudge)` as imminent overflow.

## Changes

| File | Change |
|------|--------|
| `lib/messages/inject/inject.ts` | `efficiencyNote` gated on `tipsVariant !== "maxLimit"`; `💡 …` line moved after largest ranges + reworded |

## Verification

- `tsc --noEmit`: clean
- `tsup` build: success (345.96 KB)
- Full suite: **544 pass, 1 fail** (pre-existing bun nested-`test()` incompat in prompts.test.ts, unrelated)
- No new test: change is prompt wording only; gating (`tipsVariant !== "maxLimit"`) trivially verifiable; pinning exact wording would defeat iteration

## Risk

Very low — ephemeral guidance string only. No state/schema/API change.

## Devlog

`devlog/2026-07-06_nudge-caution-wording/{REQ,WORKLOG}.md` included.

Note: branches off `master` (independent of PR #57 which is still pending merge). The two PRs touch disjoint regions of inject.ts; no conflict expected.

Refs #9.