### PR TITLE
fix: rebuild compression state on fork to prevent context overflow

### DIFF
--- a/devlog/2026-07-09_fork-rebuild/DESIGN.md
+++ b/devlog/2026-07-09_fork-rebuild/DESIGN.md
@@ -1,0 +1,69 @@
+# DESIGN: Fork Session Compression State Rebuild
+
+## Architecture
+
+New module: `lib/state/rebuild.ts` — pure function `rebuildCompressionState(state, messages, config, logger)`.
+
+### Data flow
+
+```
+ensureSessionInitialized (state.ts)
+  └─ persisted === null (fork detected)
+      └─ rebuildCompressionState(state, messages, config, logger)
+          ├─ assignMessageRefs(state, messages)     ← build mNNNNN → rawId map
+          ├─ collectCompressInvocations(messages)    ← scan for completed compress parts
+          └─ for each invocation (chronological):
+              ├─ buildSearchContext(state, messages) ← rebuild each iteration
+              │                                       (so earlier blocks visible for bN refs)
+              ├─ [range mode] rebuildRangeInvocation
+              │   ├─ resolveRanges (all entries at once)
+              │   ├─ filterProtectedToolMessages (Bug 39)
+              │   ├─ extractBoundaryConsumedBlocks + dedupe
+              │   └─ per-entry: allocateBlockId → wrapCompressedSummary → applyCompressionState
+              └─ [message mode] rebuildMessageInvocation
+                  └─ per-entry: resolve → allocateBlockId → wrapCompressedSummary → applyCompressionState
+```
+
+### Key design decisions
+
+**1. Refs are fork-stable.** `assignMessageRefs` assigns `m00001...` by message order.
+Fork has identical order → identical refs. This is the foundational insight that makes
+rebuild possible without any ID-mapping heuristics.
+
+**2. Reuse existing resolution functions.** `resolveRanges`, `resolveBoundaryIds`,
+`resolveSelection`, `applyCompressionState` are called directly — ensuring the rebuilt
+state is structurally identical to what the original compress produced.
+
+**3. Chronological processing with per-invocation searchContext rebuild.** Each
+compress invocation is replayed in message order. `buildSearchContext` is rebuilt before
+each invocation so that blocks created by earlier invocations are visible for `bN`
+boundary resolution (nested compression).
+
+**4. Mirror the original pipeline ordering.** Within a single range invocation, all
+entries are resolved BEFORE any block is created (mirrors `range.ts`). This ensures
+entries within the same call can't reference each other's blocks.
+
+**5. Config is optional.** `ensureSessionInitialized` gains `config?: PluginConfig`.
+Rebuild only runs when config is provided (production paths). Existing tests that call
+`ensureSessionInitialized` without config are unaffected (old behavior — no rebuild).
+
+**6. Graceful degradation.** Each invocation and each entry is wrapped in try/catch.
+Malformed parts, resolution failures, or unexpected states skip gracefully — partial
+rebuild is better than none.
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `lib/state/rebuild.ts` | **NEW** — rebuild logic (350 lines) |
+| `lib/state/state.ts` | `ensureSessionInitialized` + `checkSession` gain optional `config` param; rebuild call in `persisted === null` branch |
+| `lib/hooks.ts` | Pass `config` to `checkSession` and `ensureSessionInitialized` |
+| `lib/compress/pipeline.ts` | Pass `ctx.config` to `ensureSessionInitialized` |
+| `lib/compress/decompress.ts` | Pass `ctx.config` to `ensureSessionInitialized` |
+| `tests/rebuild.test.ts` | **NEW** — 9 unit tests |
+
+### Backward compatibility
+
+- `config` param is optional → no breaking change to `ensureSessionInitialized` API
+- No changes to persisted state format, internal tags, or exported APIs
+- No changes to the compress tool itself — rebuild only reads history

--- a/devlog/2026-07-09_fork-rebuild/REQ.md
+++ b/devlog/2026-07-09_fork-rebuild/REQ.md
@@ -1,0 +1,50 @@
+# REQ: Fork Session Compression State Rebuild
+
+## Problem
+
+When a user forks an ACP-compressed session in OpenCode, the fork session triggers
+`context_length_exceeded` because ACP has no compression state for the new session.
+
+OpenCode copies all messages (including completed `compress` tool parts) into the fork,
+but regenerates message IDs. ACP's persisted state is keyed off:
+1. Session ID (`plugin/acp/{sessionId}.json` — doesn't exist for fork)
+2. Raw message IDs (all internal maps use `msg.info.id` — differ in fork)
+
+Result: fork session loads with empty prune state → `filterCompressedRanges` early-returns
+→ all 330 messages sent verbatim to the model → context overflow.
+
+Reported: GitHub #89, Gitea #19.
+
+## Solution
+
+**Plan B1: Rebuild from history.** When `ensureSessionInitialized` detects no persisted
+state (`persisted === null`), scan message history for completed `compress` tool parts
+and replay them to reconstruct `CompressionBlock`s / `byMessageId` /
+`activeByAnchorMessageId` using the fork's NEW raw IDs.
+
+### Why this works
+
+Message refs (`m00001`, `m00002`, ...) are assigned sequentially by message order
+(`assignMessageRefs`). Fork copies messages in identical order → re-running
+`assignMessageRefs` in the fork produces identical refs. Therefore the `startId`/`endId`
+refs stored in compress tool inputs point to the same logical messages in both original
+and fork.
+
+### Limitations (acceptable)
+
+- Rebuilt summaries use the raw model summary from the tool input, not the enriched
+  version (protected-content append happened at original-compress-time and isn't
+  re-derived). Protected tool outputs survive in visible context anyway, so no
+  information is lost.
+- Token accounting stats are approximate (cosmetic, doesn't affect pruning).
+
+## Acceptance Criteria
+
+- [x] Fork session with compress history → rebuilds pruning state → no overflow
+- [x] Range-mode and message-mode compressions both rebuilt
+- [x] Nested blocks (b1 consumed by b2) correctly deactivated
+- [x] Protected tool messages hard-excluded (Bug 39 parity)
+- [x] Malformed/incomplete compress parts gracefully skipped
+- [x] All existing tests pass (603/604, 1 pre-existing Bun limitation)
+- [x] 9 new unit tests pass
+- [x] Build + typecheck clean

--- a/devlog/2026-07-09_fork-rebuild/WORKLOG.md
+++ b/devlog/2026-07-09_fork-rebuild/WORKLOG.md
@@ -1,0 +1,41 @@
+# WORKLOG: Fork Session Compression State Rebuild
+
+## 2026-07-09
+
+### Diagnosis
+- Confirmed bug: fork session `ses_0b9ccf1c8ffeX6k30Cjznzd5Bq` overflows because ACP state
+  file `{sessionId}.json` doesn't exist for fork, and all internal maps key off raw
+  message IDs that OpenCode regenerates on fork.
+- Root cause: `ensureSessionInitialized` (`state.ts:169-172`) early-returns when
+  `persisted === null`, leaving prune state empty → `filterCompressedRanges`
+  (`prune.ts:214-219`) early-returns → no pruning → all messages sent verbatim.
+
+### Implementation
+- Created `lib/state/rebuild.ts`: replays completed `compress` tool parts from message
+  history to reconstruct `CompressionBlock` / `byMessageId` / `activeByAnchorMessageId`.
+- Key insight: message refs (`mNNNNN`) are position-based (`assignMessageRefs` assigns
+  sequentially by order), so they're fork-stable — compress input `startId`/`endId`
+  resolve to the same logical messages in fork.
+- Wired into `ensureSessionInitialized` via optional `config` param. All production
+  callers (hooks.ts, pipeline.ts, decompress.ts) pass config; tests unaffected.
+- Reuses existing pipeline functions (`resolveRanges`, `resolveSelection`,
+  `applyCompressionState`, `filterProtectedToolMessages`) for structural correctness.
+
+### Testing
+- 9 unit tests in `tests/rebuild.test.ts`:
+  - No compress parts → no-op
+  - Single range compression → block + byMessageId populated
+  - Fork scenario (different raw IDs, same refs) → correct mapping
+  - Nested compression (b1 consumed by b2) → b1 deactivated, b2 active
+  - Message-mode compression → blocks with shared runId
+  - Protected tool exclusion (Bug 39 parity)
+  - Malformed input → graceful skip
+  - Non-completed compress part → skipped
+  - Idempotent ref assignment
+- Full suite: 603 pass, 1 pre-existing fail (Bun nested `t.test()` limitation in
+  `prompts.test.ts`, unrelated to this change).
+
+### Verification
+- `npm run build` — clean (includes `tsc --emitDeclarationOnly`)
+- `bun test tests/` — 603/604 pass
+- TypeScript typecheck — clean

--- a/lib/compress/decompress.ts
+++ b/lib/compress/decompress.ts
@@ -51,6 +51,7 @@ async function prepareDecompressSession(
         ctx.logger,
         rawMessages,
         ctx.config.manualMode.enabled,
+        ctx.config,
     )
 
     assignMessageRefs(ctx.state, rawMessages)

--- a/lib/compress/pipeline.ts
+++ b/lib/compress/pipeline.ts
@@ -63,6 +63,7 @@ export async function prepareSession(
         ctx.logger,
         rawMessages,
         ctx.config.manualMode.enabled,
+        ctx.config,
     )
 
     assignMessageRefs(ctx.state, rawMessages)

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -233,7 +233,7 @@ export function createChatMessageTransformHandler(
             return
         }
 
-        await checkSession(client, state, logger, output.messages, config.manualMode.enabled)
+        await checkSession(client, state, logger, output.messages, config.manualMode.enabled, config)
 
         syncCompressPermissionState(state, config, hostPermissions, output.messages)
 
@@ -316,6 +316,7 @@ export function createCommandExecuteHandler(
                 logger,
                 messages,
                 config.manualMode.enabled,
+                config,
             )
 
             syncCompressPermissionState(state, config, hostPermissions, messages)

--- a/lib/state/rebuild.ts
+++ b/lib/state/rebuild.ts
@@ -1,0 +1,352 @@
+/**
+ * Fork-recovery: reconstruct ACP compression state from message history.
+ *
+ * When a session is forked, OpenCode copies all messages (including completed
+ * `compress` tool parts) but regenerates message IDs. ACP's persisted state is
+ * keyed off the original session ID and original raw message IDs, so the fork
+ * session starts with empty prune state → no pruning → context overflow.
+ *
+ * This module replays historical `compress` tool invocations in chronological
+ * order, rebuilding `CompressionBlock`s / `byMessageId` / `activeByAnchorMessageId`
+ * using the fork's NEW raw IDs. Because message refs (mNNNNN) are assigned
+ * sequentially by message order, they are fork-stable: a ref in a compress
+ * input points to the same logical message in both original and fork.
+ *
+ * The rebuilt state is an approximation: protected-content enrichments that
+ * were appended to summaries at original-compress-time are not re-derived
+ * (only the raw model summary from the tool input is available). This is
+ * acceptable — protected tool outputs survive in visible context anyway, and
+ * the primary goal (pruning compressed messages to avoid overflow) is met.
+ */
+import type { GCConfig, PluginConfig } from "../config"
+import type { Logger } from "../logger"
+import { assignMessageRefs } from "../message-ids"
+import { buildSearchContext, resolveAnchorMessageId, resolveBoundaryIds, resolveSelection } from "../compress/search"
+import { filterProtectedToolMessages } from "../compress/protected-content"
+import { resolveRanges } from "../compress/range-utils"
+import {
+    allocateBlockId,
+    allocateRunId,
+    applyCompressionState,
+    wrapCompressedSummary,
+} from "../compress/state"
+import { countTokens } from "../token-utils"
+import type {
+    BoundaryReference,
+    CompressRangeToolArgs,
+    CompressRangeEntry,
+    CompressMessageToolArgs,
+    CompressMessageEntry,
+    SearchContext,
+    SelectionResolution,
+} from "../compress/types"
+import type { SessionState, WithParts } from "./types"
+
+interface CompressInvocation {
+    messageId: string
+    callId: string | undefined
+    input: unknown
+}
+
+function collectCompressInvocations(messages: WithParts[]): CompressInvocation[] {
+    const invocations: CompressInvocation[] = []
+    for (const message of messages) {
+        const parts = Array.isArray(message.parts) ? message.parts : []
+        for (const part of parts) {
+            if (part.type !== "tool" || part.tool !== "compress") {
+                continue
+            }
+            if (part.state?.status !== "completed") {
+                continue
+            }
+
+            const input = part.state?.input
+            if (!input || typeof input !== "object") {
+                continue
+            }
+
+            invocations.push({
+                messageId: message.info.id,
+                callId: typeof part.callID === "string" ? part.callID : undefined,
+                input,
+            })
+        }
+    }
+    return invocations
+}
+
+/** Range-mode entries have `startId`/`endId`; message-mode entries have `messageId`. */
+function isRangeInput(input: any): boolean {
+    const content = Array.isArray(input?.content) ? input.content : []
+    const first = content[0]
+    return !!first && typeof first.startId === "string"
+}
+
+function extractBoundaryConsumedBlocks(
+    startReference: BoundaryReference,
+    endReference: BoundaryReference,
+): number[] {
+    const consumed: number[] = []
+    const seen = new Set<number>()
+    for (const ref of [startReference, endReference]) {
+        if (ref.kind === "compressed-block" && ref.blockId !== undefined && !seen.has(ref.blockId)) {
+            seen.add(ref.blockId)
+            consumed.push(ref.blockId)
+        }
+    }
+    return consumed
+}
+
+function dedupeBlockIds(ids: number[]): number[] {
+    const seen = new Set<number>()
+    const result: number[] = []
+    for (const id of ids) {
+        if (!Number.isInteger(id) || id <= 0) continue
+        if (seen.has(id)) continue
+        seen.add(id)
+        result.push(id)
+    }
+    return result
+}
+
+/**
+ * Replay a single range-mode compress invocation.
+ * Mirrors `createCompressRangeTool.execute` (lib/compress/range.ts):
+ *   resolveRanges → filterProtectedToolMessages → per-entry block allocation.
+ *
+ * Returns the number of blocks created.
+ */
+function rebuildRangeInvocation(
+    state: SessionState,
+    input: CompressRangeToolArgs,
+    searchContext: SearchContext,
+    invocation: CompressInvocation,
+    protectedTools: string[],
+    protectedFilePatterns: string[],
+    gcConfig: GCConfig | undefined,
+    logger: Logger,
+): number {
+    // Resolve ALL entries against the pre-invocation state (mirrors range.ts:
+    // resolveRanges runs before any block from this call is created).
+    const plans = resolveRanges(input, searchContext, state)
+
+    const runId = allocateRunId(state)
+    let created = 0
+
+    for (const plan of plans) {
+        // [Bug 39] Hard-exclude protected tool messages so they survive in
+        // visible context instead of being pruned.
+        const filteredSelection = filterProtectedToolMessages(
+            plan.selection,
+            searchContext,
+            protectedTools,
+            protectedFilePatterns,
+        )
+        if (filteredSelection.messageIds.length === 0) {
+            continue
+        }
+
+        // Auto-detect consumed blocks: requiredBlockIds (active blocks whose
+        // anchor falls in range) + boundary blocks (when start/end is a bN ref).
+        const boundaryConsumed = extractBoundaryConsumedBlocks(
+            filteredSelection.startReference,
+            filteredSelection.endReference,
+        )
+        const consumedBlockIds = dedupeBlockIds([
+            ...filteredSelection.requiredBlockIds,
+            ...boundaryConsumed,
+        ])
+
+        const blockId = allocateBlockId(state)
+        const storedSummary = wrapCompressedSummary(blockId, plan.entry.summary)
+        const summaryTokens = countTokens(storedSummary)
+
+        applyCompressionState(
+            state,
+            {
+                topic: input.topic,
+                batchTopic: input.topic,
+                startId: plan.entry.startId,
+                endId: plan.entry.endId,
+                mode: "range",
+                runId,
+                compressMessageId: invocation.messageId,
+                compressCallId: invocation.callId,
+                summaryTokens,
+            },
+            filteredSelection,
+            plan.anchorMessageId,
+            blockId,
+            storedSummary,
+            consumedBlockIds,
+            gcConfig,
+        )
+        created++
+    }
+
+    return created
+}
+
+/** Mirrors `resolveMessage` (lib/compress/message-utils.ts) but skips invalid
+ *  entries gracefully instead of throwing. */
+function resolveMessageEntry(
+    entry: CompressMessageEntry,
+    searchContext: SearchContext,
+    state: SessionState,
+): { selection: SelectionResolution; anchorMessageId: string } | null {
+    const normalizedRef = entry.messageId.trim()
+    if (normalizedRef.toUpperCase() === "BLOCKED") {
+        return null
+    }
+
+    const ref = normalizedRef.toLowerCase()
+    if (!/^m\d{4,5}$/.test(ref)) {
+        return null
+    }
+
+    const messageId = state.messageIds.byRef.get(ref)
+    if (!messageId) {
+        return null
+    }
+    if (!searchContext.rawMessagesById.has(messageId)) {
+        return null
+    }
+
+    try {
+        const { startReference, endReference } = resolveBoundaryIds(
+            searchContext,
+            state,
+            ref,
+            ref,
+        )
+        const selection = resolveSelection(searchContext, startReference, endReference)
+        return {
+            selection,
+            anchorMessageId: resolveAnchorMessageId(startReference),
+        }
+    } catch {
+        return null
+    }
+}
+
+/**
+ * Replay a single message-mode compress invocation.
+ * Mirrors `createCompressMessageTool.execute` (lib/compress/message.ts):
+ *   per-entry resolve → block allocation with consumedBlockIds = [].
+ *
+ * Returns the number of blocks created.
+ */
+function rebuildMessageInvocation(
+    state: SessionState,
+    input: CompressMessageToolArgs,
+    searchContext: SearchContext,
+    invocation: CompressInvocation,
+    gcConfig: GCConfig | undefined,
+): number {
+    const runId = allocateRunId(state)
+    let created = 0
+
+    for (const entry of input.content) {
+        const resolved = resolveMessageEntry(entry, searchContext, state)
+        if (!resolved) {
+            continue
+        }
+
+        const blockId = allocateBlockId(state)
+        const storedSummary = wrapCompressedSummary(blockId, entry.summary)
+        const summaryTokens = countTokens(storedSummary)
+
+        applyCompressionState(
+            state,
+            {
+                topic: entry.topic,
+                batchTopic: input.topic,
+                startId: entry.messageId,
+                endId: entry.messageId,
+                mode: "message",
+                runId,
+                compressMessageId: invocation.messageId,
+                compressCallId: invocation.callId,
+                summaryTokens,
+            },
+            resolved.selection,
+            resolved.anchorMessageId,
+            blockId,
+            storedSummary,
+            [],
+            gcConfig,
+        )
+        created++
+    }
+
+    return created
+}
+
+/**
+ * Reconstruct compression state by replaying historical `compress` tool
+ * invocations from message history. Called when no persisted state exists
+ * (fork scenario).
+ *
+ * @returns number of compression blocks reconstructed.
+ */
+export function rebuildCompressionState(
+    state: SessionState,
+    messages: WithParts[],
+    config: PluginConfig,
+    logger: Logger,
+): number {
+    // Assign refs first so boundary resolution can map mNNNNN → rawId.
+    // (In the normal pipeline this runs later in hooks.ts; calling it here
+    // is idempotent — the later call is a no-op.)
+    assignMessageRefs(state, messages)
+
+    const invocations = collectCompressInvocations(messages)
+    if (invocations.length === 0) {
+        return 0
+    }
+
+    const protectedTools = config.compress.protectedTools
+    const protectedFilePatterns = config.protectedFilePatterns
+    const gcConfig = config.gc
+
+    let rebuilt = 0
+
+    for (const invocation of invocations) {
+        // Rebuild search context each iteration so blocks created by earlier
+        // invocations are visible (needed for nested bN boundary resolution).
+        const searchContext = buildSearchContext(state, messages)
+
+        try {
+            if (isRangeInput(invocation.input)) {
+                rebuilt += rebuildRangeInvocation(
+                    state,
+                    invocation.input as CompressRangeToolArgs,
+                    searchContext,
+                    invocation,
+                    protectedTools,
+                    protectedFilePatterns,
+                    gcConfig,
+                    logger,
+                )
+            } else {
+                rebuilt += rebuildMessageInvocation(
+                    state,
+                    invocation.input as CompressMessageToolArgs,
+                    searchContext,
+                    invocation,
+                    gcConfig,
+                )
+            }
+        } catch (err: any) {
+            logger.warn("rebuild: failed to replay compress invocation, skipping", {
+                error: err instanceof Error ? err.message : String(err),
+            })
+        }
+    }
+
+    if (rebuilt > 0) {
+        logger.info(`rebuild: reconstructed ${rebuilt} compression block(s) from history`)
+    }
+
+    return rebuilt
+}

--- a/lib/state/state.ts
+++ b/lib/state/state.ts
@@ -1,7 +1,9 @@
 import type { SessionState, ToolParameterEntry, WithParts } from "./types"
+import type { PluginConfig } from "../config"
 import type { Logger } from "../logger"
 import { applyPendingCompressionDurations } from "../compress/timing"
 import { loadSessionState, saveSessionState } from "./persistence"
+import { rebuildCompressionState } from "./rebuild"
 import {
     isSubAgentSession,
     findLastCompactionTimestamp,
@@ -21,6 +23,7 @@ export const checkSession = async (
     logger: Logger,
     messages: WithParts[],
     manualModeDefault: boolean,
+    config?: PluginConfig,
 ): Promise<void> => {
     const lastUserMessage = getLastUserMessage(messages)
     if (!lastUserMessage) {
@@ -39,6 +42,7 @@ export const checkSession = async (
                 logger,
                 messages,
                 manualModeDefault,
+                config,
             )
         } catch (err: any) {
             logger.error("Failed to initialize session state", { error: err.message })
@@ -150,6 +154,7 @@ export async function ensureSessionInitialized(
     logger: Logger,
     messages: WithParts[],
     manualModeEnabled: boolean,
+    config?: PluginConfig,
 ): Promise<void> {
     if (state.sessionId === sessionId) {
         return
@@ -168,6 +173,15 @@ export async function ensureSessionInitialized(
 
     const persisted = await loadSessionState(sessionId, logger)
     if (persisted === null) {
+        // Fork recovery: no persisted state for this session. If config is
+        // available, replay historical compress tool invocations to rebuild
+        // pruning state using the current session's message IDs.
+        if (config) {
+            const rebuilt = rebuildCompressionState(state, messages, config, logger)
+            if (rebuilt > 0) {
+                await saveSessionState(state, logger)
+            }
+        }
         return
     }
 

--- a/tests/rebuild.test.ts
+++ b/tests/rebuild.test.ts
@@ -1,0 +1,470 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { rebuildCompressionState } from "../lib/state/rebuild"
+import { createSessionState } from "../lib/state/state"
+import { assignMessageRefs } from "../lib/message-ids"
+import { Logger } from "../lib/logger"
+import type { PluginConfig } from "../lib/config"
+import type { SessionState, WithParts } from "../lib/state/types"
+
+const logger = new Logger(false)
+
+const SID = "session-rebuild-test"
+
+function buildConfig(overrides: Partial<PluginConfig> = {}): PluginConfig {
+    const base: PluginConfig = {
+        enabled: true,
+        autoUpdate: true,
+        debug: false,
+        pruneNotification: "off",
+        pruneNotificationType: "chat",
+        commands: { enabled: true, protectedTools: [] },
+        manualMode: { enabled: false, automaticStrategies: true },
+        turnProtection: { enabled: false, turns: 4 },
+        experimental: { allowSubAgents: false, customPrompts: false },
+        protectedFilePatterns: [],
+        compress: {
+            mode: "range",
+            permission: "allow",
+            showCompression: false,
+            summaryBuffer: true,
+            maxContextLimit: 150000,
+            minContextLimit: 50000,
+            nudgeFrequency: 5,
+            minNudgeContextPercent: 20,
+            iterationNudgeThreshold: 15,
+            nudgeForce: "soft",
+            protectedTools: ["task"],
+            protectTags: false,
+            protectUserMessages: false,
+            maxSummaryLengthHard: 10000,
+            minCompressRange: 0,
+            maxVisibleSegments: 3,
+        },
+        strategies: {
+            deduplication: { enabled: true, protectedTools: [] },
+            purgeErrors: { enabled: true, turns: 4, protectedTools: [] },
+        },
+        gc: {
+            algorithm: "truncate",
+            promotionThreshold: 5,
+            maxBlockAge: 15,
+            maxOldGenSummaryLength: 3000,
+            majorGcThresholdPercent: "100%",
+            batchCleanup: { lowThreshold: "60%", highThreshold: "75%", forceThreshold: "90%" },
+        },
+    }
+    return { ...base, ...overrides }
+}
+
+let msgCounter = 0
+function nextId(): string {
+    return `msg-rebuild-${++msgCounter}`
+}
+
+function makeUserMessage(id: string, text: string): WithParts {
+    return {
+        info: {
+            id,
+            sessionID: SID,
+            role: "user",
+            agent: "assistant",
+            time: { created: Date.now() },
+            model: { providerID: "test-provider", modelID: "test-model" },
+        } as WithParts["info"],
+        parts: [{ type: "text", text, id: `${id}-p1`, sessionID: SID, messageID: id }],
+    }
+}
+
+function makeAssistantMessage(id: string, parts: any[]): WithParts {
+    return {
+        info: {
+            id,
+            sessionID: SID,
+            role: "assistant",
+            agent: "test",
+            time: { created: Date.now() },
+            parentID: "parent-1",
+            modelID: "test-model",
+            providerID: "test-provider",
+            mode: "normal",
+            path: { cwd: "/", root: "/" },
+            summary: false,
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        } as WithParts["info"],
+        parts,
+    }
+}
+
+function makeTextPart(text: string): any {
+    return { type: "text", text }
+}
+
+function makeCompressPart(
+    callId: string,
+    input: any,
+): any {
+    return {
+        type: "tool",
+        tool: "compress",
+        callID: callId,
+        state: {
+            status: "completed",
+            input,
+            output: "Compressed messages into [Compressed conversation section].",
+        },
+    }
+}
+
+function makeToolPart(callId: string, tool: string, input?: any): any {
+    return {
+        type: "tool",
+        tool,
+        callID: callId,
+        state: { status: "completed", ...(input !== undefined ? { input } : {}) },
+    }
+}
+
+function freshState(): SessionState {
+    msgCounter = 0
+    return createSessionState()
+}
+
+
+test("rebuild returns 0 and makes no state changes when no compress parts exist", () => {
+    const state = freshState()
+    const messages = [
+        makeUserMessage(nextId(), "hello"),
+        makeAssistantMessage(nextId(), [makeTextPart("hi there")]),
+    ]
+    const config = buildConfig()
+
+    const result = rebuildCompressionState(state, messages, config, logger)
+
+    assert.equal(result, 0)
+    assert.equal(state.prune.messages.blocksById.size, 0)
+    assert.equal(state.prune.messages.byMessageId.size, 0)
+})
+
+test("rebuild reconstructs a single range compression block from history", () => {
+    const state = freshState()
+    const id1 = nextId()
+    const id2 = nextId()
+    const id3 = nextId()
+    const id4 = nextId()
+    const compressMsgId = nextId()
+
+    const messages: WithParts[] = [
+        makeUserMessage(id1, "hello"),
+        makeAssistantMessage(id2, [makeTextPart("hi")]),
+        makeUserMessage(id3, "do a task"),
+        makeAssistantMessage(id4, [makeTextPart("doing it")]),
+        makeAssistantMessage(compressMsgId, [
+            makeCompressPart("call-1", {
+                topic: "Intro chat",
+                content: [
+                    {
+                        startId: "m00001",
+                        endId: "m00004",
+                        summary: "User greeted and started a task.",
+                    },
+                ],
+            }),
+        ]),
+    ]
+
+    const config = buildConfig()
+    const result = rebuildCompressionState(state, messages, config, logger)
+
+    assert.equal(result, 1, "should create exactly 1 block")
+    assert.equal(state.prune.messages.blocksById.size, 1)
+
+    const block = state.prune.messages.blocksById.get(1)!
+    assert.equal(block.active, true)
+    assert.equal(block.mode, "range")
+    assert.equal(block.topic, "Intro chat")
+    assert.equal(block.compressMessageId, compressMsgId)
+    assert.equal(block.compressCallId, "call-1")
+    assert.ok(block.summary.includes("[Compressed conversation section]"))
+    assert.ok(block.summary.includes("User greeted and started a task."))
+
+    for (const id of [id1, id2, id3, id4]) {
+        const entry = state.prune.messages.byMessageId.get(id)
+        assert.ok(entry, `message ${id} should be in byMessageId`)
+        assert.ok(entry!.activeBlockIds.includes(1), `message ${id} should have block 1 active`)
+    }
+
+    assert.ok(!state.prune.messages.byMessageId.has(compressMsgId))
+
+    assert.equal(state.prune.messages.activeByAnchorMessageId.get(id1), 1)
+
+    assert.equal(state.messageIds.byRawId.get(id1), "m00001")
+    assert.equal(state.messageIds.byRawId.get(id4), "m00004")
+})
+
+test("rebuild handles fork: new message IDs but same mNNNNN refs resolve correctly", () => {
+    // Simulate a fork: the compress part references m00001-m00003 (position-based refs),
+    // but the actual raw IDs are different from the "original" session.
+    const state = freshState()
+    const forkId1 = "msg_fork_001"
+    const forkId2 = "msg_fork_002"
+    const forkId3 = "msg_fork_003"
+    const forkCompressId = "msg_fork_004"
+
+    const messages: WithParts[] = [
+        makeUserMessage(forkId1, "original message content"),
+        makeAssistantMessage(forkId2, [makeTextPart("response")]),
+        makeUserMessage(forkId3, "another message"),
+        makeAssistantMessage(forkCompressId, [
+            makeCompressPart("fork-call-1", {
+                topic: "Fork recovery",
+                content: [
+                    {
+                        startId: "m00001",
+                        endId: "m00003",
+                        summary: "Compressed fork messages.",
+                    },
+                ],
+            }),
+        ]),
+    ]
+
+    const config = buildConfig()
+    const result = rebuildCompressionState(state, messages, config, logger)
+
+    assert.equal(result, 1)
+    for (const id of [forkId1, forkId2, forkId3]) {
+        const entry = state.prune.messages.byMessageId.get(id)
+        assert.ok(entry, `fork message ${id} should be compressed`)
+        assert.ok(entry!.activeBlockIds.includes(1))
+    }
+    assert.equal(state.messageIds.byRawId.get(forkId1), "m00001")
+    assert.equal(state.messageIds.byRawId.get(forkId3), "m00003")
+})
+
+test("rebuild deactivates consumed blocks in nested compression (b1 consumed by b2)", () => {
+    const state = freshState()
+    const id1 = nextId()
+    const id2 = nextId()
+    const id3 = nextId()
+    const id4 = nextId()
+    const firstCompressId = nextId()
+    const id6 = nextId()
+    const id7 = nextId()
+    const secondCompressId = nextId()
+
+    const messages: WithParts[] = [
+        makeUserMessage(id1, "msg one"),
+        makeAssistantMessage(id2, [makeTextPart("msg two")]),
+        makeUserMessage(id3, "msg three"),
+        makeAssistantMessage(id4, [makeTextPart("msg four")]),
+        // First compress: m00001-m00004 → block b1
+        makeAssistantMessage(firstCompressId, [
+            makeCompressPart("call-1", {
+                topic: "First batch",
+                content: [{ startId: "m00001", endId: "m00004", summary: "First four messages." }],
+            }),
+        ]),
+        makeUserMessage(id6, "msg six"),
+        makeAssistantMessage(id7, [makeTextPart("msg seven")]),
+        // Second compress: b1..m00007 → block b2 (consumes b1)
+        makeAssistantMessage(secondCompressId, [
+            makeCompressPart("call-2", {
+                topic: "Second batch",
+                content: [{ startId: "b1", endId: "m00007", summary: "Expanded summary covering all." }],
+            }),
+        ]),
+    ]
+
+    const config = buildConfig()
+    const result = rebuildCompressionState(state, messages, config, logger)
+
+    assert.equal(result, 2, "should create 2 blocks")
+
+    const b1 = state.prune.messages.blocksById.get(1)!
+    const b2 = state.prune.messages.blocksById.get(2)!
+
+    assert.equal(b1.active, false, "b1 should be inactive after being consumed by b2")
+    assert.ok(b1.parentBlockIds.includes(2), "b1 should list b2 as parent")
+
+    assert.equal(b2.active, true, "b2 should be active")
+
+    assert.ok(!state.prune.messages.activeBlockIds.has(1))
+    assert.ok(state.prune.messages.activeBlockIds.has(2))
+
+    // b2 reuses id1 as anchor (same position), so id1 should map to b2 now
+    assert.equal(state.prune.messages.activeByAnchorMessageId.get(id1), 2)
+
+    for (const id of [id1, id2, id3, id4, id6, id7]) {
+        const entry = state.prune.messages.byMessageId.get(id)
+        assert.ok(entry, `message ${id} should be in byMessageId`)
+    }
+})
+
+test("rebuild handles message-mode compression", () => {
+    const state = freshState()
+    const id1 = nextId()
+    const id2 = nextId()
+    const compressMsgId = nextId()
+
+    const messages: WithParts[] = [
+        makeUserMessage(id1, "message to compress individually"),
+        makeAssistantMessage(id2, [makeTextPart("another individual message")]),
+        makeAssistantMessage(compressMsgId, [
+            makeCompressPart("call-msg-1", {
+                topic: "Individual summaries",
+                content: [
+                    { messageId: "m00001", topic: "Msg 1", summary: "Summary of msg 1." },
+                    { messageId: "m00002", topic: "Msg 2", summary: "Summary of msg 2." },
+                ],
+            }),
+        ]),
+    ]
+
+    const config = buildConfig({ compress: { ...buildConfig().compress, mode: "message" } })
+    const result = rebuildCompressionState(state, messages, config, logger)
+
+    assert.equal(result, 2, "should create 2 message-mode blocks")
+
+    const b1 = state.prune.messages.blocksById.get(1)!
+    const b2 = state.prune.messages.blocksById.get(2)!
+
+    assert.equal(b1.mode, "message")
+    assert.equal(b2.mode, "message")
+    assert.equal(b1.runId, b2.runId, "both blocks share the same runId")
+
+    assert.ok(state.prune.messages.byMessageId.get(id1)?.activeBlockIds.includes(1))
+    assert.ok(state.prune.messages.byMessageId.get(id2)?.activeBlockIds.includes(2))
+})
+
+test("rebuild excludes protected tool messages from compression (Bug 39 parity)", () => {
+    const state = freshState()
+    const userMsgId = nextId()
+    const protectedToolMsgId = nextId()
+    const normalMsgId = nextId()
+    const compressMsgId = nextId()
+
+    const messages: WithParts[] = [
+        makeUserMessage(userMsgId, "user message"),
+        // Message containing a protected tool call (task)
+        makeAssistantMessage(protectedToolMsgId, [
+            makeToolPart("task-call-1", "task", { prompt: "do something" }),
+        ]),
+        makeAssistantMessage(normalMsgId, [makeTextPart("normal assistant message")]),
+        makeAssistantMessage(compressMsgId, [
+            makeCompressPart("call-1", {
+                topic: "With protected tool",
+                content: [
+                    {
+                        startId: "m00001",
+                        endId: "m00003",
+                        summary: "Compressed range including protected tool.",
+                    },
+                ],
+            }),
+        ]),
+    ]
+
+    const config = buildConfig({
+        compress: { ...buildConfig().compress, protectedTools: ["task"] },
+    })
+    const result = rebuildCompressionState(state, messages, config, logger)
+
+    assert.equal(result, 1)
+
+    assert.ok(state.prune.messages.byMessageId.get(userMsgId)?.activeBlockIds.includes(1))
+    assert.ok(state.prune.messages.byMessageId.get(normalMsgId)?.activeBlockIds.includes(1))
+
+    // protectedToolMsgId should NOT be compressed (hard-excluded by Bug 39)
+    const protectedEntry = state.prune.messages.byMessageId.get(protectedToolMsgId)
+    assert.ok(
+        !protectedEntry || !protectedEntry.activeBlockIds.includes(1),
+        "protected tool message should not be in the compression block",
+    )
+})
+
+test("rebuild gracefully skips malformed compress invocations", () => {
+    const state = freshState()
+    const id1 = nextId()
+    const id2 = nextId()
+    const malformedCompressId = nextId()
+    const validCompressId = nextId()
+
+    const messages: WithParts[] = [
+        makeUserMessage(id1, "message one"),
+        makeAssistantMessage(id2, [makeTextPart("message two")]),
+        // Malformed: missing content array
+        makeAssistantMessage(malformedCompressId, [
+            makeCompressPart("call-bad", { topic: "Bad" }),
+        ]),
+        // Valid compress
+        makeAssistantMessage(validCompressId, [
+            makeCompressPart("call-good", {
+                topic: "Good batch",
+                content: [{ startId: "m00001", endId: "m00002", summary: "Valid summary." }],
+            }),
+        ]),
+    ]
+
+    const config = buildConfig()
+    const result = rebuildCompressionState(state, messages, config, logger)
+
+    assert.equal(result, 1)
+    assert.ok(state.prune.messages.byMessageId.get(id1)?.activeBlockIds.includes(1))
+})
+
+test("rebuild skips compress parts that are not completed", () => {
+    const state = freshState()
+    const id1 = nextId()
+    const pendingCompressId = nextId()
+
+    const messages: WithParts[] = [
+        makeUserMessage(id1, "hello"),
+        makeAssistantMessage(pendingCompressId, [
+            {
+                type: "tool",
+                tool: "compress",
+                callID: "call-pending",
+                state: {
+                    status: "running",
+                    input: {
+                        topic: "Pending",
+                        content: [{ startId: "m00001", endId: "m00001", summary: "..." }],
+                    },
+                },
+            },
+        ]),
+    ]
+
+    const config = buildConfig()
+    const result = rebuildCompressionState(state, messages, config, logger)
+
+    assert.equal(result, 0, "should not rebuild from non-completed compress parts")
+    assert.equal(state.prune.messages.blocksById.size, 0)
+})
+
+test("rebuild assigns refs idempotently — safe to call assignMessageRefs again after", () => {
+    const state = freshState()
+    const id1 = nextId()
+    const id2 = nextId()
+    const compressId = nextId()
+
+    const messages: WithParts[] = [
+        makeUserMessage(id1, "msg"),
+        makeAssistantMessage(id2, [makeTextPart("reply")]),
+        makeAssistantMessage(compressId, [
+            makeCompressPart("call-1", {
+                topic: "Test",
+                content: [{ startId: "m00001", endId: "m00002", summary: "Summary." }],
+            }),
+        ]),
+    ]
+
+    const config = buildConfig()
+    rebuildCompressionState(state, messages, config, logger)
+
+    const assigned = assignMessageRefs(state, messages)
+    assert.equal(assigned, 0, "assignMessageRefs should not re-assign existing refs")
+    assert.equal(state.messageIds.byRawId.get(id1), "m00001")
+})


### PR DESCRIPTION
## Summary

- **Fixes #89**: Fork sessions no longer overflow context because ACP now rebuilds compression state from message history when no persisted state exists.
- When `ensureSessionInitialized` detects `persisted === null`, it replays completed `compress` tool invocations from message history, reconstructing `CompressionBlock` / `byMessageId` / `activeByAnchorMessageId` using the fork's new message IDs.
- Message refs (`mNNNNN`) are position-based and fork-stable — compress input `startId`/`endId` resolve to the same logical messages in both original and fork.

## Changes

| File | Change |
|------|--------|
| `lib/state/rebuild.ts` | **NEW** — `rebuildCompressionState()`: replays compress history |
| `lib/state/state.ts` | `ensureSessionInitialized` + `checkSession` gain optional `config` param |
| `lib/hooks.ts` | Pass `config` to both functions |
| `lib/compress/pipeline.ts` | Pass `ctx.config` to `ensureSessionInitialized` |
| `lib/compress/decompress.ts` | Pass `ctx.config` to `ensureSessionInitialized` |
| `tests/rebuild.test.ts` | **NEW** — 9 unit tests |
| `devlog/2026-07-09_fork-rebuild/` | REQ + DESIGN + WORKLOG |

## Test plan

- [x] 9 new unit tests pass (range, message-mode, nested blocks, fork scenario, protected tools, malformed input, idempotent refs)
- [x] Full suite: 603 pass, 1 pre-existing fail (Bun nested `t.test()` limitation, unrelated)
- [x] `npm run build` clean
- [x] TypeScript typecheck clean