### PR TITLE
fix: persist baseline re-establishment + fix async save race condition

### DIFF
--- a/devlog/2026-07-11_baseline-persistence-fix/REQ.md
+++ b/devlog/2026-07-11_baseline-persistence-fix/REQ.md
@@ -1,0 +1,26 @@
+# REQ: Persist baseline re-establishment + fix async save race condition
+
+## Problem
+
+After PR #99 fixed the baseline bug (compress sets `lastPerMessageNudgeTokens = undefined`),
+a follow-up issue was discovered: the baseline is re-established in memory on the next
+transform, but **never persisted to disk** because the save condition
+(`anchorsChanged || decision.shouldNudge`) is false on the re-establishment turn.
+
+After restart, the on-disk state still has `lastPerMessageNudgeTokens: null`, so nudges
+never fire again.
+
+Additionally, a race condition was found in `writePersistedSessionState`: the file path
+was resolved AFTER `await ensureStorageDir`, by which point `XDG_DATA_HOME` may have
+changed (especially in tests that switch temp dirs between cases).
+
+## Solution
+
+1. Add `baselineReEstablished` flag — set when baseline transitions from `undefined` to
+   a real value. Include in the save condition.
+2. Capture file path synchronously before any `await` in `writePersistedSessionState`.
+
+## Files Changed
+
+- `lib/messages/inject/inject.ts` — `baselineReEstablished` flag + save condition
+- `lib/state/persistence.ts` — capture file path before await (race condition fix)

--- a/devlog/2026-07-11_baseline-persistence-fix/WORKLOG.md
+++ b/devlog/2026-07-11_baseline-persistence-fix/WORKLOG.md
@@ -1,0 +1,33 @@
+# WORKLOG: Persist baseline re-establishment + fix async save race condition
+
+## Date: 2026-07-11
+
+## Branch: `2026-07-11_baseline-persistence-fix`
+
+## Changes
+
+### `lib/messages/inject/inject.ts`
+
+Added `baselineReEstablished` flag:
+- Set to `true` when `lastPerMessageNudgeTokens` transitions from `undefined` to a real value (lines 200-206)
+- Added to save condition (line 319): `if (anchorsChanged || decision.shouldNudge || baselineReEstablished)`
+
+### `lib/state/persistence.ts`
+
+Fixed race condition in `writePersistedSessionState`:
+- Before: `await ensureStorageDir(logger)` then `getSessionFilePath(sessionId)` — path resolved after await
+- After: `const filePath = getSessionFilePath(sessionId)` captured synchronously before any await
+
+This prevents fire-and-forget saves from writing to the wrong directory when `XDG_DATA_HOME` changes between scheduling and execution.
+
+## Verification
+
+- `npm run typecheck`: 0 errors
+- `npm run test`: 621 tests pass, 0 failures
+
+## Context
+
+Discovered while analyzing session `ses_0b33c32f0ffe3rFc7R5zOeCRvp` which showed
+`lastPerMessageNudgeTokens: null` in persisted state despite running the PR #99 fix.
+The baseline was correctly set to `undefined` on compress (persisted), but the
+re-establishment on the next transform was in-memory only and lost on restart.

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -102,6 +102,7 @@ export const injectCompressNudges = (
     }
 
     let anchorsChanged = false
+    let baselineReEstablished = false
 
     if (!overMinLimit) {
         const hadTurnAnchors = state.nudges.turnNudgeAnchors.size > 0
@@ -202,6 +203,7 @@ export const injectCompressNudges = (
         currentTokens !== undefined
     ) {
         state.nudges.lastPerMessageNudgeTokens = currentTokens
+        baselineReEstablished = true
     }
 
     const composition = estimateContextComposition(messages, state)
@@ -315,7 +317,7 @@ export const injectCompressNudges = (
     // baseline (above) but anchorsChanged stays false when anchor sets are
     // saturated, so the on-disk baseline went stale and the nudge refired every
     // turn after restart.
-    if (anchorsChanged || decision.shouldNudge) {
+    if (anchorsChanged || decision.shouldNudge || baselineReEstablished) {
         saveSessionState(state, logger).catch(() => {})
     }
 }

--- a/lib/state/persistence.ts
+++ b/lib/state/persistence.ts
@@ -106,9 +106,15 @@ async function writePersistedSessionState(
     state: PersistedSessionState,
     logger: Logger,
 ): Promise<void> {
-    await ensureStorageDir(logger)
-
+    // Capture file path synchronously before any await — prevents race condition
+    // when fire-and-forget saves execute after XDG_DATA_HOME has changed (tests).
     const filePath = getSessionFilePath(sessionId)
+    const storageDir = getStorageDir()
+    if (!existsSync(storageDir)) {
+        migrateFromLegacyIfNeeded(logger)
+        await fs.mkdir(storageDir, { recursive: true })
+    }
+
     const content = JSON.stringify(state, null, 2)
     await fs.writeFile(filePath, content, "utf-8")
 

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -464,7 +464,100 @@ test("injectCompressNudges persists new nudge baseline to disk when a growth nud
     await cleanupPersistSession()
 })
 
-// --- toolOutput reminder adaptive threshold (issue #18) ---
+test("E2E: nudge survives compress → restart → re-establishment → growth (issue #23)", async () => {
+    await cleanupPersistSession()
+
+    const state = createSessionState()
+    state.sessionId = PERSIST_SESSION
+    state.modelContextLimit = 1_000_000
+    const config = buildConfig()
+    config.compress.maxContextLimit = 800_000
+    config.compress.minContextLimit = 200_000
+
+    // Turn 1: model calls compress → baseline cleared to undefined
+    const turn1: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 50_000 }, [
+            compressToolPart("c1", "compressed"),
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, turn1, {} as any)
+    assert.equal(state.nudges.lastPerMessageNudgeTokens, undefined, "compress should clear baseline")
+
+    // Simulate restart: load from disk
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    const loaded1 = await loadSessionState(PERSIST_SESSION, logger)
+    assert.equal(loaded1!.nudges.lastPerMessageNudgeTokens, undefined, "on-disk baseline must be undefined after compress")
+
+    const state2 = createSessionState()
+    state2.sessionId = PERSIST_SESSION
+    state2.modelContextLimit = 1_000_000
+    state2.nudges.lastPerMessageNudgeTokens = loaded1!.nudges.lastPerMessageNudgeTokens
+
+    // Turn 2: post-compress turn → baseline re-established (no nudge)
+    const turn2: WithParts[] = [
+        userMsg("u2", "next"),
+        assistantMsgWithTokens("a2", "response", { input: 150_000, output: 5_000 }),
+    ]
+    injectCompressNudges(state2, config, logger, turn2, {} as any)
+    assert.equal(state2.nudges.shouldInjectThisTurn, false, "baseline re-establishment turn should NOT nudge")
+    assert.equal(state2.nudges.lastPerMessageNudgeTokens, 155_000, "baseline re-established to real post-compression tokens")
+
+    // Simulate restart AGAIN: the bug was that baseline was NOT persisted here
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    const loaded2 = await loadSessionState(PERSIST_SESSION, logger)
+    assert.equal(
+        loaded2!.nudges.lastPerMessageNudgeTokens,
+        155_000,
+        "baseline re-establishment MUST persist to disk — otherwise nudges never fire after restart following compress",
+    )
+
+    // Turn 3: load persisted baseline, then grow past threshold → nudge MUST fire
+    const state3 = createSessionState()
+    state3.sessionId = PERSIST_SESSION
+    state3.modelContextLimit = 1_000_000
+    state3.nudges.lastPerMessageNudgeTokens = loaded2!.nudges.lastPerMessageNudgeTokens
+
+    const turn3: WithParts[] = [
+        userMsg("u3", "more work"),
+        assistantMsgWithTokens("a3", "result", { input: 200_000, output: 10_000 }),
+    ]
+    injectCompressNudges(state3, config, logger, turn3, {} as any)
+    assert.equal(
+        state3.nudges.shouldInjectThisTurn,
+        true,
+        "55K growth past re-established baseline (155K→210K, >50K threshold) — nudge MUST fire",
+    )
+
+    await cleanupPersistSession()
+})
+
+test("E2E: nudge recommendation content includes composition breakdown and compress guidance (issue #23)", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 200_000
+    const config = buildConfig()
+    config.compress.maxContextLimit = 800_000
+    config.compress.minContextLimit = 200_000
+
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 55_000 }, [
+            toolPart("c1", "x".repeat(40_000)),
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, messages, {} as any)
+
+    assert.equal(state.nudges.shouldInjectThisTurn, true, "should nudge (55K growth >= 50K threshold)")
+
+    const injected = suffixText(messages)
+    assert.ok(injected.includes("Breakdown:"), "nudge must include composition breakdown")
+    assert.ok(injected.includes("tool"), "breakdown must show tool category")
+    assert.ok(
+        injected.includes("acp_status") || injected.includes("compress") || injected.includes("review"),
+        "nudge must include compress guidance",
+    )
+})
 // Reminder threshold scales with context (via nudgeGrowthTokens); on a 1M model
 // it is 50K, not the old hardcoded 5000. Tool chars ≈ JSON.stringify(part).length/4.
 


### PR DESCRIPTION
## Summary

Follow-up to PR #99 (compress baseline fix). Two issues found while analyzing session `ses_0b33c32f0ffe3rFc7R5zOeCRvp`:

### 1. Baseline re-establishment not persisted

After PR #99 sets `lastPerMessageNudgeTokens = undefined` on compress, the next transform re-establishes the baseline in memory (lines 200-205). But the save condition (`anchorsChanged || decision.shouldNudge`) is false on that turn — growth is 0 since baseline was just set to `currentTokens`. So the baseline is **set in memory but never written to disk**.

After restart, the on-disk state still has `lastPerMessageNudgeTokens: null`, so nudges never fire.

**Fix**: Added `baselineReEstablished` flag to the save condition.

### 2. Fire-and-forget save race condition

`writePersistedSessionState` resolved the file path AFTER `await ensureStorageDir`. When fire-and-forget saves (`.catch(() => {})`) execute asynchronously, `XDG_DATA_HOME` may have already changed (especially in tests switching temp dirs), causing writes to the wrong directory.

**Fix**: Capture file path synchronously before any `await`.

## Verification

- `npm run typecheck`: 0 errors
- `npm run test`: 621 tests pass, 0 failures
- Session `ses_0b33c32f0ffe3rFc7R5zOeCRvp` confirmed `lastPerMessageNudgeTokens: null` in persisted state

Issue: dog/opencode-acp#23