### PR TITLE
release v1.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.10.1",
+    "version": "1.10.2",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
Bump version to 1.10.2 for npm publish.

Includes #87 (compress protectedTools defaults: only protect `skill`).

User-authorized release: "已经合并 发布下新版本吧"