### PR TITLE
chore: bump version to 1.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.11.0",
+    "version": "1.11.1",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 1.11.1 in `package.json`
- Tag `v1.11.1` already pushed (points to this commit)
- npm package already published as `opencode-acp@1.11.1`

## What's included in v1.11.1
1. **`lastPerMessageNudgeTokens`** — clear to `undefined` on compress (PR #99)
2. **`lastToolOutputNudgeTokens`** — clear to `undefined` on compress (additional fix in PR #99)
3. 2 new tests for tool-output baseline clearing + re-establishment

## Why this PR
The version bump was committed directly to local master but GitHub branch protection prevented direct push. Creating this PR to properly merge the version bump commit to GitHub master.

## Verification
- `npm view opencode-acp version` → `1.11.1` ✓
- `npm run typecheck`: 0 errors ✓
- `npm run test`: 621 tests pass ✓
- `npm run check:package`: passed ✓
- Pre-publish checklist (AGENTS.md Section 5.4) completed ✓