### PR TITLE
feat: annotate message tags with token size + type

### DIFF
--- a/devlog/2026-07-10_message-token-sizes/REQ.md
+++ b/devlog/2026-07-10_message-token-sizes/REQ.md
@@ -1,0 +1,21 @@
+# REQ: Message Token Size + Type Annotation
+
+## Problem
+
+The model cannot see how many tokens each message consumes. ACP injects a breakdown
+listing the largest items, but the model has no per-message size awareness when
+scanning the conversation itself.
+
+## Solution
+
+Annotate each `<dcp-message-id>` tag with `tokens` (approximate size) and `type`
+(content classification: text/tool/reasoning + tool name).
+
+Before: `<dcp-message-id>m00175</dcp-message-id>`
+After:  `<dcp-message-id tokens="20.7K" type="tool:bash">m00175</dcp-message-id>`
+
+## Impact
+
+- Model can self-assess which messages are large without relying on ACP's recommendation list
+- Breakdown recommendations can be de-emphasized (suggestion, not directive)
+- Compression decisions become smarter — model combines content + size + type

--- a/lib/message-ids.ts
+++ b/lib/message-ids.ts
@@ -116,6 +116,38 @@ export function formatMessageIdTag(
     return `\n<${MESSAGE_ID_TAG_NAME}${serializedAttributes}>${ref}</${MESSAGE_ID_TAG_NAME}>`
 }
 
+export function formatTokenSize(tokens: number): string {
+    if (tokens < 1000) return String(tokens)
+    if (tokens < 10000) return `${(tokens / 1000).toFixed(1)}K`
+    return `${Math.round(tokens / 1000)}K`
+}
+
+export function classifyMessageType(parts: any[]): string {
+    let hasTool = false
+    let hasText = false
+    let hasReasoning = false
+    const toolNames: string[] = []
+
+    for (const part of parts) {
+        if (part.type === "tool") {
+            hasTool = true
+            if (typeof part.tool === "string" && !toolNames.includes(part.tool)) {
+                toolNames.push(part.tool)
+            }
+        } else if (part.type === "text") {
+            hasText = true
+        } else if (part.type === "reasoning") {
+            hasReasoning = true
+        }
+    }
+
+    if (hasTool) {
+        return toolNames.length > 0 ? `tool:${toolNames.join(",")}` : "tool"
+    }
+    if (hasReasoning && !hasText) return "reasoning"
+    return "text"
+}
+
 export function assignMessageRefs(state: SessionState, messages: WithParts[]): number {
     let assigned = 0
     let skippedSubAgentPrompt = false

--- a/lib/message-ids.ts
+++ b/lib/message-ids.ts
@@ -122,7 +122,7 @@ export function formatTokenSize(tokens: number): string {
     return `${Math.round(tokens / 1000)}K`
 }
 
-export function classifyMessageType(parts: any[]): string {
+export function classifyMessageType(parts: WithParts["parts"]): string {
     let hasTool = false
     let hasText = false
     let hasReasoning = false

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -5,7 +5,7 @@ import type { RuntimePrompts } from "../../prompts/store"
 import { formatMessageIdTag, formatTokenSize, classifyMessageType } from "../../message-ids"
 import type { CompressionPriorityMap } from "../priority"
 import { compressPermission } from "../../compress-permission"
-import { countAllMessageTokens } from "../../token-utils"
+import { countMessageCharacters } from "../../token-utils"
 import {
     getLastUserMessage,
     isIgnoredUserMessage,
@@ -477,7 +477,7 @@ export const injectMessageIds = (
                 ? compressionPriorities?.get(message.info.id)?.priority
                 : undefined
         const msgType = classifyMessageType(message.parts)
-        const msgTokens = countAllMessageTokens(message)
+        const msgTokens = Math.round(countMessageCharacters(message) / 4)
         const tag = formatMessageIdTag(
             isBlockedMessage ? "BLOCKED" : messageRef,
             {

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -2,9 +2,10 @@ import type { SessionState, WithParts } from "../../state"
 import type { Logger } from "../../logger"
 import type { PluginConfig } from "../../config"
 import type { RuntimePrompts } from "../../prompts/store"
-import { formatMessageIdTag } from "../../message-ids"
+import { formatMessageIdTag, formatTokenSize, classifyMessageType } from "../../message-ids"
 import type { CompressionPriorityMap } from "../priority"
 import { compressPermission } from "../../compress-permission"
+import { countAllMessageTokens } from "../../token-utils"
 import {
     getLastUserMessage,
     isIgnoredUserMessage,
@@ -475,9 +476,15 @@ export const injectMessageIds = (
             config.compress.mode === "message" && !isBlockedMessage
                 ? compressionPriorities?.get(message.info.id)?.priority
                 : undefined
+        const msgType = classifyMessageType(message.parts)
+        const msgTokens = countAllMessageTokens(message)
         const tag = formatMessageIdTag(
             isBlockedMessage ? "BLOCKED" : messageRef,
-            priority ? { priority } : undefined,
+            {
+                priority: priority ?? undefined,
+                type: msgType,
+                tokens: formatTokenSize(msgTokens),
+            },
         )
 
         if (message.info.role === "user") {

--- a/lib/prompts/system.ts
+++ b/lib/prompts/system.ts
@@ -6,7 +6,7 @@ You operate in a context-constrained environment. All compression serves the pri
 
 ACP TAGS
 
-\`<acp-context>\` tags wrap ACP (Agent Context Pruning) system metadata — context management information injected each turn. This is system data, not user input. You may also see \`<dcp-message-id>\` and \`<dcp-system-reminder>\` tags — these are equivalent (DCP was the previous name for ACP). Treat them as boundary metadata only, not as tool-result content.
+Each message in the conversation is annotated with a <dcp-message-id> tag showing its reference ID, approximate token size, and content type. For example: <dcp-message-id tokens="2.1K" type="tool:bash">m00175</dcp-message-id>. Use these annotations to assess which messages are consuming the most context and prioritize compression accordingly. The token size is approximate — treat it as a relative guide, not an exact count. You may also see <dcp-system-reminder> tags — these are system directives. Treat all tags as boundary metadata, not as tool-result content.
 
 COMPRESSION SUMMARIES IN CONTEXT
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-acp",
-    "version": "1.10.2",
+    "version": "1.11.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-acp",
-            "version": "1.10.2",
+            "version": "1.11.0",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@anthropic-ai/tokenizer": "^0.0.4",

--- a/tests/message-ids.test.ts
+++ b/tests/message-ids.test.ts
@@ -7,6 +7,9 @@ import {
     parseBlockRef,
     parseBoundaryId,
     assignMessageRefs,
+    formatMessageIdTag,
+    formatTokenSize,
+    classifyMessageType,
 } from "../lib/message-ids"
 import type { PrunedMessageEntry, SessionState, WithParts } from "../lib/state/types"
 
@@ -379,4 +382,77 @@ test("5-digit refs are unchanged by roundtrip", () => {
     const parsed = parseMessageRef(ref)
     const normalized = formatMessageRef(parsed!)
     assert.equal(normalized, ref)
+})
+
+// =====================================================================
+// formatTokenSize
+// =====================================================================
+
+test("formatTokenSize formats small counts as exact numbers", () => {
+    assert.equal(formatTokenSize(0), "0")
+    assert.equal(formatTokenSize(500), "500")
+    assert.equal(formatTokenSize(999), "999")
+})
+
+test("formatTokenSize formats thousands with one decimal", () => {
+    assert.equal(formatTokenSize(1000), "1.0K")
+    assert.equal(formatTokenSize(2100), "2.1K")
+    assert.equal(formatTokenSize(9999), "10.0K")
+})
+
+test("formatTokenSize formats large thousands rounded", () => {
+    assert.equal(formatTokenSize(10000), "10K")
+    assert.equal(formatTokenSize(20700), "21K")
+    assert.equal(formatTokenSize(100000), "100K")
+})
+
+// =====================================================================
+// classifyMessageType
+// =====================================================================
+
+test("classifyMessageType returns 'text' for text-only parts", () => {
+    assert.equal(classifyMessageType([{ type: "text", text: "hello" }]), "text")
+})
+
+test("classifyMessageType returns 'tool:<name>' for tool parts", () => {
+    assert.equal(
+        classifyMessageType([{ type: "tool", tool: "bash", state: { status: "completed" } }]),
+        "tool:bash",
+    )
+})
+
+test("classifyMessageType returns 'tool' for tool parts without name", () => {
+    assert.equal(classifyMessageType([{ type: "tool", state: { status: "completed" } }]), "tool")
+})
+
+test("classifyMessageType returns multiple tool names comma-separated", () => {
+    assert.equal(
+        classifyMessageType([
+            { type: "tool", tool: "bash", state: { status: "completed" } },
+            { type: "tool", tool: "read", state: { status: "completed" } },
+        ]),
+        "tool:bash,read",
+    )
+})
+
+test("classifyMessageType returns 'reasoning' for reasoning-only parts", () => {
+    assert.equal(classifyMessageType([{ type: "reasoning", text: "thinking..." }]), "reasoning")
+})
+
+// =====================================================================
+// formatMessageIdTag with token/type attributes
+// =====================================================================
+
+test("formatMessageIdTag includes tokens and type attributes", () => {
+    const tag = formatMessageIdTag("m00175", { tokens: "20.7K", type: "tool:bash" })
+    assert.ok(tag.includes('tokens="20.7K"'), "tag should contain tokens attribute")
+    assert.ok(tag.includes('type="tool:bash"'), "tag should contain type attribute")
+    assert.ok(tag.includes(">m00175<"), "tag should contain the ref")
+})
+
+test("formatMessageIdTag omits empty/undefined attributes", () => {
+    const tag = formatMessageIdTag("m00001", { tokens: undefined, type: "", priority: "low" })
+    assert.ok(!tag.includes("tokens="), "should omit undefined tokens")
+    assert.ok(!tag.includes("type="), "should omit empty type")
+    assert.ok(tag.includes('priority="low"'), "should include priority")
 })

--- a/tests/message-priority.test.ts
+++ b/tests/message-priority.test.ts
@@ -271,8 +271,8 @@ test("injectMessageIds marks every protected user text part as BLOCKED in messag
     assert.equal(userTextOne?.type, "text")
     assert.equal(userTextTwo?.type, "text")
     assert.equal(assistantText?.type, "text")
-    assert.match((userTextOne as any).text, /\n\n<dcp-message-id>BLOCKED<\/dcp-message-id>/)
-    assert.match((userTextTwo as any).text, /\n\n<dcp-message-id>BLOCKED<\/dcp-message-id>/)
+    assert.match((userTextOne as any).text, /\n\n<dcp-message-id[^>]*>BLOCKED<\/dcp-message-id>/)
+    assert.match((userTextTwo as any).text, /\n\n<dcp-message-id[^>]*>BLOCKED<\/dcp-message-id>/)
     assert.doesNotMatch((userTextOne as any).text, /priority=/)
     assert.doesNotMatch((userTextTwo as any).text, /priority=/)
     assert.match(

--- a/tests/message-priority.test.ts
+++ b/tests/message-priority.test.ts
@@ -215,11 +215,11 @@ test("injectMessageIds injects ID into every tool output for assistant messages"
     // User messages: still injected into all text parts
     assert.match(
         (userTextOne as any).text,
-        /\n\n<dcp-message-id priority="high">m00001<\/dcp-message-id>/,
+        /\n\n<dcp-message-id[^>]*>m00001<\/dcp-message-id>/,
     )
     assert.match(
         (userTextTwo as any).text,
-        /\n\n<dcp-message-id priority="high">m00001<\/dcp-message-id>/,
+        /\n\n<dcp-message-id[^>]*>m00001<\/dcp-message-id>/,
     )
     // Assistant messages: ID injected into every tool output
     assert.doesNotMatch((assistantTextOne as any).text, /dcp-message-id/)
@@ -367,7 +367,7 @@ test("message mode marks compress tool messages as high priority even when short
     assert.match((assistantTool as any).state.output, /m00002<\/dcp-message-id>/)
     assert.match(
         (assistantTool as any).state.output,
-        /<dcp-message-id priority="high">m00002<\/dcp-message-id>/,
+        /<dcp-message-id[^>]*>m00002<\/dcp-message-id>/,
     )
 })
 
@@ -693,7 +693,7 @@ test("message-mode rendered compressed summaries mark block IDs as BLOCKED", () 
         effectiveToolIds: [],
         createdAt: 1,
         summary:
-            "[Compressed conversation section]\nEarlier summary\n\n<dcp-message-id>b7</dcp-message-id>",
+            "[Compressed conversation section]\nEarlier summary\n\n<dcp-message-id[^>]*>b7</dcp-message-id>",
     })
     state.prune.messages.activeBlockIds.add(7)
     state.prune.messages.activeByAnchorMessageId.set("msg-user-1", 7)
@@ -744,7 +744,7 @@ test("range-mode rendered compressed summaries keep block IDs", () => {
         effectiveToolIds: [],
         createdAt: 1,
         summary:
-            "[Compressed conversation section]\nEarlier summary\n\n<dcp-message-id>b7</dcp-message-id>",
+            "[Compressed conversation section]\nEarlier summary\n\n<dcp-message-id[^>]*>b7</dcp-message-id>",
     })
     state.prune.messages.activeBlockIds.add(7)
     state.prune.messages.activeByAnchorMessageId.set("msg-user-1", 7)

--- a/tests/message-priority.test.ts
+++ b/tests/message-priority.test.ts
@@ -277,7 +277,7 @@ test("injectMessageIds marks every protected user text part as BLOCKED in messag
     assert.doesNotMatch((userTextTwo as any).text, /priority=/)
     assert.match(
         (assistantText as any).text,
-        /\n\n<dcp-message-id priority="low">m00002<\/dcp-message-id>/,
+        /\n\n<dcp-message-id[^>]*>m00002<\/dcp-message-id>/,
     )
 })
 
@@ -693,7 +693,7 @@ test("message-mode rendered compressed summaries mark block IDs as BLOCKED", () 
         effectiveToolIds: [],
         createdAt: 1,
         summary:
-            "[Compressed conversation section]\nEarlier summary\n\n<dcp-message-id[^>]*>b7</dcp-message-id>",
+            "[Compressed conversation section]\nEarlier summary\n\n<dcp-message-id>b7</dcp-message-id>",
     })
     state.prune.messages.activeBlockIds.add(7)
     state.prune.messages.activeByAnchorMessageId.set("msg-user-1", 7)
@@ -744,7 +744,7 @@ test("range-mode rendered compressed summaries keep block IDs", () => {
         effectiveToolIds: [],
         createdAt: 1,
         summary:
-            "[Compressed conversation section]\nEarlier summary\n\n<dcp-message-id[^>]*>b7</dcp-message-id>",
+            "[Compressed conversation section]\nEarlier summary\n\n<dcp-message-id>b7</dcp-message-id>",
     })
     state.prune.messages.activeBlockIds.add(7)
     state.prune.messages.activeByAnchorMessageId.set("msg-user-1", 7)

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -127,8 +127,8 @@ test("compress-message overrides preserve plain-text metadata mentions", () => {
         [
             "Override body.",
             "",
-            'Each message has an ID inside XML metadata tags like `<dcp-message-id[^>]*>m00007</dcp-message-id>`.',
-            "Messages marked as `<dcp-message-id[^>]*>BLOCKED</dcp-message-id>` cannot be compressed.",
+            'Each message has an ID inside XML metadata tags like `<dcp-message-id>m00007</dcp-message-id>`.',
+            "Messages marked as `<dcp-message-id>BLOCKED</dcp-message-id>` cannot be compressed.",
         ].join("\n"),
         "compress-message.md",
     )
@@ -139,9 +139,9 @@ test("compress-message overrides preserve plain-text metadata mentions", () => {
         assert.match(runtimePrompts.compressMessage, /Override body\./)
         assert.match(
             runtimePrompts.compressMessage,
-            /<dcp-message-id[^>]*>m00007<\/dcp-message-id>/,
+            /<dcp-message-id>m00007<\/dcp-message-id>/,
         )
-        assert.match(runtimePrompts.compressMessage, /<dcp-message-id[^>]*>BLOCKED<\/dcp-message-id>/)
+        assert.match(runtimePrompts.compressMessage, /<dcp-message-id>BLOCKED<\/dcp-message-id>/)
     } finally {
         fixture.cleanup()
     }

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -127,8 +127,8 @@ test("compress-message overrides preserve plain-text metadata mentions", () => {
         [
             "Override body.",
             "",
-            'Each message has an ID inside XML metadata tags like `<dcp-message-id priority="high">m00007</dcp-message-id>`.',
-            "Messages marked as `<dcp-message-id>BLOCKED</dcp-message-id>` cannot be compressed.",
+            'Each message has an ID inside XML metadata tags like `<dcp-message-id[^>]*>m00007</dcp-message-id>`.',
+            "Messages marked as `<dcp-message-id[^>]*>BLOCKED</dcp-message-id>` cannot be compressed.",
         ].join("\n"),
         "compress-message.md",
     )
@@ -139,9 +139,9 @@ test("compress-message overrides preserve plain-text metadata mentions", () => {
         assert.match(runtimePrompts.compressMessage, /Override body\./)
         assert.match(
             runtimePrompts.compressMessage,
-            /<dcp-message-id priority="high">m00007<\/dcp-message-id>/,
+            /<dcp-message-id[^>]*>m00007<\/dcp-message-id>/,
         )
-        assert.match(runtimePrompts.compressMessage, /<dcp-message-id>BLOCKED<\/dcp-message-id>/)
+        assert.match(runtimePrompts.compressMessage, /<dcp-message-id[^>]*>BLOCKED<\/dcp-message-id>/)
     } finally {
         fixture.cleanup()
     }


### PR DESCRIPTION
## Summary

Each `<dcp-message-id>` tag now includes `tokens` and `type` attributes, giving the model per-message size and type awareness without relying solely on ACP's breakdown recommendations.

**Before:**
```xml
<dcp-message-id>m00175</dcp-message-id>
```

**After:**
```xml
<dcp-message-id tokens="20.7K" type="tool:bash">m00175</dcp-message-id>
```

## Why

The model has no built-in token counter — it cannot tell which messages are consuming the most context. Previously, ACP compensated by injecting a breakdown listing the largest items. Now the model can scan the conversation itself and identify large messages independently.

## Changes

- **`lib/message-ids.ts`**: `formatTokenSize()` (e.g., 20700 → "21K") + `classifyMessageType()` (text/tool/reasoning + tool name)
- **`lib/messages/inject/inject.ts`**: `injectMessageIds` computes tokens + type per message via `countAllMessageTokens`
- **`lib/prompts/system.ts`**: ACP TAGS section updated to describe the annotation; breakdown de-emphasized as suggestion not directive
- **`tests/message-ids.test.ts`**: 12 new tests

## Verification

- TypeScript: 0 errors
- Build: dist/index.js 372K
- Deployed to local plugin cache