### PR TITLE
feat: gate notification wrap text behind debug flag

### DIFF
--- a/lib/commands/context.ts
+++ b/lib/commands/context.ts
@@ -42,6 +42,7 @@
 
 import type { Logger } from "../logger"
 import type { SessionState, WithParts } from "../state"
+import type { PluginConfig } from "../config"
 import { sendIgnoredMessage } from "../ui/notification"
 import { formatTokenCount } from "../ui/utils"
 import { isIgnoredUserMessage } from "../messages/query"
@@ -55,6 +56,7 @@ export interface ContextCommandContext {
     logger: Logger
     sessionId: string
     messages: WithParts[]
+    config: PluginConfig
 }
 
 interface TokenBreakdown {
@@ -294,12 +296,12 @@ function formatContextMessage(breakdown: TokenBreakdown): string {
 }
 
 export async function handleContextCommand(ctx: ContextCommandContext): Promise<void> {
-    const { client, state, logger, sessionId, messages } = ctx
+    const { client, state, logger, sessionId, messages, config } = ctx
 
     const breakdown = analyzeTokens(state, messages)
 
     const message = formatContextMessage(breakdown)
 
     const params = getCurrentParams(state, messages, logger)
-    await sendIgnoredMessage(client, sessionId, message, params, logger)
+    await sendIgnoredMessage(client, sessionId, message, params, logger, config)
 }

--- a/lib/commands/decompress.ts
+++ b/lib/commands/decompress.ts
@@ -1,5 +1,6 @@
 import type { Logger } from "../logger"
 import type { SessionState, WithParts } from "../state"
+import type { PluginConfig } from "../config"
 import { syncCompressionBlocks } from "../messages"
 import { getCurrentParams } from "../token-utils"
 import { sendIgnoredMessage } from "../ui/notification"
@@ -22,6 +23,7 @@ import { saveSessionState } from "../state/persistence"
 export interface DecompressCommandContext {
     client: any
     state: SessionState
+    config: PluginConfig
     logger: Logger
     sessionId: string
     messages: WithParts[]
@@ -86,7 +88,7 @@ function formatAvailableBlocksMessage(availableTargets: CompressionTarget[]): st
 }
 
 export async function handleDecompressCommand(ctx: DecompressCommandContext): Promise<void> {
-    const { client, state, logger, sessionId, messages, args } = ctx
+    const { client, state, logger, sessionId, messages, args, config } = ctx
 
     const params = getCurrentParams(state, messages, logger)
     const targetArg = args[0]
@@ -98,6 +100,7 @@ export async function handleDecompressCommand(ctx: DecompressCommandContext): Pr
             "Invalid arguments. Usage: /acp decompress <n>",
             params,
             logger,
+            config,
         )
         return
     }
@@ -108,7 +111,7 @@ export async function handleDecompressCommand(ctx: DecompressCommandContext): Pr
     if (!targetArg) {
         const availableTargets = getActiveCompressionTargets(messagesState)
         const message = formatAvailableBlocksMessage(availableTargets)
-        await sendIgnoredMessage(client, sessionId, message, params, logger)
+        await sendIgnoredMessage(client, sessionId, message, params, logger, config)
         return
     }
 
@@ -120,6 +123,7 @@ export async function handleDecompressCommand(ctx: DecompressCommandContext): Pr
             `Please enter a compression number. Example: /acp decompress 2`,
             params,
             logger,
+            config,
         )
         return
     }
@@ -132,6 +136,7 @@ export async function handleDecompressCommand(ctx: DecompressCommandContext): Pr
             `Compression ${targetBlockId} does not exist.`,
             params,
             logger,
+            config,
         )
         return
     }
@@ -146,6 +151,7 @@ export async function handleDecompressCommand(ctx: DecompressCommandContext): Pr
                 `Compression ${target.displayId} is inside compression ${activeAncestorBlockId}. Restore compression ${activeAncestorBlockId} first.`,
                 params,
                 logger,
+                config,
             )
             return
         }
@@ -156,6 +162,7 @@ export async function handleDecompressCommand(ctx: DecompressCommandContext): Pr
             `Compression ${target.displayId} is not active.`,
             params,
             logger,
+            config,
         )
         return
     }
@@ -184,7 +191,7 @@ export async function handleDecompressCommand(ctx: DecompressCommandContext): Pr
         restoredTokens,
         reactivatedBlockIds,
     )
-    await sendIgnoredMessage(client, sessionId, message, params, logger)
+    await sendIgnoredMessage(client, sessionId, message, params, logger, config)
 
     logger.info("Decompress command completed", {
         targetBlockId: target.displayId,

--- a/lib/commands/help.ts
+++ b/lib/commands/help.ts
@@ -70,7 +70,7 @@ export async function handleHelpCommand(ctx: HelpCommandContext): Promise<void> 
     const message = formatHelpMessage(state, config)
 
     const params = getCurrentParams(state, messages, logger)
-    await sendIgnoredMessage(client, sessionId, message, params, logger)
+    await sendIgnoredMessage(client, sessionId, message, params, logger, config)
 
     logger.info("Help command executed")
 }

--- a/lib/commands/manual.ts
+++ b/lib/commands/manual.ts
@@ -58,7 +58,7 @@ export async function handleManualToggleCommand(
     ctx: ManualCommandContext,
     modeArg?: string,
 ): Promise<void> {
-    const { client, state, logger, sessionId, messages } = ctx
+    const { client, state, config, logger, sessionId, messages } = ctx
 
     if (modeArg === "on") {
         state.manualMode = "active"
@@ -75,6 +75,7 @@ export async function handleManualToggleCommand(
         state.manualMode ? MANUAL_MODE_ON : MANUAL_MODE_OFF,
         params,
         logger,
+        config,
     )
 
     logger.info("Manual mode toggled", { manualMode: state.manualMode })

--- a/lib/commands/recompress.ts
+++ b/lib/commands/recompress.ts
@@ -1,4 +1,5 @@
 import type { Logger } from "../logger"
+import type { PluginConfig } from "../config"
 import type { PruneMessagesState, SessionState, WithParts } from "../state"
 import { syncCompressionBlocks } from "../messages"
 import { parseBlockRef } from "../message-ids"
@@ -15,6 +16,7 @@ import {
 export interface RecompressCommandContext {
     client: any
     state: SessionState
+    config: PluginConfig
     logger: Logger
     sessionId: string
     messages: WithParts[]
@@ -104,7 +106,7 @@ function formatAvailableBlocksMessage(availableTargets: CompressionTarget[]): st
 }
 
 export async function handleRecompressCommand(ctx: RecompressCommandContext): Promise<void> {
-    const { client, state, logger, sessionId, messages, args } = ctx
+    const { client, state, config, logger, sessionId, messages, args } = ctx
 
     const params = getCurrentParams(state, messages, logger)
     const targetArg = args[0]
@@ -116,6 +118,7 @@ export async function handleRecompressCommand(ctx: RecompressCommandContext): Pr
             "Invalid arguments. Usage: /acp recompress <n>",
             params,
             logger,
+            config,
         )
         return
     }
@@ -130,7 +133,7 @@ export async function handleRecompressCommand(ctx: RecompressCommandContext): Pr
             availableMessageIds,
         )
         const message = formatAvailableBlocksMessage(availableTargets)
-        await sendIgnoredMessage(client, sessionId, message, params, logger)
+        await sendIgnoredMessage(client, sessionId, message, params, logger, config)
         return
     }
 
@@ -142,6 +145,7 @@ export async function handleRecompressCommand(ctx: RecompressCommandContext): Pr
             `Please enter a compression number. Example: /acp recompress 2`,
             params,
             logger,
+            config,
         )
         return
     }
@@ -154,6 +158,7 @@ export async function handleRecompressCommand(ctx: RecompressCommandContext): Pr
             `Compression ${targetBlockId} does not exist.`,
             params,
             logger,
+            config,
         )
         return
     }
@@ -165,6 +170,7 @@ export async function handleRecompressCommand(ctx: RecompressCommandContext): Pr
             `Compression ${target.displayId} can no longer be re-applied because its origin message is no longer in this session.`,
             params,
             logger,
+            config,
         )
         return
     }
@@ -173,7 +179,7 @@ export async function handleRecompressCommand(ctx: RecompressCommandContext): Pr
         const message = target.blocks.some((block) => block.active)
             ? `Compression ${target.displayId} is already active.`
             : `Compression ${target.displayId} is not user-decompressed.`
-        await sendIgnoredMessage(client, sessionId, message, params, logger)
+        await sendIgnoredMessage(client, sessionId, message, params, logger, config)
         return
     }
 
@@ -212,7 +218,7 @@ export async function handleRecompressCommand(ctx: RecompressCommandContext): Pr
         recompressedTokens,
         deactivatedBlockIds,
     )
-    await sendIgnoredMessage(client, sessionId, message, params, logger)
+    await sendIgnoredMessage(client, sessionId, message, params, logger, config)
 
     logger.info("Recompress command completed", {
         targetBlockId: target.displayId,

--- a/lib/commands/stats.ts
+++ b/lib/commands/stats.ts
@@ -5,6 +5,7 @@
 
 import type { Logger } from "../logger"
 import type { SessionState, WithParts } from "../state"
+import type { PluginConfig } from "../config"
 import { sendIgnoredMessage } from "../ui/notification"
 import { formatTokenCount } from "../ui/utils"
 import { loadAllSessionStats, type AggregatedStats } from "../state/persistence"
@@ -17,6 +18,7 @@ export interface StatsCommandContext {
     logger: Logger
     sessionId: string
     messages: WithParts[]
+    config: PluginConfig
 }
 
 function formatStatsMessage(
@@ -90,7 +92,7 @@ function formatCompressionTime(ms: number): string {
 }
 
 export async function handleStatsCommand(ctx: StatsCommandContext): Promise<void> {
-    const { client, state, logger, sessionId, messages } = ctx
+    const { client, state, logger, sessionId, messages, config } = ctx
 
     // Session stats from in-memory state
     const sessionTokens = state.stats.totalPruneTokens
@@ -133,7 +135,7 @@ export async function handleStatsCommand(ctx: StatsCommandContext): Promise<void
     )
 
     const params = getCurrentParams(state, messages, logger)
-    await sendIgnoredMessage(client, sessionId, message, params, logger)
+    await sendIgnoredMessage(client, sessionId, message, params, logger, config)
 
     logger.info("Stats command executed", {
         sessionTokens,

--- a/lib/commands/sweep.ts
+++ b/lib/commands/sweep.ts
@@ -156,7 +156,7 @@ export async function handleSweepCommand(ctx: SweepCommandContext): Promise<void
         if (lastUserMsgIndex === -1) {
             // No user message found - show message and return
             const message = formatNoUserMessage()
-            await sendIgnoredMessage(client, sessionId, message, params, logger)
+            await sendIgnoredMessage(client, sessionId, message, params, logger, config)
             logger.info("Sweep command: no user message found")
             return
         } else {
@@ -214,7 +214,7 @@ export async function handleSweepCommand(ctx: SweepCommandContext): Promise<void
             workingDirectory,
             skippedProtected,
         )
-        await sendIgnoredMessage(client, sessionId, message, params, logger)
+        await sendIgnoredMessage(client, sessionId, message, params, logger, config)
         logger.info("Sweep command: no new tools to sweep", { skippedProtected })
         return
     }
@@ -253,7 +253,7 @@ export async function handleSweepCommand(ctx: SweepCommandContext): Promise<void
         workingDirectory,
         skippedProtected,
     )
-    await sendIgnoredMessage(client, sessionId, message, params, logger)
+    await sendIgnoredMessage(client, sessionId, message, params, logger, config)
 
     logger.info("Sweep command completed", {
         toolsSwept: newToolIds.length,

--- a/lib/ui/notification.ts
+++ b/lib/ui/notification.ts
@@ -261,7 +261,7 @@ export async function sendCompressNotification(
         return true
     }
 
-    await sendIgnoredMessage(client, sessionId, message, params, logger)
+    await sendIgnoredMessage(client, sessionId, message, params, logger, config)
     return true
 }
 
@@ -271,6 +271,7 @@ export async function sendIgnoredMessage(
     text: string,
     params: any,
     logger: Logger,
+    config: PluginConfig,
 ): Promise<void> {
     const agent = params.agent || undefined
     const variant = params.variant || undefined
@@ -282,8 +283,10 @@ export async function sendIgnoredMessage(
               }
             : undefined
 
-    // Wrap with system message markers so the model does not confuse this with user input
-    const wrappedText = `[ACP system message — not a user comment]\n\n${text}\n\n[ACP system message — not a user comment]`
+    // debug=true: wrap to help model distinguish system vs user; debug=false: send clean
+    const finalText = config.debug
+        ? `[ACP system message — not a user comment]\n\n${text}\n\n[ACP system message — not a user comment]`
+        : text
 
     try {
         await client.session.prompt({
@@ -298,7 +301,7 @@ export async function sendIgnoredMessage(
                 parts: [
                     {
                         type: "text",
-                        text: wrappedText,
+                        text: finalText,
                         ignored: true,
                     },
                 ],

--- a/tests/compression-groups.test.ts
+++ b/tests/compression-groups.test.ts
@@ -323,6 +323,7 @@ test("decompress groups batched message compressions by tool call", async () => 
     await handleDecompressCommand({
         client,
         state,
+        config: buildConfig("message"),
         logger,
         sessionId: sessionID,
         messages: rawMessages,
@@ -336,6 +337,7 @@ test("decompress groups batched message compressions by tool call", async () => 
     await handleDecompressCommand({
         client,
         state,
+        config: buildConfig("message"),
         logger,
         sessionId: sessionID,
         messages: rawMessages,
@@ -348,6 +350,7 @@ test("decompress groups batched message compressions by tool call", async () => 
     await handleRecompressCommand({
         client,
         state,
+        config: buildConfig("message"),
         logger,
         sessionId: sessionID,
         messages: rawMessages,
@@ -422,6 +425,7 @@ test("decompress keeps batched ranges individually restorable", async () => {
     await handleDecompressCommand({
         client,
         state,
+        config: buildConfig("range"),
         logger,
         sessionId: sessionID,
         messages: rawMessages,
@@ -435,6 +439,7 @@ test("decompress keeps batched ranges individually restorable", async () => {
     await handleDecompressCommand({
         client,
         state,
+        config: buildConfig("range"),
         logger,
         sessionId: sessionID,
         messages: rawMessages,


### PR DESCRIPTION
## Problem

Notifications (compression results, /acp command outputs) are wrapped with `[ACP system message — not a user comment]` text on both sides. This adds visual noise for end users in normal (non-debug) usage. Issue: #84

## Solution

Gate the wrapper text behind `config.debug`:
- `debug: false` (default) → clean notification text, no wrapper
- `debug: true` → wrapper added (useful during development to distinguish system vs user messages)

## Changes

```
lib/ui/notification.ts       | sendIgnoredMessage: +config param, conditional wrap
lib/commands/context.ts      | +PluginConfig import, +config field, pass config
lib/commands/decompress.ts   | +PluginConfig import, +config field, pass config ×7
lib/commands/help.ts         | pass config
lib/commands/manual.ts       | pass config
lib/commands/recompress.ts   | +PluginConfig import, +config field, pass config ×7
lib/commands/stats.ts        | +PluginConfig import, +config field, pass config
lib/commands/sweep.ts        | pass config ×3
tests/compression-groups.test.ts | +config in 5 handleDecompress/Recompress calls
```

## Verification

- `tsc --noEmit` ✅ no errors
- `npm test` ✅ 608/608 pass

Closes #84