### PR TITLE
test: version bump without changelog (should fail CI)

### DIFF
--- a/devlog/2026-07-11_test-no-changelog/REQ.md
+++ b/devlog/2026-07-11_test-no-changelog/REQ.md
@@ -1,0 +1,1 @@
+# REQ - test

--- a/devlog/2026-07-11_test-no-changelog/WORKLOG.md
+++ b/devlog/2026-07-11_test-no-changelog/WORKLOG.md
@@ -1,0 +1,1 @@
+# WORKLOG - test

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.11.1",
+    "version": "1.11.2-test",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
Test PR — version bumped to 1.11.2-test but no changelog update. PR Checks should fail.