### PR TITLE
fix: compress protectedTools defaults should only protect skill

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -113,7 +113,7 @@ const DEFAULT_PROTECTED_TOOLS = [
     "edit",
 ]
 
-const COMPRESS_DEFAULT_PROTECTED_TOOLS = ["task", "skill", "todowrite", "todoread", "decompress"]
+const COMPRESS_DEFAULT_PROTECTED_TOOLS = ["skill"]
 
 export { VALID_CONFIG_KEYS, getInvalidConfigKeys, validateConfigTypes, type ValidationError } from "./config-validation"
 


### PR DESCRIPTION
## Summary
- `COMPRESS_DEFAULT_PROTECTED_TOOLS` now only contains `["skill"]`
- Removed `todowrite`, `todoread`, `task`, `decompress`

## Problem
PR #75 (Bug 39 fix) introduced hard exclusion of protected tools from compression ranges. It added multiple tools to the default compress protectedTools, treating them all as needing **permanent** protection.

This was wrong for most tools:

| Tool | Why it should NOT be protected |
|------|-------------------------------|
| `todowrite`/`todoread` | Old todo states are historical — only latest matters. Observed 73–84 calls (~17.7K tok) accumulating in real sessions |
| `task` | Subagent results can be consumed and compressed once the subagent is done |
| `decompress` | **One-way ratchet**: if decompress output is protected, you can never re-compress it. Every decompress permanently bloats context → "完蛋" |

Only `skill` needs permanent protection — live skill instructions degrade to useless historical recap if compressed.

## Fix
```diff
-const COMPRESS_DEFAULT_PROTECTED_TOOLS = ["task", "skill", "todowrite", "todoread", "decompress"]
+const COMPRESS_DEFAULT_PROTECTED_TOOLS = ["skill"]
```

Users who need other tools protected can add them via `compress.protectedTools` in their config.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] 594 tests pass (1 pre-existing Bun incompatibility in `prompts.test.ts`)
- [x] No existing tests rely on the default value (all tests set their own `protectedTools`)