### PR TITLE
fix: persist nudge baseline when a growth nudge fires without anchor changes (#60)

### DIFF
--- a/devlog/2026-07-06_nudge-persist-baseline/REQ.md
+++ b/devlog/2026-07-06_nudge-persist-baseline/REQ.md
@@ -1,0 +1,83 @@
+# REQ — Persist nudge baseline when a growth nudge fires (#60)
+
+## Background
+
+GitHub issue #60 reports that the per-message context nudge fires on **every
+single turn** after restarting OpenCode, showing a large "+N since last nudge"
+that is actually the _total_ session usage rather than real growth since the
+last nudge.
+
+Reported against legacy DCP `0.19`, but ACP inherited the same logic and the
+bug reproduces on `master` (1.9.1).
+
+## Reproduction (from the issue + confirmed in source)
+
+1. Long session, a nudge fires naturally when growth exceeds
+   `nudgeGrowthTokens`.
+2. No compress/decompress around the same time → no anchor changes.
+3. Restart OpenCode.
+4. Send any message → nudge fires immediately. Repeat indefinitely.
+
+## Root cause
+
+In `lib/messages/inject/inject.ts`, when a growth nudge fires
+(`decision.shouldNudge === true`), the new baseline is written to memory:
+
+```ts
+state.nudges.lastPerMessageNudgeTokens = currentTokens
+state.nudges.lastPerMessageNudgeTurn = state.currentTurn ?? 0
+```
+
+But the persistence guard only saves when anchors changed:
+
+```ts
+if (anchorsChanged) {
+    saveSessionState(state, logger).catch(() => {})
+}
+```
+
+`anchorsChanged` only becomes `true` on anchor add/clear (context-limit anchor,
+turn/iteration anchor add, tool-output reminder). A growth-triggered nudge can
+fire with `anchorsChanged === false` when:
+
+- the turn/iteration anchor sets are already saturated (re-adding the same IDs
+  does not grow the `Set`, so the size check leaves `anchorsChanged` false), or
+- the last message is an assistant turn (the turn-anchor block is gated on
+  `isLastMessageUser`), or
+- `messagesSinceUser < iterationNudgeThreshold` (iteration anchor not added).
+
+In those cases the in-memory baseline is updated but never reaches disk. On the
+next restart `loadSessionState()` reads the stale `lastPerMessageNudgeTokens`,
+growth is recomputed against the old value, the threshold is exceeded again, and
+the nudge refires — every turn, for the whole session.
+
+## Constraints
+
+- Minimal change; do not refactor surrounding nudge logic.
+- Must not change persisted state shape (backward compat, §2.6 of AGENTS.md).
+- Must include a test that fails before the fix and passes after.
+
+## Acceptance criteria
+
+- [x] `inject.ts` save guard persists when `decision.shouldNudge === true`, not
+      only when `anchorsChanged`.
+- [x] New test: a growth nudge with `anchorsChanged === false` persists the new
+      baseline to disk; reloaded value equals the new `currentTokens`.
+- [x] Test fails on the pre-fix code (`200000 !== 255000`) and passes after.
+- [x] `npm run typecheck` clean.
+- [x] Full suite green (excluding the pre-existing `prompts.test.ts` bun
+      nested-test incompatibility).
+- [x] `npm run build` succeeds.
+
+## Approach
+
+Widen the single guard:
+
+```ts
+if (anchorsChanged || decision.shouldNudge) {
+    saveSessionState(state, logger).catch(() => {})
+}
+```
+
+Semantically correct: if a nudge fired, the baseline moved and must be
+persisted. Follows the issue's proposed fix exactly.

--- a/devlog/2026-07-06_nudge-persist-baseline/WORKLOG.md
+++ b/devlog/2026-07-06_nudge-persist-baseline/WORKLOG.md
@@ -1,0 +1,104 @@
+# WORKLOG — Persist nudge baseline when a growth nudge fires (#60)
+
+## Summary
+
+Fixed issue #60: the per-message nudge baseline (`lastPerMessageNudgeTokens`)
+was updated in memory when a growth nudge fired but not persisted to disk when
+no anchors changed, causing the nudge to refire every turn after an OpenCode
+restart. One-line guard widening + a regression test that reproduces the
+restart-stale-baseline scenario.
+
+## ChangeLog
+
+| Commit        | File                            | Change                                                                                                                                         |
+| ------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | --- | ------------------------------------------------------------------------------------------ |
+| (this branch) | `lib/messages/inject/inject.ts` | Save guard `if (anchorsChanged)` → `if (anchorsChanged                                                                                         |     | decision.shouldNudge)`at the end of`injectCompressNudges`, with a comment referencing #60. |
+| (this branch) | `tests/inject.test.ts`          | New regression test: seeds a stale baseline on disk, fires a growth nudge with no anchor changes, reloads, asserts the new baseline persisted. |
+
+## KeyFiles
+
+- `lib/messages/inject/inject.ts` — `injectCompressNudges` save guard (line ~313
+  post-edit). The in-memory baseline update at ~264-265 was already correct; only
+  the persistence guard was too narrow.
+- `tests/inject.test.ts` — `injectCompressNudges` unit tests. Added
+  `saveSessionState`/`loadSessionState` imports, `XDG_DATA_HOME`-derived
+  `STORAGE_DIR`, `PERSIST_SESSION` id and `cleanupPersistSession()` helper
+  matching the `persistence.test.ts` pattern.
+- `lib/state/persistence.ts` — read to confirm the storage path is
+  `XDG_DATA_HOME`-injectable and that no other save call site covers the
+  growth-nudge path (it does not).
+
+## DesignNotes
+
+**Why `|| decision.shouldNudge` and not a separate `saveSessionState` call
+inside the `if (decision.shouldNudge)` block?** Keeping a single save site at
+the end of the function preserves the existing structure (one persistence
+trigger per `injectCompressNudges` invocation) and avoids a double-save when a
+nudge fires _and_ anchors changed in the same pass.
+
+**Why the test seeds the stale baseline to disk first.** The bug is
+specifically about _persistence_, not the in-memory value (the in-memory value
+was always updated correctly at ~264-265). A pure state assertion cannot
+distinguish the fix from the bug. Pre-saving the stale 200K baseline makes the
+without-fix failure read exactly like the issue report — `200000 !== 255000`
+(stale value reloaded) — instead of "no file / null", which is less faithful to
+the reported symptom.
+
+**Why `setTimeout(resolve, 50)` after `injectCompressNudges`.** The save inside
+`injectCompressNudges` is fire-and-forget (`saveSessionState(...).catch(() => {})`),
+not awaited. The flush lets the write settle before `loadSessionState` reads
+it. 50ms is far above a local file write; `persistence.test.ts` awaits
+`saveSessionState` directly so writes are fast.
+
+**Scenario engineering (the non-obvious part).** Forcing
+`shouldNudge === true && anchorsChanged === false` required:
+
+- `modelContextLimit = 1_000_000` → adaptive `nudgeGrowthTokens = 50_000`.
+- `maxContextLimit = 800_000`, `minContextLimit = 200_000`,
+  `currentTokens = 255_000` → `overMinLimit = true`, `overMaxLimit = false`
+  (avoids the context-limit anchor branch which would set `anchorsChanged`).
+- `growth = 255K − 200K = 55K ≥ 50K` → `shouldNudge = true`.
+- Last message is an **assistant** turn → `isLastMessageUser === false` → the
+  turn-anchor block is skipped.
+- Only one message after the user → `messagesSinceUser = 1 < iterationNudgeThreshold(15)`
+  → the iteration-anchor block is skipped.
+- No tool parts → the tool-output reminder block is skipped.
+- Result: no path sets `anchorsChanged`, so it stays `false`.
+
+## Testing
+
+- `npm run typecheck` — clean.
+- `bun test tests/inject.test.ts` — 14/14 pass (was 13; +1 new).
+- **Regression validity verified**: temporarily reverted the fix → the new test
+  fails with `AssertionError: 200000 !== 255000` (the exact reported symptom);
+  restored the fix → passes.
+- Full suite: `bun test tests/` → 563 pass / 1 fail. The single failure is the
+  pre-existing `prompts.test.ts` "system prompt overrides handle reminder tags
+  safely" test, caused by bun's nested-`t.test` incompatibility (unrelated to
+  this change — this branch only touches `inject.ts` and `inject.test.ts`).
+- `npm run build` — success, `dist/index.js` 349.15 KB.
+
+## Risk
+
+**Low.** One guard widened; no state-shape change; no API change; save is still
+idempotent and already fire-and-forget. The only behavioral change is that a
+nudge-triggered baseline now reaches disk immediately instead of waiting for the
+next anchor mutation — which is exactly the intended fix.
+
+## Lessons
+
+- The bug was invisible to the existing test suite because all nudge tests
+  asserted on _in-memory_ state (`state.nudges.*`), never on _persisted_ state.
+  Persistence behavior needs persistence-level (disk round-trip) tests — the
+  `persistence.test.ts` pattern should be reused wherever a code path claims to
+  "save".
+- A growth-triggered nudge with no anchor change is a real, common path
+  (assistant's turn, saturated anchors). The save guard must not be coupled to
+  anchor mutations.
+
+## Followups
+
+- Release as `1.9.2` (patch) per semver — bug fix only.
+- Consider auditing other `if (anchorsChanged) saveSessionState(...)`-style
+  guards for the same class of bug (none found in `hooks.ts` save sites; those
+  are tied to concrete mutations like deactivation, tool-cache, command exec).

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -310,7 +310,11 @@ export const injectCompressNudges = (
         appendToLastTextPart(suffixMessage, "\n")
     }
 
-    if (anchorsChanged) {
+    // [FIX #60] Save on nudge too: a growth-triggered nudge updates the in-memory
+    // baseline (above) but anchorsChanged stays false when anchor sets are
+    // saturated, so the on-disk baseline went stale and the nudge refired every
+    // turn after restart.
+    if (anchorsChanged || decision.shouldNudge) {
         saveSessionState(state, logger).catch(() => {})
     }
 }

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -1,10 +1,15 @@
 import assert from "node:assert/strict"
 import test from "node:test"
+import * as fs from "fs/promises"
+import { existsSync } from "fs"
+import { join } from "path"
+import { homedir } from "os"
 import type { PluginConfig } from "../lib/config"
 import { Logger } from "../lib/logger"
 import { injectMessageIds, injectCompressNudges } from "../lib/messages/inject/inject"
 import { createSyntheticUserMessage } from "../lib/messages/utils"
 import { createSessionState, type WithParts } from "../lib/state"
+import { saveSessionState, loadSessionState } from "../lib/state/persistence"
 import { formatMessageIdTag } from "../lib/message-ids"
 
 function buildConfig(mode: "message" | "range" = "range"): PluginConfig {
@@ -34,6 +39,22 @@ function buildConfig(mode: "message" | "range" = "range"): PluginConfig {
 }
 
 const SID = "ses-inject-test"
+
+const STORAGE_DIR = join(
+    process.env.XDG_DATA_HOME || join(homedir(), ".local", "share"),
+    "opencode",
+    "storage",
+    "plugin",
+    "acp",
+)
+const PERSIST_SESSION = "test-inject-nudge-persist"
+
+async function cleanupPersistSession(): Promise<void> {
+    const filePath = join(STORAGE_DIR, `${PERSIST_SESSION}.json`)
+    if (existsSync(filePath)) {
+        await fs.unlink(filePath)
+    }
+}
 
 function textPart(msgId: string, text: string) {
     return { id: `${msgId}-p`, messageID: msgId, sessionID: SID, type: "text" as const, text }
@@ -289,4 +310,51 @@ test("injectCompressNudges: post-compress large growth DOES nudge", () => {
         "55K growth after compress (> 50K adaptive threshold) — should nudge",
     )
     assert.equal(state.nudges.lastPerMessageNudgeTokens, 305_000)
+})
+
+test("injectCompressNudges persists new nudge baseline to disk when a growth nudge fires without anchor changes (#60)", async () => {
+    await cleanupPersistSession()
+
+    // Seed disk with a stale baseline, as left by a prior session before restart.
+    const seed = createSessionState()
+    seed.sessionId = PERSIST_SESSION
+    seed.nudges.lastPerMessageNudgeTokens = 200_000
+    await saveSessionState(seed, logger)
+
+    // Simulate the post-restart in-memory state: stale baseline loaded back.
+    const state = createSessionState()
+    state.sessionId = PERSIST_SESSION
+    state.modelContextLimit = 1_000_000
+    const loaded = await loadSessionState(PERSIST_SESSION, logger)
+    state.nudges.lastPerMessageNudgeTokens = loaded!.nudges.lastPerMessageNudgeTokens
+
+    const config = buildConfig()
+    config.compress.maxContextLimit = 800_000
+    config.compress.minContextLimit = 200_000
+
+    // Last message is an assistant turn → turnNudgeAnchors block skipped (isLastMessageUser=false);
+    // only one message after the user → iterationNudgeAnchors skipped (< iterationNudgeThreshold);
+    // no tool parts → toolOutput reminder skipped. So anchorsChanged stays false.
+    // Growth = 255K - 200K = 55K >= 50K adaptive threshold → shouldNudge=true.
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "response", { input: 200_000, output: 55_000 }),
+    ]
+
+    injectCompressNudges(state, config, logger, messages, {} as any)
+
+    assert.equal(state.nudges.shouldInjectThisTurn, true, "growth nudge should fire (55K >= 50K adaptive)")
+    assert.equal(state.nudges.lastPerMessageNudgeTokens, 255_000, "in-memory baseline updated to currentTokens")
+
+    // saveSessionState is fire-and-forget inside injectCompressNudges (.catch(()=>{})); flush before reload.
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const reloaded = await loadSessionState(PERSIST_SESSION, logger)
+    assert.ok(reloaded, "state must be persisted when a nudge fires")
+    assert.equal(
+        reloaded!.nudges.lastPerMessageNudgeTokens,
+        255_000,
+        "[#60] new baseline must reach disk — otherwise restart reloads the stale 200K and the nudge refires every turn",
+    )
+    await cleanupPersistSession()
 })


### PR DESCRIPTION
## Summary

Fixes #60.

The per-message context nudge fired **every turn after an OpenCode restart** because the new growth baseline (`lastPerMessageNudgeTokens`) was updated in memory when a growth nudge fired but never persisted — the save guard only ran when `anchorsChanged`, and a growth-triggered nudge can fire with `anchorsChanged === false` (anchor sets saturated, or the last message is an assistant turn so no turn anchor is added).

On restart the stale baseline was reloaded, growth was recomputed against the old value, the threshold was exceeded again, and the nudge refired for the whole session.

## Fix

Widen the single save guard at the end of `injectCompressNudges`:

```diff
-    if (anchorsChanged) {
+    // [FIX #60] Save on nudge too: a growth-triggered nudge updates the in-memory
+    // baseline (above) but anchorsChanged stays false when anchor sets are
+    // saturated, so the on-disk baseline went stale and the nudge refired every
+    // turn after restart.
+    if (anchorsChanged || decision.shouldNudge) {
         saveSessionState(state, logger).catch(() => {})
     }
```

Semantically correct: if a nudge fired, the baseline moved and must be persisted. Matches the fix proposed in the issue.

## Test

New regression test in `tests/inject.test.ts`:

- Seeds a stale `200K` baseline to disk (as left by a prior session).
- Reloads it (simulating restart), then fires a growth nudge (`+55K ≥ 50K` adaptive threshold) with `anchorsChanged === false` (last message is an assistant turn, <15 messages since user, no tool parts).
- Reloads from disk and asserts the baseline is now `255K`.

**Regression validity verified**: reverting the fix makes the test fail with `200000 !== 255000` (the exact reported symptom); the fix makes it pass.

## Verification

- `npm run typecheck` — clean
- `bun test tests/inject.test.ts` — 14/14 pass (+1 new)
- `npm run build` — success (349.15 KB)
- Full suite: 563 pass / 1 fail (pre-existing `prompts.test.ts` bun nested-`t.test` incompatibility, unrelated)

## Devlog

`devlog/2026-07-06_nudge-persist-baseline/` (REQ.md + WORKLOG.md) included.

## Release

Patch-only bug fix → target **1.9.2**.