### PR TITLE
chore: bump version to 1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.9.2",
+    "version": "1.10.0",
     "type": "module",
-    "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 34 bug fixes)",
+    "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {


### PR DESCRIPTION
Bump version to 1.10.0 for release. Includes skill hard-protection fix (issue #16, PR #75).