### PR TITLE
feat: reinforce SUMMARY STRUCTURE at system prompt + nudge point (issue #9)

### DIFF
--- a/devlog/2026-07-07_compress-prompt-reinforcement/REQ.md
+++ b/devlog/2026-07-07_compress-prompt-reinforcement/REQ.md
@@ -1,0 +1,70 @@
+# REQ — Compress summary-structure prompt reinforcement
+
+## Background
+
+PR #63 added a 4-point SUMMARY STRUCTURE to the compress tool *description*
+(`lib/prompts/compress-range.ts` + `compress-message.ts`). Investigation of an
+ML-research session (`ses_0cf8549c4ff`, block 38 "B知识图谱") showed the model
+was **not** following the new structure: block 38 was a dense data-dump with
+pointer-refs (`EDITING_REPORT §4.2`) instead of transcribed content, points ③④
+missing entirely, and truncation at the length limit.
+
+Root cause is **few-shot interference**: that session already carried 37 older
+summaries written under the previous (unstructured) format. In-context examples
+overpower tool-description instructions, so the model mimics the legacy dense
+style and ignores the 4-point structure buried in the tool description.
+
+## Problem
+
+The SUMMARY STRUCTURE prompt lives **only** in the `compress` tool's
+`description` field — it is never surfaced in the system prompt or at the
+compress call-to-action. Two weaknesses:
+
+1. **Low prompt weight** — tool descriptions are read once; the structure is
+   easily drowned out by 37 in-context counter-examples.
+2. **Far from the action point** — when the nudge fires and tells the model to
+   compress, there is no reminder of the required structure at that moment.
+
+## Constraints
+
+- Token budget is not a concern (user confirmed: relative to huge contexts this
+  is negligible). Reinforcement can be added in two places without worry.
+- Must not duplicate the full tool-description text verbatim (that lives in the
+  editable prompts); the system-prompt version is a concise reinforcement.
+- Must not break the 6 editable-prompt override mechanism or existing tests.
+- No type-safety regressions; no `as any` / `@ts-ignore`.
+
+## Acceptance Criteria
+
+1. **(a) System-prompt reinforcement** — `lib/prompts/system.ts` gains a
+   `SUMMARY STRUCTURE` section that restates the 4 points concisely AND includes
+   an explicit anti-mimicry note ("do **not** mimic the style of existing
+   summaries already in context — many were written under an older format").
+2. **(b) Nudge-time reminder** — when a compress nudge fires
+   (`lib/messages/inject/inject.ts`), a one-line reminder is appended right
+   after the "💡 Compress incrementally" tip, pointing to the SUMMARY STRUCTURE
+   and repeating the anti-mimicry warning.
+3. `npm run typecheck` passes (exit 0).
+4. `npm run build` succeeds; new strings present in `dist/index.js`.
+5. Test suite green (563 pass; 1 pre-existing bun-incompat fail in
+   `prompts.test.ts` unrelated to this change).
+
+## Approach
+
+Two surgical string edits, no logic changes:
+
+- **system.ts** — insert `SUMMARY STRUCTURE` section between the `TOOLS`
+  (high position → high attention, adjacent to the tool it governs) and
+  `COMPRESSION PHILOSOPHY` sections.
+- **inject.ts** — append one `\n📝 New summaries must follow the SUMMARY
+  STRUCTURE …` line to the breakdown string built when
+  `decision.shouldNudge === true`, immediately after the incremental-compress
+  tip.
+
+No new config, no state changes, no test changes (both edits are prompt text).
+
+## Out of scope
+
+- Decompress-tool documentation (D3 — deferred until D4 tool ready).
+- Changing the compress tool description itself (already done in PR #63).
+- Re-running the ML session to measure conformance (requires user restart).

--- a/devlog/2026-07-07_compress-prompt-reinforcement/WORKLOG.md
+++ b/devlog/2026-07-07_compress-prompt-reinforcement/WORKLOG.md
@@ -1,0 +1,98 @@
+# WORKLOG — Compress summary-structure prompt reinforcement
+
+## Summary
+
+Reinforced the 4-point SUMMARY STRUCTURE in two high-leverage locations to
+counteract few-shot interference from legacy summaries already in context.
+The full structure text lives in the `compress` tool description (PR #63);
+this change surfaces a concise version at (a) the system-prompt head and
+(b) the compress-nudge action point, so the model is reminded of the required
+format both globally and at the moment it is about to compress.
+
+## ChangeLog
+
+| Commit | File | Change |
+|--------|------|--------|
+| (this PR) | `lib/prompts/system.ts` | New `SUMMARY STRUCTURE` section after `TOOLS`: 4 concise points (cover / transcribe verbatim / recoverable / why omitted) + explicit anti-mimicry note. |
+| (this PR) | `lib/messages/inject/inject.ts` | Append one-line `📝 New summaries must follow the SUMMARY STRUCTURE …` reminder to the breakdown string immediately after the "💡 Compress incrementally" tip (fires on every compress nudge). |
+
+## Key Files
+
+- `lib/prompts/system.ts` — base system prompt constant (`SYSTEM`), rendered by
+  `lib/prompts/index.ts`. Non-editable; only the 6 prompts in `store.ts` are
+  user-overridable. New section is additive, no existing line changed.
+- `lib/messages/inject/inject.ts` — `injectCompressNudges()` builds the
+  breakdown string (context usage + categories + largest ranges + tips) when
+  `decision.shouldNudge === true`. Reminder appended at the action point
+  (after the incremental tip, before `appendToLastTextPart`).
+
+## Design Notes
+
+**Why two locations, not one.** The compress-structure prompt had a single
+home (tool `description`) and was being overpowered by 37 in-context legacy
+summaries. Two reinforcements cover the two failure modes:
+
+- (a) **System prompt** — global, high-attention, read every turn. Raises the
+  baseline weight of the structure so it isn't drowned by few-shot examples.
+  Placed right after `TOOLS` (early = higher attention) and adjacent to the
+  tool it governs.
+- (b) **Nudge-time reminder** — local, at the exact moment the model is told
+  "compress now". Closest possible placement to the call-to-action; the model
+  sees the required format right when it decides how to write the summary.
+
+**Anti-mimicry note is load-bearing.** Without it, the model treats existing
+summaries as correct examples and copies their style. The note explicitly tells
+the model those were an older format — this is the key lever against few-shot
+interference.
+
+**Concise, not duplicated.** The system-prompt version restates the 4 points in
+one line each; the full detail (with examples, "transcribe verbatim" emphasis,
+recoverability mechanics) stays in the tool description. This avoids doubling
+maintenance and keeps the system prompt scannable.
+
+**Tokens are negligible.** (a) adds ~10 lines (~150 tokens); (b) adds 1 line
+(~45 tokens). Per turn these are rounding error against typical 50K+ contexts.
+
+## Testing
+
+- `npm run typecheck` — exit 0 (no type changes; pure string edits).
+- `npm run build` — success, `dist/index.js` 350.38 KB.
+- Bundle verification:
+  - `grep -c 'SUMMARY STRUCTURE' dist/index.js` = 2 (system prompt + nudge).
+  - 4 points all present; anti-mimicry line present.
+- `bun test tests/` — 563 pass / 1 fail. The 1 fail is the pre-existing
+  `prompts.test.ts:53` `checkNotInsideTest` nested-t.test incompatibility with
+  the bun test runner ("system prompt overrides handle reminder tags safely"),
+  unrelated to this change (it tests the `store.ts` override mechanism, not the
+  `SYSTEM` constant content, and fails on a bun runner quirk).
+
+## Risk
+
+**Low.** Two additive string edits; no logic, config, state, or type changes.
+No existing line modified (both are pure insertions at clearly-bounded points).
+
+- Worst case: the reminders have no measurable effect (few-shot interference is
+  stubborn). No functional regression is possible — the edits are prompt text
+  only.
+- The anti-mimicry note is opinionated ("many were written under an older
+  format") — accurate for sessions that predate PR #63, and harmless for
+  fresh sessions (no legacy summaries to mimic).
+
+## Lessons
+
+- **Tool-description prompts are weak against in-context few-shot examples.**
+  When a format change must take effect on sessions that already carry
+  old-format output, surface the new format in the system prompt AND at the
+  action point, not only in the tool description.
+- **Placement matters as much as content.** The same reminder string is far
+  more effective 1 line away from "compress now" than 40 lines earlier.
+
+## Followups
+
+- Re-measure conformance on the ML-research session after the user restarts
+  opencode to load the new bundle (block 38 was the baseline non-conforming
+  example).
+- If interference persists, consider D3 (decompress-tool documentation) and D4
+  (a decompress helper tool) — currently deferred.
+- Consider whether the anti-mimicry note should age out once pre-PR#63 sessions
+  are no longer in the wild.

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -255,6 +255,7 @@ export const injectCompressNudges = (
                 breakdown += `\nLargest text messages: ${composition.largestMessageRanges.map((r) => `${r.ref} (${fmt(r.tokens)})`).join(", ")}`
             }
             breakdown += `\n💡 Compress incrementally: target the ranges above whose content you have already extracted for this step. Size alone is not a reason to compress — if a large range is still needed in full, keep it.`
+            breakdown += `\n📝 New summaries must follow the SUMMARY STRUCTURE from the compress tool — (1) what the range covers, (2) critical content transcribed verbatim (not pointers), (3) what's recoverable, (4) why detail was omitted. Do not mimic the style of older summaries already in context.`
             appendToLastTextPart(suffixMessage, breakdown)
         }
 

--- a/lib/prompts/system.ts
+++ b/lib/prompts/system.ts
@@ -15,6 +15,16 @@ You have four context-management tools:
 - \`search_context\` — Search compressed block summaries (and optionally visible messages) by keyword. Use BEFORE decompressing to find the right block. Example: \`search_context({ query: "auth token refresh" })\`.
 - \`acp_status\` — List all active compressed blocks with their sizes, ages, and the message ranges they consumed. Use when you are unsure which IDs are still compressible, or before choosing compress boundaries. Example: \`acp_status({ mode: "summary", sort: "recent" })\`.
 
+SUMMARY STRUCTURE
+
+When you write a compress summary, follow this structure (full detail in the \`compress\` tool description):
+1. **What the range covers** — a one-line semantic label (topic, scope, time span).
+2. **Critical content, transcribed verbatim** — file paths, signatures, decisions, constraints, exact values, error text. Never replace these with pointers ("see §4.2"); the reader needs the actual content.
+3. **What is recoverable, and when** — which details were trimmed because they can be retrieved via \`acp_status\` + \`decompress\`; name the blocks if relevant.
+4. **Why detail was omitted** — a phrase justifying any non-transcription (e.g. "verbose build log, no errors").
+
+Omit a point only if it genuinely does not apply; never fabricate. Important: do **not** mimic the style of existing summaries already in context — many were written under an older format. Follow the current structure above.
+
 COMPRESSION PHILOSOPHY
 
 Two failure modes to avoid:


### PR DESCRIPTION
## Summary

PR #63 added the 4-point SUMMARY STRUCTURE to the `compress` tool *description*. Investigation of an ML-research session (block 38, `ses_0cf8549c4ff`) showed the model was **not** following it: dense data-dumps with pointer-refs (`EDITING_REPORT §4.2`) instead of transcribed content, points ③④ missing, truncation at the length limit.

**Root cause: few-shot interference.** That session carried 37 older summaries written under the previous format. In-context examples overpower tool-description instructions, so the model mimics the legacy style.

**Fix (per user direction "a b 都做吧"):** surface the structure at two high-leverage points —
- **(a) `lib/prompts/system.ts`** — new `SUMMARY STRUCTURE` section after `TOOLS` (high attention + adjacent to the tool it governs). Restates the 4 points concisely + explicit **anti-mimicry** note ("do **not** mimic the style of existing summaries already in context — many were written under an older format").
- **(b) `lib/messages/inject/inject.ts`** — append a one-line `📝 New summaries must follow the SUMMARY STRUCTURE …` reminder to the breakdown string right after the compress-nudge tip (closest placement to the call-to-action), fires on every nudge.

Tokens negligible (~150 + ~45/turn). Pure string edits — no logic, type, config, or state changes.

## Verification

- `npm run typecheck` → exit 0
- `npm run build` → OK, `dist/index.js` 350.38 KB
- Bundle: `SUMMARY STRUCTURE` appears 2× (system prompt + nudge); all 4 points present; anti-mimicry line present
- `bun test tests/` → 563 pass / 1 fail (pre-existing `prompts.test.ts:53` bun nested-t.test incompatibility, unrelated — tests the `store.ts` override mechanism, not the `SYSTEM` constant)

## Why two locations

Tool-description prompts are weak against in-context few-shot examples. Two reinforcements cover the two failure modes:
- (a) system prompt = global, high-attention, read every turn → raises baseline weight above the few-shot noise
- (b) nudge reminder = local, at the exact moment the model is told "compress now" → closest possible placement to the decision point

The anti-mimicry note is the key lever: without it the model treats existing summaries as correct examples.

## Related

- Builds on #63 (4-point SUMMARY STRUCTURE in tool description)
- Investigates the non-conformance reported in #9
- devlog: `devlog/2026-07-07_compress-prompt-reinforcement/` (REQ + WORKLOG)