### PR TITLE
fix: dev-deploy.sh syncs legacy resolution path (issue #9)

### DIFF
--- a/devlog/2026-07-07_dev-deploy-dual-path/REQ.md
+++ b/devlog/2026-07-07_dev-deploy-dual-path/REQ.md
@@ -1,0 +1,41 @@
+# REQ: dev-deploy.sh dual-path sync (legacy resolution path)
+
+## Background
+
+While testing PR #63 locally, a long-running session showed that compress
+summaries did not pick up new prompt changes. Root cause:
+`scripts/dev-deploy.sh` deploys to **one** path only:
+
+```
+~/.cache/opencode/packages/opencode-acp@latest/node_modules/opencode-acp/
+```
+
+But a second, stale install existed at the legacy resolution path:
+
+```
+~/.cache/opencode/node_modules/opencode-acp/
+```
+
+The legacy bundle was from Jul 2 with **none** of the recent features
+(PR #57/#58/#60/#63 all 0 matches by grep). Depending on opencode version,
+the running process may resolve `opencode-acp@latest` to the legacy path, so
+deploys to the primary path silently had no effect.
+
+## Requirement
+
+`dev-deploy.sh` must keep both resolution paths in sync so a deploy takes
+effect regardless of which path the running opencode loads.
+
+## Acceptance criteria
+
+- [x] Script defines a `LEGACY_TARGET` for the `~/.cache/opencode/node_modules/opencode-acp/` path
+- [x] After the primary deploy + version verify, if the legacy path exists, dist + package.json are copied there too
+- [x] Legacy sync is logged (`info "Legacy path also synced: ..."`)
+- [x] If legacy path doesn't exist, a skip message is logged (no error)
+- [x] `bash -n` syntax check passes
+- [x] Running the script produces md5-identical bundles at both paths
+
+## Constraints
+
+- No behavior change when the legacy path is absent (fresh machines are unaffected)
+- Primary path remains the source of truth; legacy is best-effort sync

--- a/devlog/2026-07-07_dev-deploy-dual-path/WORKLOG.md
+++ b/devlog/2026-07-07_dev-deploy-dual-path/WORKLOG.md
@@ -1,0 +1,57 @@
+# WORKLOG: dev-deploy.sh dual-path sync (legacy resolution path)
+
+## Summary
+
+`dev-deploy.sh` now syncs the legacy opencode resolution path
+(`~/.cache/opencode/node_modules/opencode-acp/`) in addition to the primary
+`packages/@latest` path, so deploys take effect regardless of which path the
+running opencode loads. Prevents the silent-no-op that occurred when a stale
+legacy install shadowed the primary deploy.
+
+## ChangeLog
+
+| Commit | File | Change |
+|--------|------|--------|
+| (this PR) | `scripts/dev-deploy.sh` | + `LEGACY_TARGET` var; after primary deploy+verify, copy dist+package.json to legacy path if it exists, log result |
+
+## KeyFiles
+
+- `scripts/dev-deploy.sh` — local dev build+deploy script
+
+## DesignNotes
+
+The legacy path exists on machines that have run older opencode versions. The
+script does not create it (fresh machines stay clean); it only syncs if the
+directory already exists. The primary path remains authoritative — the legacy
+sync is purely defensive against version-dependent resolution differences.
+
+The two comments added (`LEGACY_TARGET` declaration + the sync block) are
+necessary: they document a non-obvious gotcha (two resolution paths that differ
+by opencode version) that already caused a real incident (stale shadow made
+deploys silently ineffective). Without them a future dev would not understand
+why the second path is synced.
+
+## Testing
+
+- `bash -n scripts/dev-deploy.sh` — syntax OK
+- Ran `./scripts/dev-deploy.sh` end-to-end — primary deployed, legacy synced
+  (`info "Legacy path also synced: ..."`), both paths md5-identical
+  (`73e3437c196c6247a5ea194b6132c76f`) after the run
+
+## Risk
+
+Low. Best-effort sync guarded by `[[ -d ... ]]`; no-op when legacy path absent.
+No change to primary deploy behavior.
+
+## Lessons
+
+- A deploy script that targets one path can be silently defeated by a stale
+  install at an alternate resolution path. When a runtime may resolve a package
+  to more than one location, the deploy tooling must cover all of them (or
+  clean the alternates).
+
+## Followups
+
+- Consider documenting both resolution paths explicitly in AGENTS.md §3.4
+  (currently it only calls the legacy path "wrong" — better to acknowledge it
+  may be loaded and must be kept in sync).

--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -45,6 +45,12 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # opencode plugin cache (uses $HOME, works for any user)
 DEPLOY_TARGET="$HOME/.cache/opencode/packages/opencode-acp@latest/node_modules/opencode-acp"
 
+# Legacy resolution path. Older opencode versions resolve "opencode-acp@latest" to
+# ~/.cache/opencode/node_modules/opencode-acp/ instead of the packages/@latest path.
+# If this directory exists, keep it in sync so deploys take effect regardless of
+# which resolution path the running opencode uses. (See AGENTS.md §3.4.)
+LEGACY_TARGET="$HOME/.cache/opencode/node_modules/opencode-acp"
+
 # ── Helpers ────────────────────────────────────────────────────────────────
 
 RED='\033[0;31m'
@@ -132,6 +138,18 @@ cp "$PROJECT_ROOT/package.json" "$DEPLOY_TARGET/package.json"
 DEPLOYED_VER=$(node -p "require('$DEPLOY_TARGET/package.json').version" 2>/dev/null || echo "?")
 [[ "$DEPLOYED_VER" == "$NEW_VER" ]] \
     || error "Version mismatch after deploy (expected $NEW_VER, got $DEPLOYED_VER)"
+
+# Sync the legacy resolution path if it exists (see comment on LEGACY_TARGET).
+if [[ -d "$LEGACY_TARGET/dist" ]]; then
+    cp -r "$PROJECT_ROOT/dist/"* "$LEGACY_TARGET/dist/"
+    cp "$PROJECT_ROOT/package.json" "$LEGACY_TARGET/package.json"
+    LEGACY_VER=$(node -p "require('$LEGACY_TARGET/package.json').version" 2>/dev/null || echo "?")
+    [[ "$LEGACY_VER" == "$NEW_VER" ]] \
+        || warn "Legacy path synced but version mismatch (expected $NEW_VER, got $LEGACY_VER)"
+    info "Legacy path also synced: $LEGACY_TARGET"
+else
+    info "No legacy install at $LEGACY_TARGET — skipping sync"
+fi
 
 # ── Done ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

`dev-deploy.sh` only deployed to `~/.cache/opencode/packages/opencode-acp@latest/`, but a stale install at the legacy path `~/.cache/opencode/node_modules/opencode-acp/` (Jul 2, zero recent features) could shadow it depending on opencode version — making deploys silently ineffective.

**Root cause found while testing PR #63**: a long-running session never picked up deployed changes because opencode resolved to the stale legacy install.

## Fix

After the primary deploy + version verify, if the legacy path exists, copy `dist/` + `package.json` there too and log it. Primary path stays authoritative; legacy sync is best-effort and a no-op on fresh machines.

## Verification

- `bash -n scripts/dev-deploy.sh` — syntax OK
- Ran end-to-end: primary deployed, legacy synced (`info "Legacy path also synced: ..."`), both paths md5-identical (`73e3437c196c6247a5ea194b6132c76f`)

## Scope

- `scripts/dev-deploy.sh` only (dev tooling). No plugin/runtime change.
- Devlog: `devlog/2026-07-07_dev-deploy-dual-path/` (REQ + WORKLOG)