### PR TITLE
feat: remove size-based nudge recommendations, replace with need-based guidance

### DIFF
--- a/devlog/2026-07-11_nudge-remove-recommendations/REQ.md
+++ b/devlog/2026-07-11_nudge-remove-recommendations/REQ.md
@@ -1,0 +1,38 @@
+# REQ: Remove size-based recommendations from nudge
+
+## Problem
+
+ACP's nudge injection listed specific message ranges by size ("Largest tool
+outputs: m00175 (20.7K)", "Largest code messages", "Largest text messages").
+The model treated these lists as **directives** — compressing by size rather
+than by need. This caused the "context leak" pattern: grow 5%, compress 2%
+(the largest items), net +3%, eventually overflowing context.
+
+Analysis of session `ses_0e1951573ffeWOaARblvet5U7s` proved the point: when
+the user manually directed compression by work phase (ignoring ACP's
+size-based recommendations), compression achieved 93–99% reduction across 6
+blocks (147,975 → 4,121 tokens). The model already has per-message token
+annotations (`<dcp-message-id tokens="2.1K" type="tool:bash">m00175</dcp-message-id>`)
+— it does not need ACP to list ranges for it.
+
+## Solution
+
+1. **Remove** the "Largest tool outputs", "Largest code messages", and
+   "Largest text messages" range listings from the nudge injection.
+2. **Remove** the `topRanges` listing from the `toolOutputReminder`.
+3. **Keep** the composition ratio breakdown (`tool 40% | summaries 10% |
+   code 28% | text 22%`) and top-tools ratio — these are information, not
+   directives.
+4. **Replace** the old "Compress incrementally: target the ranges above..."
+   text with new guidance:
+   - Use `acp_status` or review context to identify consumed content
+   - Prefer large continuous ranges by work phase, not small incremental steps
+   - Convert verbose tool outputs into concise summaries
+5. **Update** the system prompt's CONTEXT BREAKDOWN section to match.
+
+## Files Changed
+
+- `lib/messages/inject/inject.ts` — nudge injection (removed range listings,
+  replaced guidance text, simplified toolOutputReminder)
+- `lib/prompts/system.ts` — CONTEXT BREAKDOWN section (removed size-based
+  directive, replaced with need-based guidance)

--- a/devlog/2026-07-11_nudge-remove-recommendations/WORKLOG.md
+++ b/devlog/2026-07-11_nudge-remove-recommendations/WORKLOG.md
@@ -1,0 +1,62 @@
+# WORKLOG: Remove size-based recommendations from nudge
+
+## Date: 2026-07-11
+
+## Branch: `2026-07-11_nudge-remove-recommendations`
+
+## Changes
+
+### `lib/messages/inject/inject.ts`
+
+**Removed** from `injectCompressNudges` (lines 249-257):
+- `composition.largestToolRanges.slice(0, 10)` → "Largest tool outputs:" listing
+- `composition.largestCodeRanges` → "Largest code messages:" listing
+- `composition.largestMessageRanges` → "Largest text messages:" listing
+
+These listings caused the model to compress by size (directive) rather than
+by need (self-assessment).
+
+**Replaced** (line 258):
+- Old: `💡 Compress incrementally: target the ranges above whose content you have already extracted for this step. Size alone is not a reason to compress — if a large range is still needed in full, keep it.`
+- New: `💡 Use \`acp_status\` or review the context above to identify consumed content. Prefer compressing large continuous ranges by work phase — not small incremental steps. Convert verbose tool outputs into concise summaries rather than keeping raw content.`
+
+**Simplified** `toolOutputReminder` (lines 214-219):
+- Removed `topRanges = composition.largestRanges.slice(0, 15)` listing
+- Replaced: `⚠️ X new tool outputs accumulated (Y total). Use \`acp_status\` or review the context above to identify and compress consumed ranges. Prefer large continuous ranges by work phase — convert tool outputs into concise summaries rather than keeping raw content.`
+
+**Kept unchanged**:
+- Composition ratio breakdown (`tool (40%) | summaries (10%) | code (28%) | text (22%)`)
+- Top tools ratio
+- Growth signal (`+X since last nudge`)
+- `estimateContextComposition()` function — still computes `largestRanges` etc., just not displayed
+
+### `lib/prompts/system.ts`
+
+**Modified** CONTEXT BREAKDOWN section (lines 76-83):
+- Line 76: Removed `(largest category — compress first when consumed)` after `"tool" = tool call outputs`
+- Lines 81-83: Removed the paragraph listing largest ranges + "Compress incrementally" directive
+- Replaced with need-based guidance:
+  > The breakdown shows where tokens are spent — it is INFORMATION, not a
+  > directive. Use `acp_status` or review the context above to identify which
+  > content you have already consumed. When compressing, prefer large
+  > continuous ranges by work phase (e.g. m00150–m00220) rather than small
+  > incremental steps — small compressions create overhead that can exceed
+  > their savings. Convert verbose tool outputs into concise summaries: most
+  > useful content in tool calls should become part of a summary, not kept
+  > as raw, lengthy output. Each compression creates a reusable summary block
+  > you can decompress later if needed.
+
+## Verification
+
+- `npm run typecheck`: 0 errors
+- `npm run test`: 609 tests pass, 0 failures
+- No test files reference the removed text strings
+
+## Rationale
+
+Analysis of session `ses_0e1951573ffeWOaARblvet5U7s` showed 93-99% compression
+when the model compressed by work phase (user-directed), vs. the "context leak"
+pattern (grow 5%, compress 2%) when following ACP's size-based "Largest tool
+outputs" recommendations. The model already has per-message token annotations
+— it doesn't need ACP to list ranges for it. When ACP lists ranges, the model
+treats the list as a directive and compresses by size, not by need.

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -213,8 +213,7 @@ export const injectCompressNudges = (
             const toolGrowth = composition.toolTokens - state.nudges.lastToolOutputNudgeTokens
             if (toolGrowth >= toolOutputThreshold) {
                 const fmt = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n))
-                const topRanges = composition.largestRanges.slice(0, 15).map((r) => `${r.ref} (${fmt(r.tokens)})`).join(", ")
-                toolOutputReminder = `\n\n⚠️ ${fmt(toolGrowth)} new tool outputs accumulated (${fmt(composition.toolTokens)} total). Largest: ${topRanges}. Use compress tool to compress these ranges now.`
+                toolOutputReminder = `\n\n⚠️ ${fmt(toolGrowth)} new tool outputs accumulated (${fmt(composition.toolTokens)} total). Use \`acp_status\` or review the context above to identify and compress consumed ranges. Prefer large continuous ranges by work phase — convert tool outputs into concise summaries rather than keeping raw content.`
                 state.nudges.lastToolOutputNudgeTokens = composition.toolTokens
                 anchorsChanged = true
             }
@@ -246,16 +245,7 @@ export const injectCompressNudges = (
                 breakdown += `\nTop tools: ${topToolTypes.map((t) => `${t.tool} (${pct(t.tokens)}%)`).join(", ")}`
             }
 
-            if (composition.largestToolRanges.length > 0) {
-                breakdown += `\nLargest tool outputs: ${composition.largestToolRanges.slice(0, 10).map((r) => `${r.ref} (${fmt(r.tokens)})${r.tool ? " " + r.tool : ""}`).join(", ")}`
-            }
-            if (composition.largestCodeRanges.length > 0) {
-                breakdown += `\nLargest code messages: ${composition.largestCodeRanges.map((r) => `${r.ref} (${fmt(r.tokens)})`).join(", ")}`
-            }
-            if (composition.largestMessageRanges.length > 0) {
-                breakdown += `\nLargest text messages: ${composition.largestMessageRanges.map((r) => `${r.ref} (${fmt(r.tokens)})`).join(", ")}`
-            }
-            breakdown += `\n💡 Compress incrementally: target the ranges above whose content you have already extracted for this step. Size alone is not a reason to compress — if a large range is still needed in full, keep it.`
+            breakdown += `\n💡 Use \`acp_status\` or review the context above to identify consumed content. Prefer compressing large continuous ranges by work phase — not small incremental steps. Convert verbose tool outputs into concise summaries rather than keeping raw content.`
             if (decision.tipsVariant !== "maxLimit") {
                 breakdown += `\n\n${HOW_TO_COMPRESS_RULES}`
             }

--- a/lib/prompts/system.ts
+++ b/lib/prompts/system.ts
@@ -73,12 +73,10 @@ When context usage passes a threshold, the system appends a breakdown showing wh
 
 Breakdown: 12.3K tool (40%) | 3.1K summaries (10%) | 8.5K code (28%) | 6.5K text (22%)
 
-- "tool" = tool call outputs (largest category — compress first when consumed)
+- "tool" = tool call outputs
 - "summaries" = existing compression block summaries (already compressed; do not re-compress standalone)
 - "code" = messages containing code blocks
 - "text" = plain text messages
 
-Below the breakdown, the system lists the largest ranges in each category (e.g. \`Largest tool outputs: m00175 (20.7K), m00200 (8.1K)\`). These are high-value compression candidates — compress those whose content you have already consumed (extracted the facts you need). Keep any you still need to reference.
-
-Compress incrementally: target one large consumed range per compress call (e.g. m00150–m00200), not the entire context at once. Each compression creates a reusable summary block you can decompress later if needed.
+The breakdown shows where tokens are spent — it is INFORMATION, not a directive. Use \`acp_status\` or review the context above to identify which content you have already consumed. When compressing, prefer large continuous ranges by work phase (e.g. m00150–m00220) rather than small incremental steps — small compressions create overhead that can exceed their savings. Convert verbose tool outputs into concise summaries: most useful content in tool calls should become part of a summary, not kept as raw, lengthy output. Each compression creates a reusable summary block you can decompress later if needed.
 `


### PR DESCRIPTION
## Summary

Fixes the context "memory leak" reported in issue dog/opencode-acp#23: context grows 5%, model compresses only 2%, net positive growth eventually overflows context.

### Root Cause

The nudge injection listed specific message ranges by size (`Largest tool outputs: m00175 (20.7K)`, `Largest code messages`, `Largest text messages`). The model treated these lists as **directives** — compressing by size rather than by need. This caused the leak: grow 5%, compress 2% (the largest items), net +3%.

Analysis of session `ses_0e1951573ffeWOaARblvet5U7s` proved the point: when the model compressed by work phase (user-directed, ignoring ACP's size-based recommendations), compression achieved **93-99% reduction** across 6 blocks (147,975 → 4,121 tokens). The model already has per-message token annotations (`<dcp-message-id tokens="2.1K" type="tool:bash">`) — it does not need ACP to list ranges for it.

### Changes

**`lib/messages/inject/inject.ts`**:
- Removed `Largest tool outputs` / `Largest code messages` / `Largest text messages` range listings from nudge breakdown
- Removed `topRanges` listing from `toolOutputReminder`
- Replaced "Compress incrementally" with need-based guidance: use `acp_status`, prefer large continuous ranges by work phase, convert tool outputs to concise summaries
- Kept: composition ratio breakdown, top-tools ratio, growth signal

**`lib/prompts/system.ts`**:
- Removed "largest category — compress first" size directive from CONTEXT BREAKDOWN
- Replaced with need-based guidance: breakdown is INFORMATION not directive; compress by work phase; tool content should become summaries, not kept raw

### Verification

- `npm run typecheck`: 0 errors
- `npm run test`: 609 tests pass, 0 failures
- Devlog: `devlog/2026-07-11_nudge-remove-recommendations/`

Issue: dog/opencode-acp#23