### PR TITLE
feat: summary structure guidance in compress prompts (issue #9)

### DIFF
--- a/devlog/2026-07-07_compress-summary-format/REQ.md
+++ b/devlog/2026-07-07_compress-summary-format/REQ.md
@@ -34,8 +34,9 @@ point with no content. Do NOT fabricate to fill the template
 ## Acceptance criteria
 
 - [x] Both compress prompts (range + message) gain a `SUMMARY STRUCTURE` section
-- [x] Three points: (1) what this range/message covers, (2) critical content
-      transcribed verbatim, (3) what is recoverable + when
+- [x] Four points: (1) what this range/message covers, (2) critical content
+      transcribed verbatim, (3) what is recoverable + when, (4) why detail was
+      omitted (justification for anything not transcribed in detail)
 - [x] Wording states the structure is not mandatory and empty points are omitted
 - [x] No `do not push the reader to decompress` sentence (D3 deferred)
 - [x] No tool/schema change (D2 = wording only)

--- a/devlog/2026-07-07_compress-summary-format/REQ.md
+++ b/devlog/2026-07-07_compress-summary-format/REQ.md
@@ -1,0 +1,55 @@
+# REQ: Compression summary format guidance (issue #9)
+
+## Background
+
+Issue #9 (`调查这个压缩失败可能原因`) surfaced that model-written compress
+summaries were inconsistent: some were pointer-style ("X is in file Y") rather
+than self-contained records, some omitted the kind of detail that got trimmed,
+and the model had no guidance on what a good summary *structure* looks like.
+
+The compression quality prompts (`lib/prompts/compress-range.ts`,
+`lib/prompts/compress-message.ts`) told the model to be EXHAUSTIVE and LEAN but
+did not give it a concrete structure to organize the summary around.
+
+## Requirement
+
+Give the model a summary structure in the two compress prompts so summaries
+become self-contained, faithfully preserve critical content, and name what was
+trimmed (so a later step knows whether to decompress).
+
+## Design decisions (per user, 2026-07-07)
+
+| # | Question | Decision |
+|---|----------|----------|
+| D1 | What counts as "critical content"? | **(b)** the model self-judges what is critical; no hardcoded category list |
+| D2 | Structure enforcement | **(a)** sections *inside* a single summary string — no schema/tool change |
+| D3 | Push decompress? | **Deferred** — do NOT add "do not push the reader to decompress" wording yet (the range-decompress tooling is not ready; revisit after D4) |
+| D4 | Range-aligned decompress tool | **Follow-up PR** (tool-layer change) — out of scope here |
+| D5 | Rollout | **Prompt wording first** (`看效果`), then decide on a release |
+
+Core philosophy (user): the structure is **not mandatory**. The model omits any
+point with no content. Do NOT fabricate to fill the template
+("要求强制，他没有就瞎造，最后乱七八糟").
+
+## Acceptance criteria
+
+- [x] Both compress prompts (range + message) gain a `SUMMARY STRUCTURE` section
+- [x] Three points: (1) what this range/message covers, (2) critical content
+      transcribed verbatim, (3) what is recoverable + when
+- [x] Wording states the structure is not mandatory and empty points are omitted
+- [x] No `do not push the reader to decompress` sentence (D3 deferred)
+- [x] No tool/schema change (D2 = wording only)
+- [x] `npm run typecheck` clean
+- [x] Build succeeds
+
+## Constraints
+
+- Backward compatibility: no persisted-state or tool-schema change
+- Editable prompts only (`compress-range.ts`, `compress-message.ts`) — the
+  non-editable format schema in `lib/prompts/extensions/tool.ts` is untouched
+- No version bump this PR — release later after observing the effect
+
+## Out of scope
+
+- D4: range-aligned decompress tool (separate PR)
+- D3 decompress-nudge wording (revisit after D4 lands)

--- a/devlog/2026-07-07_compress-summary-format/WORKLOG.md
+++ b/devlog/2026-07-07_compress-summary-format/WORKLOG.md
@@ -1,0 +1,72 @@
+# WORKLOG: Compression summary format guidance (issue #9)
+
+## Summary
+
+Added a `SUMMARY STRUCTURE` section to both compress prompts (range + message)
+giving the model a three-point structure for organizing summaries: what the
+range covers, critical content transcribed verbatim, and what is recoverable +
+when. The structure is explicitly **not mandatory** — empty points are omitted
+and the model is told not to invent material to fill the template.
+
+Per user decision D3, the "do not push the reader to decompress" wording is
+**deferred** (the range-decompress tooling is not ready); only the "when to
+decompress" / "what is recoverable" guidance is added now.
+
+## ChangeLog
+
+| Commit | File | Change |
+|--------|------|--------|
+| (this PR) | `lib/prompts/compress-range.ts` | + `SUMMARY STRUCTURE` section (3 points) after LEAN paragraph |
+| (this PR) | `lib/prompts/compress-message.ts` | + `SUMMARY STRUCTURE` section (3 points, message-worded) before MESSAGE IDS |
+
+No tool/schema/state change. No version bump.
+
+## KeyFiles
+
+- `lib/prompts/compress-range.ts` — range-mode compress prompt (editable)
+- `lib/prompts/compress-message.ts` — message-mode compress prompt (editable)
+- `lib/prompts/extensions/tool.ts` — NON-editable format schema (untouched)
+
+## DesignNotes
+
+The three points map to the failure modes observed in issue #9:
+
+1. **What this range covers** — semantic description, not raw IDs. Fixes
+   summaries that were just lists of message IDs.
+2. **Critical content, transcribed** — copy the content itself (code, error
+   text, exact values), not a pointer to where it lives. Fixes pointer-style
+   summaries that lost the actual detail.
+3. **What is recoverable, and when** — name the kind of detail trimmed (full
+   diffs, long logs, complete reads) and the situations a later step might
+   want it back. The model must not invent a block ID (it does not know the
+   eventual `bN`); the reader locates blocks via `acp_status` / `search_context`
+   when needed.
+
+**D3 deferral**: the original draft included "do not push the reader to
+decompress" to implement decision D3 (don't force decompress). User said to
+hold that wording until the range-decompress tool (D4) is ready — only the
+"when to decompress" part ships now.
+
+## Testing
+
+- `npm run typecheck` — clean (prompts are string constants; no type surface)
+- Build — succeeds (bundle size 351.18 KB)
+- `tests/prompts.test.ts` references `compress-message` only in an
+  override-preservation test (no content assertions), so the edit is safe
+
+## Risk
+
+Low. Prompt-only change. No persisted-state, schema, or control-flow change.
+Worst case: wording does not improve summary quality → iterate on prompt copy.
+
+## Lessons
+
+- Defer tooling-dependent wording until the tool exists. Adding "don't push
+  decompress" before range-decompress is ready would advise against behavior the
+  tool layer doesn't yet support cleanly.
+
+## Followups
+
+- D4: range-aligned decompress tool (separate PR)
+- D3: revisit decompress-nudge wording after D4 lands
+- Release: bump version + changelog after observing effect (`看效果`)

--- a/devlog/2026-07-07_compress-summary-format/WORKLOG.md
+++ b/devlog/2026-07-07_compress-summary-format/WORKLOG.md
@@ -41,6 +41,11 @@ The three points map to the failure modes observed in issue #9:
    want it back. The model must not invent a block ID (it does not know the
    eventual `bN`); the reader locates blocks via `acp_status` / `search_context`
    when needed.
+4. **Why detail was omitted** (added per user follow-up) — when a file, report,
+   code, user instruction, or discussion result is not transcribed (or is
+   reduced to one line), state why (redundant / dead end / recoverable /
+   low-signal). Closes the accountability gap: the reader should never wonder
+   why something that looked important was dropped.
 
 **D3 deferral**: the original draft included "do not push the reader to
 decompress" to implement decision D3 (don't force decompress). User said to

--- a/lib/prompts/compress-message.ts
+++ b/lib/prompts/compress-message.ts
@@ -10,6 +10,13 @@ Directly quote short user instructions when that best preserves exact meaning.
 Yet be LEAN. Strip away the noise: failed attempts that led nowhere, verbose tool output, and repetition. What remains should be pure signal - golden nuggets of detail that preserve full understanding with zero ambiguity.
 If a message contains no significant technical decisions, code changes, or user requirements, produce a minimal one-line summary rather than a detailed one.
 
+SUMMARY STRUCTURE
+For messages worth a detailed summary, organize what remains around three points. Omit any point that has no content for this message — do not invent material to fill the template.
+
+- What this message contains: describe the message's purpose in semantic terms (e.g. "the build failure report from the test run"), not raw message IDs.
+- Critical content, transcribed: when the message carries important code, error text, report output, commands, or exact values, copy the content itself into the summary — not a pointer to where it lives. If it is critical, transcribe it verbatim.
+- What is recoverable, and when: name the kind of detail you trimmed and the situations in which a later step might want it back. Do not invent a block ID — you do not know this block's eventual ID. The reader locates it via acp_status or search_context when needed.
+
 MESSAGE IDS
 You specify individual raw messages by ID using the injected IDs visible in the conversation:
 

--- a/lib/prompts/compress-message.ts
+++ b/lib/prompts/compress-message.ts
@@ -11,11 +11,12 @@ Yet be LEAN. Strip away the noise: failed attempts that led nowhere, verbose too
 If a message contains no significant technical decisions, code changes, or user requirements, produce a minimal one-line summary rather than a detailed one.
 
 SUMMARY STRUCTURE
-For messages worth a detailed summary, organize what remains around three points. Omit any point that has no content for this message — do not invent material to fill the template.
+For messages worth a detailed summary, organize what remains around the points below. Omit any point that has no content for this message — do not invent material to fill the template.
 
 - What this message contains: describe the message's purpose in semantic terms (e.g. "the build failure report from the test run"), not raw message IDs.
 - Critical content, transcribed: when the message carries important code, error text, report output, commands, or exact values, copy the content itself into the summary — not a pointer to where it lives. If it is critical, transcribe it verbatim.
 - What is recoverable, and when: name the kind of detail you trimmed and the situations in which a later step might want it back. Do not invent a block ID — you do not know this block's eventual ID. The reader locates it via acp_status or search_context when needed.
+- Why detail was omitted: when the message contains a file, report, code, user instruction, or discussion result that you do not transcribe (or reduce to a single line), state why — it was redundant, a dead end, recoverable elsewhere, or otherwise low-signal. The reader should never wonder why something that looked important was dropped.
 
 MESSAGE IDS
 You specify individual raw messages by ID using the injected IDs visible in the conversation:

--- a/lib/prompts/compress-range.ts
+++ b/lib/prompts/compress-range.ts
@@ -9,6 +9,13 @@ Directly quote user messages when they are short enough to include safely. Direc
 
 Yet be LEAN. Strip away the noise: failed attempts that led nowhere, verbose tool outputs, back-and-forth exploration. What remains should be pure signal - golden nuggets of detail that preserve full understanding with zero ambiguity.
 
+SUMMARY STRUCTURE
+Organize what remains around three points. Omit any point that has no content for this range — do not invent material to fill the template. Match depth to what is actually there: a range with no critical content yields a lean summary; a range carrying a key decision or result yields a verbatim record.
+
+- What this range covers: describe the phase, task, or exploration in semantic terms (e.g. "the debugging phase that located the off-by-one in search.ts"), not raw message IDs.
+- Critical content, transcribed: when the range contains important code, error text, report output, commands, or exact values, copy the content itself into the summary — not a pointer to where it lives. If it is critical, transcribe it verbatim.
+- What is recoverable, and when: name the kind of detail you trimmed (full diffs, long logs, complete reads) and the situations in which a later step might want it back. Do not invent a block ID — you do not know this block's eventual ID. The reader locates it via acp_status or search_context when needed.
+
 COMPRESSED BLOCK PLACEHOLDERS
 The system auto-detects any previously compressed blocks whose anchor messages fall inside your selected range. You do NOT need to manually list \`(bN)\` placeholders in your summary — every consumed block is tracked automatically.
 

--- a/lib/prompts/compress-range.ts
+++ b/lib/prompts/compress-range.ts
@@ -10,11 +10,12 @@ Directly quote user messages when they are short enough to include safely. Direc
 Yet be LEAN. Strip away the noise: failed attempts that led nowhere, verbose tool outputs, back-and-forth exploration. What remains should be pure signal - golden nuggets of detail that preserve full understanding with zero ambiguity.
 
 SUMMARY STRUCTURE
-Organize what remains around three points. Omit any point that has no content for this range — do not invent material to fill the template. Match depth to what is actually there: a range with no critical content yields a lean summary; a range carrying a key decision or result yields a verbatim record.
+Organize what remains around the points below. Omit any point that has no content for this range — do not invent material to fill the template. Match depth to what is actually there: a range with no critical content yields a lean summary; a range carrying a key decision or result yields a verbatim record.
 
 - What this range covers: describe the phase, task, or exploration in semantic terms (e.g. "the debugging phase that located the off-by-one in search.ts"), not raw message IDs.
 - Critical content, transcribed: when the range contains important code, error text, report output, commands, or exact values, copy the content itself into the summary — not a pointer to where it lives. If it is critical, transcribe it verbatim.
 - What is recoverable, and when: name the kind of detail you trimmed (full diffs, long logs, complete reads) and the situations in which a later step might want it back. Do not invent a block ID — you do not know this block's eventual ID. The reader locates it via acp_status or search_context when needed.
+- Why detail was omitted: when a file, report, code, user instruction, or discussion result in the range is not transcribed (or is reduced to a single line), state why — it was redundant, a dead end, recoverable elsewhere, or otherwise low-signal. The reader should never wonder why something that looked important was dropped.
 
 COMPRESSED BLOCK PLACEHOLDERS
 The system auto-detects any previously compressed blocks whose anchor messages fall inside your selected range. You do NOT need to manually list \`(bN)\` placeholders in your summary — every consumed block is tracked automatically.


### PR DESCRIPTION
## Summary

Add a `SUMMARY STRUCTURE` section to both compress prompts (range + message) so model-written summaries become self-contained, faithfully preserve critical content, and name what was trimmed.

Per the design discussion in issue #9 (decisions D1–D5):

- **D1 (critical content)**: the model self-judges what is critical — no hardcoded category list.
- **D2 (structure)**: sections *inside* a single summary string — no tool/schema change.
- **D3 (push decompress)**: **deferred** — no "do not push the reader to decompress" wording yet (range-decompress tooling not ready). Only "when to decompress" guidance ships now.
- **D4 (range-aligned decompress tool)**: follow-up PR (tool-layer).
- **D5 (rollout)**: prompt wording first (`看效果`), release later.

The three points map to the failure modes observed in #9:
1. **What this range/message covers** — semantic description, not raw IDs.
2. **Critical content, transcribed** — copy the content itself (code, error text, exact values), not a pointer.
3. **What is recoverable, and when** — names the trimmed detail + situations a later step might want it back. Model must not invent a block ID; reader locates via `acp_status` / `search_context`.

The structure is explicitly **not mandatory** — empty points are omitted, model told not to invent material to fill the template.

## Scope

- Prompt-only (2 editable prompt files). No tool/schema/state change.
- No version bump this PR (release later after observing effect).
- Devlog: `devlog/2026-07-07_compress-summary-format/` (REQ.md + WORKLOG.md).

## Verification

- `npm run typecheck` — clean
- `npm run build` — clean (351.06 KB)
- `tests/prompts.test.ts` references `compress-message` only in an override-preservation test (no content assertions)