### PR TITLE
fix: compress baseline set to undefined instead of pre-compression currentTokens

### DIFF
--- a/devlog/2026-07-11_compress-baseline-fix/REQ.md
+++ b/devlog/2026-07-11_compress-baseline-fix/REQ.md
@@ -1,0 +1,27 @@
+# REQ: Fix compress baseline tracking bug
+
+## Problem
+
+When the model calls `compress`, `injectCompressNudges` detected the compress
+and set `lastPerMessageNudgeTokens = currentTokens`. But `currentTokens` comes
+from `getCurrentTokenUsage()` which reads the LAST assistant message's API
+token count — the message that CALLED compress, seeing PRE-compression context.
+
+So if context was 100K before compress and dropped to 50K after, the baseline
+was recorded as 100K. Next transform: `growth = 50K - 100K = -50K`, looking
+like "no growth", so nudges never fired.
+
+The baseline correction logic (`currentTokens < baseline - nudgeGrowthTokens`)
+only fired when compress saved more than `nudgeGrowthTokens` (50K on 1M models).
+Smaller compressions left the baseline stuck at the pre-compression value.
+
+## Solution
+
+Set `lastPerMessageNudgeTokens = undefined` on compress detection. The next
+message-transform run re-establishes the baseline from the real post-compression
+API token count (lines 197-202), without triggering a nudge.
+
+## Files Changed
+
+- `lib/messages/inject/inject.ts` — 3-line fix (compress baseline → undefined)
+- `tests/inject.test.ts` — 3 tests updated for new baseline behavior

--- a/devlog/2026-07-11_compress-baseline-fix/WORKLOG.md
+++ b/devlog/2026-07-11_compress-baseline-fix/WORKLOG.md
@@ -1,0 +1,42 @@
+# WORKLOG: Fix compress baseline tracking bug
+
+## Date: 2026-07-11
+
+## Branch: `2026-07-11_compress-baseline-fix`
+
+## Changes
+
+### `lib/messages/inject/inject.ts` (line 96-98)
+
+Before:
+```ts
+state.nudges.lastPerMessageNudgeTokens = currentTokens
+```
+
+After:
+```ts
+// currentTokens reflects PRE-compression context; baseline must wait
+// for the next API response to capture the real post-compression level.
+state.nudges.lastPerMessageNudgeTokens = undefined
+```
+
+### `tests/inject.test.ts` — 3 tests updated
+
+1. **Renamed**: "after compress, baseline cleared to undefined for re-establishment"
+   - Was: asserts `lastPerMessageNudgeTokens === 250_000`
+   - Now: asserts `lastPerMessageNudgeTokens === undefined`
+
+2. **Renamed**: "post-compress baseline re-establishment then small growth does NOT re-nudge"
+   - Turn 1: compress → baseline = undefined
+   - Turn 2: baseline established from post-compression API tokens → no nudge
+
+3. **Renamed**: "post-compress baseline re-establishment then large growth DOES nudge"
+   - Now a 3-turn sequence:
+     - Turn 1: compress → baseline = undefined
+     - Turn 2: baseline established (305K) → no nudge
+     - Turn 3: growth to 361K (56K > 50K threshold) → nudge
+
+## Verification
+
+- `npm run typecheck`: 0 errors
+- `npm run test`: 619 tests pass, 0 failures

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -93,7 +93,9 @@ export const injectCompressNudges = (
         state.nudges.contextLimitAnchors.clear()
         state.nudges.turnNudgeAnchors.clear()
         state.nudges.iterationNudgeAnchors.clear()
-        state.nudges.lastPerMessageNudgeTokens = currentTokens
+        // currentTokens reflects PRE-compression context; baseline must wait
+        // for the next API response to capture the real post-compression level.
+        state.nudges.lastPerMessageNudgeTokens = undefined
         saveSessionState(state, logger).catch(() => {})
         return
     }

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -93,9 +93,10 @@ export const injectCompressNudges = (
         state.nudges.contextLimitAnchors.clear()
         state.nudges.turnNudgeAnchors.clear()
         state.nudges.iterationNudgeAnchors.clear()
-        // currentTokens reflects PRE-compression context; baseline must wait
+        // currentTokens reflects PRE-compression context; baselines must wait
         // for the next API response to capture the real post-compression level.
         state.nudges.lastPerMessageNudgeTokens = undefined
+        state.nudges.lastToolOutputNudgeTokens = undefined
         saveSessionState(state, logger).catch(() => {})
         return
     }

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -326,6 +326,97 @@ test("injectCompressNudges: post-compress baseline re-establishment then large g
     assert.equal(state.nudges.lastPerMessageNudgeTokens, 361_000)
 })
 
+test("injectCompressNudges: after compress, tool-output baseline cleared to undefined for re-establishment", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    const config = buildConfig()
+    config.compress.maxContextLimit = 800_000
+    config.compress.minContextLimit = 550_000
+
+    // Turn 1: seed tool-output baseline (~15K tokens from 60K chars)
+    const turn1: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 50_000 }, [
+            toolPart("t1", "x".repeat(60_000)),
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, turn1, {} as any)
+    assert.ok(
+        state.nudges.lastToolOutputNudgeTokens !== undefined,
+        "tool-output baseline must be seeded before compress",
+    )
+
+    // Turn 2: compress detected → tool-output baseline cleared to undefined
+    const turn2: WithParts[] = [
+        userMsg("u2", "compress now"),
+        assistantMsgWithTokens("a2", "compressed", { input: 200_000, output: 50_000 }, [
+            compressToolPart("c1", "compressed"),
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, turn2, {} as any)
+
+    assert.equal(
+        state.nudges.lastToolOutputNudgeTokens,
+        undefined,
+        "lastToolOutputNudgeTokens must be undefined after compress — composition.toolTokens reflects pre-compression context, not post-compression",
+    )
+})
+
+test("injectCompressNudges: post-compress tool-output baseline re-establishment then large growth DOES fire reminder", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    const config = buildConfig()
+    config.compress.maxContextLimit = 800_000
+    config.compress.minContextLimit = 550_000
+
+    // Turn 1: seed tool-output baseline
+    const turn1: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 50_000 }, [
+            toolPart("t1", "x".repeat(60_000)),
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, turn1, {} as any)
+
+    // Turn 2: compress → tool-output baseline cleared
+    const turn2: WithParts[] = [
+        userMsg("u2", "compress now"),
+        assistantMsgWithTokens("a2", "compressed", { input: 200_000, output: 50_000 }, [
+            compressToolPart("c1", "compressed"),
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, turn2, {} as any)
+    assert.equal(state.nudges.lastToolOutputNudgeTokens, undefined)
+
+    // Turn 3: baseline re-established from post-compression tool tokens (~5K from 20K chars), no reminder
+    const turn3: WithParts[] = [
+        userMsg("u3", "next"),
+        assistantMsgWithTokens("a3", "response", { input: 100_000, output: 10_000 }, [
+            toolPart("t2", "x".repeat(20_000)),
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, turn3, {} as any)
+    assert.ok(
+        state.nudges.lastToolOutputNudgeTokens !== undefined,
+        "tool-output baseline re-established from post-compression composition",
+    )
+    const reestablished = state.nudges.lastToolOutputNudgeTokens
+
+    // Turn 4: large tool growth (~70K from 280K chars) → growth 65K > 50K threshold → reminder fires
+    const turn4: WithParts[] = [
+        userMsg("u4", "more"),
+        assistantMsgWithTokens("a4", "response", { input: 100_000, output: 10_000 }, [
+            toolPart("t3", "x".repeat(280_000)),
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, turn4, {} as any)
+    assert.notEqual(
+        state.nudges.lastToolOutputNudgeTokens,
+        reestablished,
+        "large tool growth >= 50K adaptive threshold after re-establishment — reminder must fire and advance baseline",
+    )
+})
+
 test("injectCompressNudges persists new nudge baseline to disk when a growth nudge fires without anchor changes (#60)", async () => {
     await cleanupPersistSession()
 

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -233,7 +233,7 @@ test("createSyntheticUserMessage produces an all-synthetic user message that ens
     )
 })
 
-test("injectCompressNudges: after compress, lastPerMessageNudgeTokens = currentTokens (not 0)", () => {
+test("injectCompressNudges: after compress, baseline cleared to undefined for re-establishment", () => {
     const state = createSessionState()
     state.modelContextLimit = 1_000_000
     const config = buildConfig()
@@ -249,18 +249,19 @@ test("injectCompressNudges: after compress, lastPerMessageNudgeTokens = currentT
 
     assert.equal(
         state.nudges.lastPerMessageNudgeTokens,
-        250_000,
-        "lastPerMessageNudgeTokens must equal currentTokens (250K) after compress — NOT 0",
+        undefined,
+        "lastPerMessageNudgeTokens must be undefined after compress — currentTokens reflects pre-compression context, not post-compression",
     )
 })
 
-test("injectCompressNudges: post-compress small growth does NOT re-nudge", () => {
+test("injectCompressNudges: post-compress baseline re-establishment then small growth does NOT re-nudge", () => {
     const state = createSessionState()
     state.modelContextLimit = 1_000_000
     const config = buildConfig()
     config.compress.maxContextLimit = 800_000
     config.compress.minContextLimit = 550_000
 
+    // Turn 1: compress detected → baseline cleared to undefined
     const turn1: WithParts[] = [
         userMsg("u1", "hello"),
         assistantMsgWithTokens("a1", "done", { input: 200_000, output: 50_000 }, [
@@ -268,8 +269,9 @@ test("injectCompressNudges: post-compress small growth does NOT re-nudge", () =>
         ]),
     ]
     injectCompressNudges(state, config, logger, turn1, {} as any)
-    assert.equal(state.nudges.lastPerMessageNudgeTokens, 250_000)
+    assert.equal(state.nudges.lastPerMessageNudgeTokens, undefined)
 
+    // Turn 2: baseline re-established from post-compression API tokens, no nudge
     const turn2: WithParts[] = [
         userMsg("u2", "next"),
         assistantMsgWithTokens("a2", "response", { input: 247_000, output: 6_000 }),
@@ -279,11 +281,11 @@ test("injectCompressNudges: post-compress small growth does NOT re-nudge", () =>
     assert.equal(
         state.nudges.shouldInjectThisTurn,
         false,
-        "only 3K growth after compress (< 50K adaptive threshold) — should NOT nudge",
+        "baseline re-establishment turn — should NOT nudge",
     )
 })
 
-test("injectCompressNudges: post-compress large growth DOES nudge", () => {
+test("injectCompressNudges: post-compress baseline re-establishment then large growth DOES nudge", () => {
     const state = createSessionState()
     state.modelContextLimit = 1_000_000
     const config = buildConfig()
@@ -300,16 +302,28 @@ test("injectCompressNudges: post-compress large growth DOES nudge", () => {
 
     const turn2: WithParts[] = [
         userMsg("u2", "next"),
-        assistantMsgWithTokens("a2", "response", { input: 250_000, output: 55_000 }),
+        assistantMsgWithTokens("a2", "baseline", { input: 250_000, output: 55_000 }),
     ]
     injectCompressNudges(state, config, logger, turn2, {} as any)
+    assert.equal(
+        state.nudges.shouldInjectThisTurn,
+        false,
+        "baseline establishment turn — should NOT nudge",
+    )
+    assert.equal(state.nudges.lastPerMessageNudgeTokens, 305_000)
+
+    const turn3: WithParts[] = [
+        userMsg("u3", "more"),
+        assistantMsgWithTokens("a3", "growth", { input: 356_000, output: 5_000 }),
+    ]
+    injectCompressNudges(state, config, logger, turn3, {} as any)
 
     assert.equal(
         state.nudges.shouldInjectThisTurn,
         true,
-        "55K growth after compress (> 50K adaptive threshold) — should nudge",
+        "56K growth after baseline re-establishment (> 50K adaptive threshold) — should nudge",
     )
-    assert.equal(state.nudges.lastPerMessageNudgeTokens, 305_000)
+    assert.equal(state.nudges.lastPerMessageNudgeTokens, 361_000)
 })
 
 test("injectCompressNudges persists new nudge baseline to disk when a growth nudge fires without anchor changes (#60)", async () => {


### PR DESCRIPTION
## Summary

Fixes a bug where `lastPerMessageNudgeTokens` was set to `currentTokens` when compress was detected, but `currentTokens` reflects the **pre-compression** context (it comes from the assistant message that called compress).

**Before**: Context 100K → compress to 50K → baseline recorded as 100K → growth = 50K - 100K = -50K → nudges never fire.

**After**: Context 100K → compress to 50K → baseline = undefined → next transform re-establishes baseline from real post-compression API tokens → nudges work correctly.

## Root Cause

`inject.ts:98` set `lastPerMessageNudgeTokens = currentTokens` on compress detection. `currentTokens` comes from `getCurrentTokenUsage()` which reads the last assistant message's API token count — the message that called compress, seeing pre-compression context.

The baseline correction logic (`currentTokens < baseline - nudgeGrowthTokens`) only fired when compress saved more than `nudgeGrowthTokens` (50K on 1M models). Smaller compressions left the baseline stuck at the pre-compression value.

## Fix

Set `lastPerMessageNudgeTokens = undefined` on compress detection. The next message-transform run re-establishes the baseline from the real post-compression API token count (existing lines 197-202), without triggering a nudge.

## Test Changes

3 tests in `inject.test.ts` updated for the new 2-phase baseline behavior:
1. Baseline assertion: `250_000` → `undefined` after compress
2. Small-growth test: now tests baseline re-establishment (no nudge)
3. Large-growth test: now a 3-turn sequence (compress → establish → growth → nudge)

## Verification

- `npm run typecheck`: 0 errors
- `npm run test`: 619 tests pass, 0 failures

Issue: dog/opencode-acp#23