### PR TITLE
fix: route range-utils placeholder diagnostic to logger (#67)

### DIFF
--- a/devlog/2026-07-07_console-warn-leak-67/REQ.md
+++ b/devlog/2026-07-07_console-warn-leak-67/REQ.md
@@ -1,0 +1,52 @@
+# REQ - Route range-utils placeholder diagnostic to logger
+
+- Task ID: `2026-07-07_console-warn-leak-67`
+- Home Repo: `opencode-acp`
+- Created: 2026-07-07
+- Status: Done
+- Priority: P1
+- Owner: awork
+- References: GitHub issue #67
+
+## 1. Background & Problem Statement
+
+- **Context**: `validateSummaryPlaceholders()` in `lib/compress/range-utils.ts` emits a Plan B diagnostic when the model omits `(bN)` block placeholders in its compress summary.
+- **Current behavior (symptom)**: The diagnostic used `console.warn(...)`, which writes to stderr. opencode's TUI captures plugin stdout/stderr and renders it into the chat dialog the model reads. This leaked `[ACP] compress summary omitted placeholders...` into the conversation mid-turn whenever the model omitted placeholders — the same dialog-pollution class as the historical sentinel-throw / `output.parts` leaks.
+- **Expected behavior**: The diagnostic is routed to the plugin's `Logger` (debug sink writing to `~/.config/opencode/logs/acp/`) so it never reaches the chat dialog, while remaining available for debugging.
+- **Impact**: Every compress call where the model omits `(bN)` placeholders polluted the model's context. Noise grows with compression frequency.
+
+## 2. Reproduction (if applicable)
+
+- **Environment**: opencode with opencode-acp plugin active; default config (range mode).
+- **Minimal reproduction steps**:
+  1. Trigger a `compress` call whose summary omits a `(bN)` placeholder for a consumed block.
+  2. Observe `[ACP] compress summary omitted placeholders for required blocks: bN...` rendered in the chat dialog.
+- **Relevant configuration**: N/A (default config reproduces).
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+  - Backward compatibility: `validateSummaryPlaceholders` is an internal function (not exported from the package public API); signature change is safe.
+  - The `Logger` is debug-gated (`enabled = config.debug`, default `false`) and writes only to disk — it never touches stdout/stderr.
+- **Non-Goals** (explicitly out of scope):
+  - Converting `console.*` in `lib/config.ts` and `lib/prompts/store.ts`. These are user-facing one-time migration notices that run before `Logger` exists (config init) and/or must stay visible regardless of the debug flag. See audit rationale in the PR description.
+
+## 4. Acceptance Criteria (must be testable)
+
+- **Correctness**:
+  - [x] `validateSummaryPlaceholders` calls `logger.warn(...)` instead of `console.warn(...)`.
+  - [x] The caller in `lib/compress/range.ts` passes `ctx.logger`.
+  - [x] No `[ACP]` prefix in the message (Logger manages component tagging via `getCallerFile`).
+- **Performance / Stability**:
+  - [x] No new disk I/O when `debug === false` (Logger early-returns).
+- **Regression**:
+  - [x] New/modified test cases added to test suite and passing (3 call sites in `tests/compress-range-placeholders.test.ts` updated).
+
+## 5. Proposed Approach (optional)
+
+- **Affected modules & entry files**:
+  - `lib/compress/range-utils.ts` — add `logger: Logger` param, route to `logger.warn`.
+  - `lib/compress/range.ts` — pass `ctx.logger` at the call site.
+  - `tests/compress-range-placeholders.test.ts` — construct `new Logger(false)` and thread through 3 call sites.
+- **Risks**: Low. Purely an internal diagnostic-routing change.
+- **Rollback strategy**: Revert the commit.

--- a/devlog/2026-07-07_console-warn-leak-67/WORKLOG.md
+++ b/devlog/2026-07-07_console-warn-leak-67/WORKLOG.md
@@ -1,0 +1,79 @@
+# WORKLOG - Route range-utils placeholder diagnostic to logger
+
+- Task ID: `2026-07-07_console-warn-leak-67`
+- Home Repo: `opencode-acp`
+- Status: Done
+- Updated: 2026-07-07 21:40
+
+## 1. Summary
+
+- **What was done**: Replaced the `console.warn(...)` call in `validateSummaryPlaceholders` (Plan B placeholder-omission path) with `logger.warn(...)`, and threaded a `logger: Logger` parameter through the function signature and its single caller in `range.ts`. Updated the 3 call sites in the test file.
+- **Why**: opencode's TUI captures plugin stderr and renders it into the chat dialog the model reads; the `console.warn` diagnostic leaked mid-turn on every compress that omitted `(bN)` placeholders. The `Logger` writes only to disk and is debug-gated, so the diagnostic never reaches the dialog.
+- **Behavior / compatibility changes**: No. Internal function signature change only; no persisted-state, config, or public-API surface touched.
+- **Risk level**: Low
+
+## 2. Change Log
+
+### Commits
+
+| Commit | Description |
+|--------|-------------|
+| `<sha>` | fix: route range-utils placeholder diagnostic to logger (#67) |
+
+### Key Files
+
+- `lib/compress/range-utils.ts` — imported `Logger`; added `logger: Logger` 7th param to `validateSummaryPlaceholders`; `console.warn` → `logger.warn`; dropped `[ACP]` prefix.
+- `lib/compress/range.ts` — call site at line ~137 now passes `ctx.logger`.
+- `tests/compress-range-placeholders.test.ts` — added module-level `const logger = new Logger(false)`; passed `logger` to all 3 `validateSummaryPlaceholders` call sites.
+
+## 3. Design & Implementation Notes
+
+- **Entry point / key function**: `validateSummaryPlaceholders(...)` in `lib/compress/range-utils.ts`.
+- **Key configuration items**: None — `Logger` is constructed with `enabled = config.debug` (default `false`).
+- **Key logic explanation**: The `Logger` class early-returns from every method when `enabled === false`, so routing the diagnostic there silences it in production while preserving it in debug logs. This is semantically correct: the diagnostic is internal developer noise, not user-facing information.
+
+### Audit of remaining `console.*` sites (kept as-is, documented)
+
+| Site | Decision | Reason |
+|------|----------|--------|
+| `config.ts` (4 sites, dcp→acp migration notices) | Kept `console.log` | Runs at plugin init before `Logger` exists (`getConfig` at `index.ts:29` → `new Logger` at `index.ts:35`). Logger is debug-gated; routing user-facing one-time migration notices through it would silence them in production. |
+| `prompts/store.ts:186/188` (prompt migration) | Kept `console.log`/`console.warn` | Same debug-gating concern; `resolvePromptPaths` is a free function; one-time user-facing migration events should stay visible regardless of the debug flag. |
+
+## 4. Testing & Verification
+
+### Build & Test Commands
+
+```sh
+# Type check
+npm run typecheck
+
+# Full test suite
+bun test
+
+# Build
+npm run build
+```
+
+### Test Coverage
+
+- New/modified test files: `tests/compress-range-placeholders.test.ts`
+- Test count: 563 total pass, 1 fail (pre-existing `prompts.test.ts` bun incompatibility — `test() inside test()`, unrelated to this change)
+- Key scenarios verified: `validateSummaryPlaceholders` correctly accepts the new logger param; all 6 placeholder tests pass.
+
+### Results
+
+- **PASS** (typecheck clean, build success, bundle verified: `omitted placeholders for required blocks` now via `logger.warn`; only remaining `console.warn` in bundle is the intentional `prompts/store.ts` migration notice).
+
+## 5. Risk Assessment & Rollback
+
+- **Risk points**: None beyond the function signature change, which is internal-only.
+- **Rollback method**: Revert the commit.
+- **Compatibility notes**: No persisted-state, config, or public-API changes.
+
+## 6. Lessons Learned (optional)
+
+- `Logger` is a debug-only sink (early-returns when `enabled === false`). This makes it correct for internal diagnostics but **wrong** for user-facing one-time notices (migration success/failure), which must remain visible regardless of the debug flag. The two cases warrant different handling — a blanket "convert all console.* to logger" would hide legitimate user notices.
+
+## 7. Follow-ups (optional)
+
+- [ ] Consider adding a non-debug, always-visible notice channel for future user-facing plugin events if `console.*` proves problematic at startup.

--- a/lib/compress/range-utils.ts
+++ b/lib/compress/range-utils.ts
@@ -1,3 +1,4 @@
+import type { Logger } from "../logger"
 import type { CompressionBlock, SessionState } from "../state"
 import { resolveAnchorMessageId, resolveBoundaryIds, resolveSelection } from "./search"
 import type {
@@ -130,6 +131,7 @@ export function validateSummaryPlaceholders(
     startReference: BoundaryReference,
     endReference: BoundaryReference,
     summaryByBlockId: Map<number, CompressionBlock>,
+    logger: Logger,
 ): number[] {
     const boundaryOptionalIds = new Set<number>()
     if (startReference.kind === "compressed-block") {
@@ -169,8 +171,8 @@ export function validateSummaryPlaceholders(
     // auto-detects every consumed block in range, so the model no longer
     // needs to manually list (bN) placeholders in its summary.
     if (missingIds.length > 0) {
-        console.warn(
-            `[ACP] compress summary omitted placeholders for required blocks: ${missingIds
+        logger.warn(
+            `compress summary omitted placeholders for required blocks: ${missingIds
                 .map((id) => `b${id}`)
                 .join(", ")}. They will be auto-attached as consumed blocks.`,
         )

--- a/lib/compress/range.ts
+++ b/lib/compress/range.ts
@@ -134,6 +134,7 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
                     plan.selection.startReference,
                     plan.selection.endReference,
                     searchContext.summaryByBlockId,
+                    ctx.logger,
                 )
 
                 const injected = injectBlockPlaceholders(

--- a/tests/compress-range-placeholders.test.ts
+++ b/tests/compress-range-placeholders.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 import type { CompressionBlock } from "../lib/state"
+import { Logger } from "../lib/logger"
 import {
     appendMissingBlockSummaries,
     injectBlockPlaceholders,
@@ -9,6 +10,8 @@ import {
 } from "../lib/compress/range-utils"
 import { wrapCompressedSummary } from "../lib/compress/state"
 import type { BoundaryReference } from "../lib/compress/types"
+
+const logger = new Logger(false)
 
 function createBlock(blockId: number, body: string): CompressionBlock {
     return {
@@ -67,6 +70,7 @@ test("validateSummaryPlaceholders filters to valid required blocks and returns m
         createMessageBoundary("msg-a", 0),
         createMessageBoundary("msg-b", 1),
         summaryByBlockId,
+        logger,
     )
 
     assert.deepEqual(
@@ -87,6 +91,7 @@ test("validateSummaryPlaceholders returns required blocks not referenced in summ
         createMessageBoundary("msg-a", 0),
         createMessageBoundary("msg-b", 1),
         summaryByBlockId,
+        logger,
     )
 
     assert.deepEqual(missingBlockIds, [1])
@@ -105,6 +110,7 @@ test("injectBlockPlaceholders returns summary unchanged (independent blocks)", (
         createMessageBoundary("msg-a", 0),
         createMessageBoundary("msg-b", 1),
         summaryByBlockId,
+        logger,
     )
 
     const injected = injectBlockPlaceholders(


### PR DESCRIPTION
## Summary

The Plan B placeholder-omission diagnostic in `validateSummaryPlaceholders` (`lib/compress/range-utils.ts:172`) used `console.warn(...)`, which writes to stderr. opencode's TUI captures plugin stdout/stderr and renders it into the chat dialog the model reads, so this leaked mid-turn on every `compress` call where the model omitted `(bN)` placeholders — the same dialog-pollution class as the historical sentinel-throw / `output.parts` leaks.

This routes the diagnostic through `logger.warn` instead. The `Logger` writes only to disk (`~/.config/opencode/logs/acp/`) and is debug-gated (`enabled = config.debug`), so the diagnostic never reaches the chat dialog while remaining available for debugging.

## Changes

- `lib/compress/range-utils.ts` — imported `Logger`; added `logger: Logger` 7th param to `validateSummaryPlaceholders`; `console.warn` → `logger.warn`; dropped the `[ACP]` prefix (Logger manages component tagging).
- `lib/compress/range.ts` — call site now passes `ctx.logger` (already available on `ToolContext`).
- `tests/compress-range-placeholders.test.ts` — added module-level `const logger = new Logger(false)`; threaded `logger` through all 3 call sites.

## Console.* audit (repo-wide)

Per-site decision rather than blanket conversion:

| Site | Decision | Reason |
|------|----------|--------|
| `range-utils.ts:172` | **Converted → `logger.warn`** | Diagnostic, fires mid-turn, pollutes dialog. This is the actual bug. |
| `config.ts` (4 sites, dcp→acp migration notices) | **Kept `console.log`** | Runs at plugin init **before** `Logger` exists (`getConfig` at `index.ts:29` → `new Logger` at `index.ts:35`). Logger is debug-gated (`enabled = config.debug`, default `false`); routing user-facing one-time migration notices through it would **silence them in production**. |
| `prompts/store.ts:186/188` (prompt migration) | **Kept `console.log`/`console.warn`** | Same debug-gating concern — Logger writes nothing when `debug=false`. `resolvePromptPaths` is a free function; these are one-time user-facing migration events that should stay visible regardless of the debug flag. |

The key insight: `Logger` is a **debug-only** sink (all methods early-return when `enabled === false`). Using it for user-facing migration notices would hide them from the ~99% of users who don't run with `debug: true`. The `range-utils` warn is internal diagnostic noise that *should* be debug-only — different semantics, different correct answer.

## Verification

- `npm run typecheck` — clean (0 errors)
- `bun test` — 563 pass, 1 fail (pre-existing `prompts.test.ts` bun incompatibility: `test() inside test()` — unrelated to this change)
- `npm run build` — success; bundle verified to contain `logger.warn(...omitted placeholders...)`
- Deployed bundle checked: only remaining `console.warn` is the intentional `prompts/store.ts` migration notice

## Backward compatibility

No breaking changes. `validateSummaryPlaceholders` is an internal function (not part of the package public API). No persisted-state, config, or exported-API surface touched.

Fixes #67