### PR TITLE
release: v1.11.1 — version bump + changelog + devlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,16 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.11.1 — Compress Baseline Fix (PR #99)
+
+**Problem**: When the model called `compress`, both `lastPerMessageNudgeTokens` and `lastToolOutputNudgeTokens` were set to `currentTokens` — the token count from the compress-calling assistant message, which reflects **pre-compression** context. After compressing 100K→50K, the baseline was stuck at 100K, so `growth = 50K - 100K = -50K` and nudges never fired again.
+
+**Fix**: Both baselines are now set to `undefined` on compress detection. The next message-transform run re-establishes the baseline from the real post-compression API token count, without triggering a nudge (`computeShouldNudge` returns `shouldNudge: false` when baseline is `undefined`).
+
+Files: `lib/messages/inject/inject.ts` (line 98-99). Tests: `tests/inject.test.ts` — 3 updated + 2 new (621 total, 0 fail).
+
+---
+
 ### v1.11.0 — Tool-Result Recap Injection, Context Breakdown & Fork Rebuild
 
 This release fixes two critical compression-injection bugs (#20 echo, #78 drift), adds a visible context breakdown to `acp_status`, and introduces a fork-rebuild mechanism.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -395,6 +395,16 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.11.1 — 压缩基线修复（PR #99）
+
+**问题**：当模型调用 `compress` 时，`lastPerMessageNudgeTokens` 和 `lastToolOutputNudgeTokens` 都被设为 `currentTokens` —— 这是调用 compress 的 assistant 消息的 token 计数，反映的是**压缩前**的上下文。压缩 100K→50K 后，基线卡在 100K，导致 `growth = 50K - 100K = -50K`，nudge 永远不再触发。
+
+**修复**：压缩时将两个基线都设为 `undefined`。下一次 message-transform 运行时从真实的压缩后 API token 计数重建基线，不会误触发 nudge（`computeShouldNudge` 在基线为 `undefined` 时返回 `shouldNudge: false`）。
+
+文件：`lib/messages/inject/inject.ts`（第 98-99 行）。测试：`tests/inject.test.ts` — 3 个更新 + 2 个新增（共 621 个测试，0 失败）。
+
+---
+
 ### v1.11.0 — 工具结果注入、上下文分解 & Fork 重建
 
 本次发布修复了两个关键压缩注入 bug（#20 复读、#78 漂移），为 `acp_status` 添加了可见上下文分解，并引入了 fork 重建机制。

--- a/devlog/2026-07-11_release-v1.11.1/REQ.md
+++ b/devlog/2026-07-11_release-v1.11.1/REQ.md
@@ -1,0 +1,39 @@
+# REQ - Release v1.11.1
+
+- Task ID: `2026-07-11_release-v1.11.1`
+- Home Repo: `opencode-acp`
+- Created: 2026-07-11
+- Status: Done
+- Priority: P0
+- Owner: awork
+- References: PR #99, PR #102 (closed), issue #25
+
+## 1. Background & Problem Statement
+
+- **Context**: PR #99 fixed a compress baseline bug where `lastPerMessageNudgeTokens` and `lastToolOutputNudgeTokens` were set to pre-compression `currentTokens` instead of being cleared to `undefined`. The fix was merged to master.
+- **Current behavior**: npm registry has v1.11.1 published, but GitHub master still shows v1.11.0 because the version bump commit was made directly to local master and GitHub branch protection blocked the push.
+- **Expected behavior**: GitHub master should have `package.json` version `1.11.1`, matching the npm registry. README changelog should document v1.11.1 changes. Devlog should exist per AGENTS.md Section 5.1.2.
+- **Impact**: Repo/registry version mismatch. Missing changelog and devlog violates AGENTS.md contributing standards.
+
+## 2. Constraints & Non-Goals
+
+- **Constraints**:
+  - Must follow AGENTS.md Section 5.1.1 workflow (feature branch, devlog, PR)
+  - Branch naming: `YYYY-MM-DD_short-title`
+  - Devlog folder name must match branch name
+  - README changelog must be updated in both English and Chinese
+- **Non-Goals**:
+  - No code changes (only version bump + documentation)
+  - No npm republish (v1.11.1 already correct on registry)
+
+## 3. Acceptance Criteria
+
+- **Correctness**:
+  - [x] `package.json` version is `1.11.1`
+  - [x] `devlog/2026-07-11_release-v1.11.1/REQ.md` exists
+  - [x] `devlog/2026-07-11_release-v1.11.1/WORKLOG.md` exists
+  - [x] README.md has v1.11.1 changelog entry
+  - [x] README.zh-CN.md has v1.11.1 changelog entry
+  - [x] Branch name follows `YYYY-MM-DD_short-title` convention
+- **Regression**:
+  - [x] No code changes, no tests affected

--- a/devlog/2026-07-11_release-v1.11.1/WORKLOG.md
+++ b/devlog/2026-07-11_release-v1.11.1/WORKLOG.md
@@ -1,0 +1,70 @@
+# WORKLOG - Release v1.11.1
+
+- Task ID: `2026-07-11_release-v1.11.1`
+- Home Repo: `opencode-acp`
+- Status: Done
+- Updated: 2026-07-11 17:30
+
+## 1. Summary
+
+- **What was done**: Version bump to 1.11.1, README changelog update (EN + ZH), devlog entry creation. Released via PR after fixing AGENTS.md compliance issues identified in issue #25 review.
+- **Why**: v1.11.1 was already published to npm but GitHub master was not synced (branch protection blocked direct push). Initial PR #102 was missing devlog and changelog per AGENTS.md requirements.
+- **Behavior / compatibility changes**: No
+- **Risk level**: Low
+
+## 2. Change Log
+
+### Commits
+
+| Commit | Description |
+|--------|-------------|
+| `c39c42d` | chore: bump version to 1.11.1 |
+| (this commit) | docs: add v1.11.1 changelog + devlog entry |
+
+### Key Files
+
+- `package.json` — version bumped from 1.11.0 to 1.11.1
+- `README.md` — added v1.11.1 changelog entry (English)
+- `README.zh-CN.md` — added v1.11.1 changelog entry (Chinese)
+- `devlog/2026-07-11_release-v1.11.1/REQ.md` — requirement document
+- `devlog/2026-07-11_release-v1.11.1/WORKLOG.md` — this file
+
+## 3. What v1.11.1 Contains
+
+Two bug fixes from PR #99 (`2026-07-11_compress-baseline-fix`):
+
+1. **`lastPerMessageNudgeTokens`** — On compress detection, set to `undefined` instead of `currentTokens`. The old value reflected pre-compression context (from the compress-calling assistant message), causing `growth = postCompress - preCompress < 0`, so nudges never fired after compress.
+
+2. **`lastToolOutputNudgeTokens`** — Same bug, same fix. Not cleared on compress, stayed at stale pre-compression value, delaying tool-output reminder nudges until tool tokens exceeded the stale baseline + threshold.
+
+Both fixes use the same 2-phase pattern: compress → set `undefined` → next transform re-establishes baseline from real post-compression API token count.
+
+Tests: 2 new tests added (`tests/inject.test.ts`) for tool-output baseline clearing + re-establishment. 3 existing tests updated for per-message baseline. Total: 621 tests pass.
+
+## 4. Testing & Verification
+
+### Build & Test Commands
+
+```sh
+npm run typecheck     # 0 errors
+npm run test          # 621 tests pass, 0 fail
+npm run check:package # build + verify passed
+```
+
+### Results
+
+- **PASS**: All checks passed
+- npm registry: `opencode-acp@1.11.1` verified via `npm view opencode-acp version`
+- Local deploy: deployed to `~/.cache/opencode/packages/opencode-acp@latest/`
+
+## 5. Process Issues Identified
+
+- Initial version bump was committed directly to local master, bypassing the PR workflow (AGENTS.md Section 5.1.1)
+- GitHub branch protection correctly blocked the direct push
+- PR #102 was created but missing devlog (Section 5.1.2) and README changelog
+- This PR fixes all compliance issues
+
+## 6. Follow-ups
+
+- [ ] After merge: verify GitHub master shows version 1.11.1
+- [ ] After merge: sync local master with GitHub master

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.11.0",
+    "version": "1.11.1",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 1.11.1 in `package.json`
- Add v1.11.1 changelog to `README.md` (English) and `README.zh-CN.md` (Chinese)
- Create devlog entry `devlog/2026-07-11_release-v1.11.1/` (REQ.md + WORKLOG.md)

## What v1.11.1 Contains
Two bug fixes from PR #99 (`2026-07-11_compress-baseline-fix`):
1. **`lastPerMessageNudgeTokens`** — cleared to `undefined` on compress (was set to pre-compression `currentTokens`, causing nudges to never fire after compress)
2. **`lastToolOutputNudgeTokens`** — same bug, same fix (not cleared on compress, delayed tool-output reminders)

Tests: 621 pass, 0 fail. TypeScript: 0 errors.

## AGENTS.md Compliance
- [x] Branch naming: `YYYY-MM-DD_short-title`
- [x] Devlog: `devlog/2026-07-11_release-v1.11.1/` with REQ.md + WORKLOG.md
- [x] Changelog: README.md + README.zh-CN.md
- [x] npm package already published (v1.11.1 on registry)
- [x] Tag `v1.11.1` already pushed

## Verification
- `npm run typecheck`: 0 errors
- `npm run test`: 621 tests pass
- `npm view opencode-acp version` → `1.11.1`