### PR TITLE
ci: auto-tag on release branch merge

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,46 @@
+name: Auto-Tag
+
+on:
+    push:
+        branches: [master]
+
+jobs:
+    auto-tag:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Check if release branch was merged
+              id: check
+              run: |
+                  MERGE_MSG=$(git log -1 --pretty=%B)
+                  echo "Commit message: $MERGE_MSG"
+
+                  if echo "$MERGE_MSG" | grep -qE 'Merge pull request #[0-9]+ from .*[0-9]{4}-[0-9]{2}-[0-9]{2}_release-v'; then
+                      echo "is_release=true" >> "$GITHUB_OUTPUT"
+                      echo "Release branch detected"
+                  else
+                      echo "is_release=false" >> "$GITHUB_OUTPUT"
+                      echo "Not a release branch merge — skipping"
+                  fi
+
+            - name: Create tag from package.json version
+              if: steps.check.outputs.is_release == 'true'
+              run: |
+                  VERSION=$(node -p "require('./package.json').version")
+                  TAG="v${VERSION}"
+
+                  if git rev-parse "$TAG" >/dev/null 2>&1; then
+                      echo "Tag $TAG already exists — skipping"
+                      exit 0
+                  fi
+
+                  echo "Creating tag $TAG"
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git tag -a "$TAG" -m "release $TAG (auto-tagged on merge)"
+                  git push origin "$TAG"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -566,94 +566,136 @@ All source code changes (files under `lib/`) MUST undergo independent review by 
 | **Type safety**            | No `as any`, no `@ts-ignore`, no type assertion hacks                                        |
 | **State integrity**        | State mutations are safe, no lost data on save/load cycle                                    |
 
-### 5.4 Pre-Publish Checklist (MANDATORY)
+### 5.4 Release Workflow (Automated via CI)
 
-Before every `npm publish`, ALL of the following steps MUST be executed **in order**.
+Releases are **fully automated through GitHub Actions**. The workflow is: create a release PR → merge → CI auto-tags → CI auto-builds, tests, and publishes to npm. No manual `npm publish` or `git tag` needed.
 
-**Step 0: Git state (MUST pass before anything else)**
+#### 5.4.1 CI Workflows
+
+Three GitHub Actions workflows enforce AGENTS.md standards and automate releases:
+
+**`pr-checks.yml`** — runs on every PR to master:
+
+| Check | What it validates | Script |
+|-------|------------------|--------|
+| Branch name | Matches `YYYY-MM-DD_short-title` (regex: `^\d{4}-\d{2}-\d{2}_[a-z0-9.-]+$`) | `scripts/ci/check-pr.sh` |
+| Devlog | `devlog/{branch-name}/REQ.md` and `WORKLOG.md` exist | same |
+| Changelog | If `package.json` version changed, `README.md` and `README.zh-CN.md` must be modified and contain `### v{VERSION}` | same |
+
+**`auto-tag.yml`** — triggers on push to master (PR merge):
+
+1. Checks if the merge commit came from a release branch (`YYYY-MM-DD_release-v*`)
+2. If yes, reads `package.json` version and creates `v{VERSION}` tag
+3. Only triggers on release branches — normal branches that accidentally change version are ignored
+
+**`release.yml`** — triggers on `v*` tag push (auto-tagged by `auto-tag.yml` or manually pushed):
+
+1. `npm ci` — install dependencies
+2. `npm run check:package` — build + verify package contents
+3. `npm test` — run full test suite
+4. `npm publish` — publish to npm registry (uses `NPM_TOKEN` secret)
+5. Create GitHub Release with auto-generated notes
+
+#### 5.4.2 Release Process (Step-by-Step)
+
+**Step 1: Create a release branch**
 
 ```bash
-# 1. Clean working tree — no uncommitted changes
-git status --porcelain
-# MUST output nothing. If not: commit or stash first.
-
-# 2. On master branch
-git branch --show-current
-# MUST output "master". If not: git checkout master
-
-# 3. Local synced with remote
-git fetch origin && git status
-# MUST show "Your branch is up to date with 'origin/master'".
-# If behind: git pull
-# If ahead: git push first
+git checkout master
+git pull origin master
+git checkout -b YYYY-MM-DD_release-v{VERSION}
 ```
 
-| Check              | Expected                                 | Fix if failed                      |
-| ------------------ | ---------------------------------------- | ---------------------------------- |
-| Clean working tree | `git status --porcelain` outputs nothing | Commit or stash changes            |
-| On master          | `git branch --show-current` = `master`   | `git checkout master`              |
-| Local = remote     | `git status` shows up-to-date            | `git pull` or `git push` as needed |
+The branch name MUST match `YYYY-MM-DD_release-v{VERSION}` for auto-tagging to work (e.g., `2026-07-11_release-v1.11.2`).
 
-**If ANY git check fails: STOP. Do NOT proceed to Step 1.**
-
-**Step 1: Automated verification**
+**Step 2: Bump version + update changelog + devlog**
 
 ```bash
-npm run check:package    # build + verify-package.mjs
+# Edit package.json — bump version
+# Edit README.md — add changelog entry under "## Changelog"
+# Edit README.zh-CN.md — add changelog entry under "## 更新日志"
+# Create devlog/YYYY-MM-DD_release-v{VERSION}/REQ.md + WORKLOG.md
 ```
 
-This runs `verify-package.mjs` which checks:
+Changelog format:
 
-- Required files exist (`dist/index.js`, `dist/index.d.ts`, `README.md`, `LICENSE`)
-- `package.json` shape is correct (`main`, `exports`, `files`)
-- Runtime import graph has no CommonJS dependencies
-- `npm pack --dry-run` contains no forbidden paths
+```markdown
+### v{VERSION} — Title (PR #NNN)
 
-**Step 2: Privacy / Security audit (MANUAL)**
+**Problem**: What was wrong.
+**Fix**: What changed.
+Files: `path/to/file.ts`. Tests: `tests/file.test.ts`.
+```
+
+**Step 3: Verify locally, commit, push, create PR**
 
 ```bash
-# Inspect what will actually be published
+# Verify CI checks pass locally
+./scripts/ci/check-pr.sh YYYY-MM-DD_release-v{VERSION} origin/master
+
+# Commit
+git add -A
+git commit -m "release: v{VERSION} — title"
+git push origin YYYY-MM-DD_release-v{VERSION}
+
+# Create PR (CI will run pr-checks.yml + ci.yml)
+gh pr create --title "release: v{VERSION} — title" --body "..."
+```
+
+**Step 4: Merge PR (requires human confirmation)**
+
+Wait for CI to pass (`pr-validation`, `test`, `build`), then a human merges the PR.
+
+**Step 5: Auto-tag + auto-publish (fully automated)**
+
+Merging the PR triggers the following chain automatically — no manual action needed:
+
+1. Push to master → `auto-tag.yml` detects release branch merge → creates `v{VERSION}` tag
+2. Tag push → `release.yml` runs → builds, tests, publishes to npm → creates GitHub Release
+
+**Step 6: Verify**
+
+```bash
+# Check npm registry
+npm view opencode-acp version
+
+# Check GitHub Release
+gh release view v{VERSION} --repo ranxianglei/opencode-acp
+```
+
+#### 5.4.3 Prerequisites
+
+- **`NPM_TOKEN` secret** must be set in GitHub repo settings (Settings → Secrets → Actions). Create an "Automation" type token at https://www.npmjs.com/settings/ranxianglei/tokens.
+- **GitHub branch protection** on `master` must require `pr-validation` check to pass before merge.
+- **Release branch naming** must follow `YYYY-MM-DD_release-v{VERSION}` for auto-tagging to trigger.
+
+#### 5.4.4 Manual Publish (Legacy Fallback)
+
+If CI is down or `NPM_TOKEN` is misconfigured, publish manually as a fallback:
+
+```bash
+# 0. Ensure clean state on master
+git checkout master && git pull origin master
+git status --porcelain  # MUST be empty
+
+# 1. Build + verify
+npm run check:package
+
+# 2. Privacy audit
 npm pack --dry-run 2>&1
-
-# Scan for secrets in the tarball
 npm pack && tar -tf opencode-acp-*.tgz | grep -iE '\.env|secret|credential|token|key|\.pem|\.key'
 rm opencode-acp-*.tgz
-```
 
-| Check                               | What to verify                                                                          |
-| ----------------------------------- | --------------------------------------------------------------------------------------- |
-| **`files` field**                   | Only contains `dist/`, `README.md`, `LICENSE` — no source, tests, configs, or dev files |
-| **No secrets in tarball**           | No API keys, tokens, passwords, or credentials in any packed file                       |
-| **`.git/config` not packed**        | Verify `.git/` is excluded (contains OAuth token in remote URL)                         |
-| **No hardcoded secrets in `dist/`** | Grep `dist/` for patterns like `sk-`, `gho_`, `api_key`, `apiKey`, `password`           |
-| **`.npmignore` is current**         | Explicitly excludes `AGENTS.md`, `devlog/`, `tests/`, `scripts/`, `.github/`, `.git/`   |
-| **Version bumped**                  | `package.json` version matches the intended release version                             |
-
-**Step 3: Content review**
-
-After `npm pack --dry-run`, visually verify:
-
-1. Only `dist/*.js`, `dist/*.d.ts`, `dist/*.map`, `README.md`, `LICENSE`, `package.json` appear
-2. No `lib/`, `tests/`, `scripts/`, `devlog/`, `AGENTS.md`, `.github/`, `tsconfig.json`, etc.
-3. `dist/` bundle does not contain hardcoded API keys or internal URLs
-
-**Step 4: Tag and publish**
-
-```bash
-# Tag FIRST — if publish fails, the tag marks the attempt
+# 3. Tag + publish
 git tag -a "v{VERSION}" -m "release v{VERSION}"
 git push origin "v{VERSION}"
-
-# Then publish
 npm publish
 
-# Verify
+# 4. Verify
 npm view opencode-acp version
 ```
 
-**Tag BEFORE publish.** If `npm publish` fails, the tag documents the intended version. Do NOT tag after — that risks forgetting if publish succeeds.
-
-**If any check in Steps 0–3 fails: DO NOT PUBLISH.** Fix the issue first.
+Only use this as a fallback. The automated workflow (Section 5.4.2) is the standard release process.
 
 ### 5.5 Commit Convention
 

--- a/devlog/2026-07-11_auto-tag-on-merge/REQ.md
+++ b/devlog/2026-07-11_auto-tag-on-merge/REQ.md
@@ -1,0 +1,26 @@
+# REQ - Auto-Tag on Release Branch Merge
+
+- Task ID: `2026-07-11_auto-tag-on-merge`
+- Home Repo: `opencode-acp`
+- Created: 2026-07-11
+- Status: Done
+- Priority: P0
+- Owner: awork
+
+## 1. Background
+
+Current release flow requires manual `git tag` + `git push origin v*` after merging a release PR. This is error-prone (easy to forget) and adds an unnecessary manual step.
+
+## 2. Solution
+
+Add `auto-tag.yml` workflow: on push to master, if the merge commit came from a `YYYY-MM-DD_release-v*` branch, automatically read `package.json` version and push `v{VERSION}` tag. The tag push then triggers `release.yml` for auto-publish.
+
+Only release branches trigger auto-tagging. Normal branches that accidentally change `package.json` version are ignored.
+
+## 3. Acceptance Criteria
+
+- [x] `auto-tag.yml` workflow created
+- [x] Only triggers on release branch merges (`YYYY-MM-DD_release-v*`)
+- [x] Reads version from `package.json`, creates `v{VERSION}` tag
+- [x] Skips if tag already exists
+- [x] AGENTS.md Section 5.4 updated with auto-tag documentation

--- a/devlog/2026-07-11_auto-tag-on-merge/WORKLOG.md
+++ b/devlog/2026-07-11_auto-tag-on-merge/WORKLOG.md
@@ -1,0 +1,22 @@
+# WORKLOG - Auto-Tag on Release Branch Merge
+
+- Task ID: `2026-07-11_auto-tag-on-merge`
+- Home Repo: `opencode-acp`
+- Status: Done
+- Updated: 2026-07-11 18:30
+
+## 1. Summary
+
+Added `auto-tag.yml` GitHub Actions workflow that automatically creates a version tag when a release branch (`YYYY-MM-DD_release-v*`) is merged to master. The tag then triggers `release.yml` for auto-publish. Also updated AGENTS.md Section 5.4 with full auto-tag documentation.
+
+## 2. Change Log
+
+- `.github/workflows/auto-tag.yml` — new workflow: detects release branch merge, reads package.json version, creates tag
+- `AGENTS.md` Section 5.4 — rewritten with auto-tag flow (supersedes PR #109)
+- `devlog/2026-07-11_auto-tag-on-merge/` — REQ.md + WORKLOG.md
+
+## 3. Pipeline Flow
+
+1. Release PR created → `pr-checks.yml` validates (branch name, devlog, changelog)
+2. Release PR merged → `auto-tag.yml` creates `v{VERSION}` tag
+3. Tag pushed → `release.yml` runs → build + test + publish + GitHub Release


### PR DESCRIPTION
## Summary

Automates the last manual step in the release flow: pushing the version tag.

### New: `auto-tag.yml` workflow

When a PR from a **release branch** (`YYYY-MM-DD_release-v*`) is merged to master:
1. Detects release branch merge from commit message
2. Reads version from `package.json`
3. Creates and pushes `v{VERSION}` tag
4. Tag push triggers `release.yml` → auto-publish to npm

**Only release branches trigger auto-tagging.** Normal branches that accidentally change `package.json` version are ignored.

### AGENTS.md Update

Section 5.4 rewritten with full automated pipeline documentation (supersedes PR #109).

### Release Flow (After This PR)

```
Create release branch → PR → merge
  ↓ auto-tag.yml (detects release branch)
  ↓ creates v{VERSION} tag
  ↓ release.yml (triggered by tag)
  ↓ npm ci → check:package → test → npm publish → GitHub Release
```

Fully automated. No manual `git tag` or `npm publish` needed.

### Also: Close PR #109

This PR supersedes PR #109 (AGENTS.md docs) — it includes the same documentation plus the auto-tag workflow.

## AGENTS.md Compliance
- [x] Branch: `2026-07-11_auto-tag-on-merge`
- [x] Devlog: `devlog/2026-07-11_auto-tag-on-merge/` (REQ.md + WORKLOG.md)