### PR TITLE
fix: add spacing around arrow in context transition notification (#68)

### DIFF
--- a/devlog/2026-07-07_arrow-spacing-68/REQ.md
+++ b/devlog/2026-07-07_arrow-spacing-68/REQ.md
@@ -1,0 +1,42 @@
+# REQ - Add spacing around arrow in context transition notification
+
+- Task ID: `2026-07-07_arrow-spacing-68`
+- Home Repo: `opencode-acp`
+- Created: 2026-07-07
+- Status: Done
+- Priority: P2
+- Owner: awork
+- References: GitHub issue #68
+
+## 1. Background & Problem Statement
+
+- **Context**: `formatContextTransition()` in `lib/ui/notification.ts` renders the token delta shown in compression notifications (e.g. the toast/chat message after a compress completes).
+- **Current behavior (symptom)**: The output was `Context 141.9K→111K` — the `→` (U+2192) had no surrounding whitespace, fusing visually with adjacent digits.
+- **Expected behavior**: `Context 141.9K → 111K` — spaces around the arrow, matching the `→ ` (arrow followed by space) convention used everywhere else in the notification module.
+- **Impact**: Cosmetic readability friction on every compression notification (high-frequency event).
+
+## 2. Reproduction (if applicable)
+
+- **Environment**: Any compression that triggers a notification.
+- **Minimal reproduction steps**:
+  1. Run a compression that fires a notification.
+  2. Read the rendered `Context X→Y` string — no spaces around `→`.
+- **Relevant configuration**: Any config that shows notifications (default).
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**: Match existing module convention (`→ ` with trailing space, used at lines 211, 212, 223; `lib/ui/utils.ts:272`).
+- **Non-Goals**: No other notification-formatting changes.
+
+## 4. Acceptance Criteria (must be testable)
+
+- **Correctness**:
+  - [x] `formatContextTransition` returns `Context ${beforeStr} → ${afterStr}` (spaces around `→`).
+- **Performance / Stability**: N/A (one-character cosmetic change).
+- **Regression**: N/A (no logic change).
+
+## 5. Proposed Approach (optional)
+
+- **Affected modules & entry files**: `lib/ui/notification.ts` (single line).
+- **Risks**: None.
+- **Rollback strategy**: Revert the commit.

--- a/devlog/2026-07-07_arrow-spacing-68/WORKLOG.md
+++ b/devlog/2026-07-07_arrow-spacing-68/WORKLOG.md
@@ -1,0 +1,62 @@
+# WORKLOG - Add spacing around arrow in context transition notification
+
+- Task ID: `2026-07-07_arrow-spacing-68`
+- Home Repo: `opencode-acp`
+- Status: Done
+- Updated: 2026-07-07 21:42
+
+## 1. Summary
+
+- **What was done**: Added spaces around the `→` (U+2192) in `formatContextTransition`'s return template.
+- **Why**: The arrow had no surrounding whitespace, fusing with adjacent digits (`141.9K→111K`). Every other `→` in the notification module follows the `→ ` convention.
+- **Behavior / compatibility changes**: No.
+- **Risk level**: Low
+
+## 2. Change Log
+
+### Commits
+
+| Commit | Description |
+|--------|-------------|
+| `<sha>` | fix: add spacing around arrow in context transition notification (#68) |
+
+### Key Files
+
+- `lib/ui/notification.ts` — line 118: `` `Context ${beforeStr}→${afterStr}` `` → `` `Context ${beforeStr} → ${afterStr}` ``.
+
+## 3. Design & Implementation Notes
+
+- **Entry point / key function**: `formatContextTransition(tokensBefore, tokensAfter)` at `lib/ui/notification.ts:116`.
+- **Key logic explanation**: Pure string-template change. No branching or logic affected.
+
+## 4. Testing & Verification
+
+### Build & Test Commands
+
+```sh
+npm run typecheck
+npm run build
+```
+
+### Test Coverage
+
+- No dedicated unit test for this string-formatting helper (it's private and trivial); change verified via bundle inspection.
+- Bundle verified: `Context ${beforeStr} \u2192 ${afterStr}` (spaces around the escaped arrow) present in `dist/index.js`.
+
+### Results
+
+- **PASS** (typecheck clean, build success).
+
+## 5. Risk Assessment & Rollback
+
+- **Risk points**: None.
+- **Rollback method**: Revert the commit.
+- **Compatibility notes**: No.
+
+## 6. Lessons Learned (optional)
+
+- N/A — trivial cosmetic fix.
+
+## 7. Follow-ups (optional)
+
+- [ ] None.

--- a/lib/ui/notification.ts
+++ b/lib/ui/notification.ts
@@ -115,7 +115,7 @@ function formatCompressionMetrics(removedTokens: number, summaryTokens: number):
 function formatContextTransition(tokensBefore: number, tokensAfter: number): string {
     const beforeStr = formatTokenCount(tokensBefore, true)
     const afterStr = formatTokenCount(tokensAfter, true)
-    return `Context ${beforeStr}→${afterStr}`
+    return `Context ${beforeStr} → ${afterStr}`
 }
 
 export async function sendCompressNotification(


### PR DESCRIPTION
## Summary

`formatContextTransition` in `lib/ui/notification.ts:118` rendered `Context 141.9K→111K` — the `→` (U+2192) had no surrounding spaces, fusing visually with adjacent digits. This fires on every compression notification (high frequency), causing readability friction.

Every other `→` in the notification module follows the `→ ` (arrow + space) convention (lines 211, 212, 223; `lib/ui/utils.ts:272`).

## Change

`lib/ui/notification.ts:118`:

```diff
-    return `Context ${beforeStr}→${afterStr}`
+    return `Context ${beforeStr} → ${afterStr}`
```

One-character cosmetic fix to match module convention.

## Verification

- `npm run typecheck` — clean
- `npm run build` — success; bundle verified: `Context ${beforeStr} \u2192 ${afterStr}` (spaces around the escaped arrow)

Fixes #68