### PR TITLE
feat: KEEP/REF markers + compressible ranges listing

### DIFF
--- a/devlog/2026-07-11_compress-keep-ranges/REQ.md
+++ b/devlog/2026-07-11_compress-keep-ranges/REQ.md
@@ -1,12 +1,39 @@
-# REQ: KEEP/REF Markers + Compressible Ranges Listing
+# REQ: Issue #23 — ACP Context Memory Leak Fix
 
 ## Problem
 
-Models over-summarize when compressing — key details (file paths, function
-signatures, error messages) get lost because the model can't precisely
-retype them in the summary. Additionally, the nudge only recommends the
-top 10 largest items by size, missing the "long tail" of many small tool
-calls that collectively waste 20K+ tokens.
+ACP's model-driven compression has a structural leak: context grows 5%,
+model compresses 2%, net positive, eventually overflows. Root causes:
+
+1. **Baseline leak after compress**: Compress drops context to 78K, model
+   continues working to 150K in the same turn. Each transform re-establishes
+   the nudge baseline to the inflated 150K instead of the post-compression 78K,
+   leaking 72K of headroom. Next nudge needs 200K instead of 128K.
+
+2. **Size-based recommendations cause fragment compression**: The nudge's
+   "Largest tool outputs" listing causes the model to compress by size (wrong)
+   instead of by work phase (correct). Results in many small blocks with
+   structural overhead exceeding savings.
+
+3. **Missing content preservation mechanism**: Model over-summarizes because
+   it can't precisely retype large content. Key details (file paths, function
+   signatures, error messages) get lost.
+
+4. **`toolOutputReminder` bypasses adaptive threshold**: Uses a hardcoded
+   5000-token growth check, firing ~10x too often on 1M-context models.
+
+5. **Compress detection misses continuation**: Only checks the LAST assistant
+   message for compress calls. When model continues after compress
+   (`[assistant(compress)] → [tool_result] → [assistant(continuation)]`),
+   detection fails and baseline never resets.
+
+6. **Multi-block notification empty summary**: `buildCompressionSummary`
+   checks full summary length before truncation, causing early break and
+   returning only "... and N more".
+
+7. **Baseline persistence race**: `writePersistedSessionState` resolves
+   file path AFTER `await fs.mkdir()`, causing fire-and-forget saves to
+   write to the wrong directory when `XDG_DATA_HOME` changes.
 
 ## Solution
 
@@ -16,26 +43,58 @@ Two marker types the model can embed in compress summaries:
 
 1. `[[KEEP:mNNNNN]]` — Auto-expand: system replaces with formatted original
    message content inline. Truncated to `compress.keepEmbedMaxChars`
-   (default 2000). Format by tool type: bash→`$ cmd\noutput`,
-   read→output, write/edit→`filePath:\ncontent`.
-
-2. `[[REF:mNNNNN|description]]` — Compact link: becomes
-   `[→ m00065: description]`. No expansion. Model can `decompress` later.
-
-Resolution runs after summary is finalized, before `wrapCompressedSummary`.
+   (default 2000).
+2. `[[REF:mNNNNN|description]]` — Compact link `[→ m00065: description]`.
+   No expansion. Model can `decompress` later.
 
 ### Compressible Ranges Listing
 
-Groups visible messages by conversation turn (user message = boundary).
-Each range shows: ref span, message count, token estimate, composition %.
-Injected into nudge alongside existing breakdown.
+Replaces size-based "Largest code/text messages" with need-based ranges
+grouped by conversation turn. Shows ALL ranges (no limit), with gap
+detection (no ranges spanning compressed holes).
+
+### Compression Philosophy (5 bullets)
+
+- All compression serves the primary task, but be frugal
+- Context capacity is precious — compress consumed outputs, don't avoid tools
+- Compress by need, not by percentage
+- Work from summaries, not raw tool outputs — compress ALL listed ranges
+- Curate summaries with KEEP/REF markers for critical content
+
+### Baseline Leak Fix (`compressBaselineSet` lock)
+
+- On first compress detection: set baseline to `currentTokens`, lock flag
+- Subsequent transforms in same turn: skip (lock prevents inflation)
+- New turn: release lock, baseline corrects downward to actual level
+- Turn-wide scan: `messages.slice(currentTurnStart).some(...)` instead of
+  checking only last assistant message
+
+### Other Fixes
+
+- Remove `toolOutputReminder` (was bypassing adaptive threshold)
+- `acp_status` default = compressible ranges view
+- Debug nudge: `config.debug: true` → terminal output via `sendIgnoredMessage`
+- `baselineCorrected` save condition (persistence fix)
+- Bug 14 cap: detailed notification summary capped at 10K chars
+- System prompt: 5 fixes (acp_status description, protected tools, etc.)
 
 ## Files
 
 - `lib/compress/keep-markers.ts` — NEW: marker parsing + resolution
-- `lib/messages/inject/utils.ts` — NEW: `buildCompressibleRanges` + `formatCompressibleRanges`
-- `lib/messages/inject/inject.ts` — Hook ranges into nudge
-- `lib/compress/range.ts` — Call `resolveKeepMarkers` before storing summary
-- `lib/prompts/compress-range.ts` — Document KEEP/REF in tool prompt
-- `lib/config.ts` + `lib/config-validation.ts` — Add `keepEmbedMaxChars`
+- `lib/messages/inject/utils.ts` — `buildCompressibleRanges` + `formatCompressibleRanges`
+- `lib/messages/inject/inject.ts` — compressBaselineSet lock, philosophy, ranges
+- `lib/compress/range.ts` — `resolveKeepMarkers` call
+- `lib/compress/status.ts` — acp_status ranges view default
+- `lib/prompts/compression-rules.ts` — `COMPRESS_PHILOSOPHY` constant
+- `lib/prompts/system.ts` — 5 system prompt fixes
+- `lib/state/types.ts` — `compressBaselineSet` in Nudges
+- `lib/state/state.ts` — init/load flag
+- `lib/state/persistence.ts` — persist flag
+- `lib/state/utils.ts` — resetOnCompaction flag
+- `lib/ui/notification.ts` — Bug 14 cap + multi-block fix
+- `lib/hooks.ts` — debug nudge callback
+- `lib/config.ts` + `lib/config-validation.ts` — `keepEmbedMaxChars`
+- `lib/prompts/compress-range.ts` — KEEP/REF docs
+- `tests/inject.test.ts` — 7 tests updated for new baseline behavior
 - `tests/keep-markers.test.ts` — NEW: 7 tests
+- `tests/acp-status.test.ts` — ranges view tests

--- a/devlog/2026-07-11_compress-keep-ranges/REQ.md
+++ b/devlog/2026-07-11_compress-keep-ranges/REQ.md
@@ -1,0 +1,41 @@
+# REQ: KEEP/REF Markers + Compressible Ranges Listing
+
+## Problem
+
+Models over-summarize when compressing — key details (file paths, function
+signatures, error messages) get lost because the model can't precisely
+retype them in the summary. Additionally, the nudge only recommends the
+top 10 largest items by size, missing the "long tail" of many small tool
+calls that collectively waste 20K+ tokens.
+
+## Solution
+
+### KEEP/REF Markers
+
+Two marker types the model can embed in compress summaries:
+
+1. `[[KEEP:mNNNNN]]` — Auto-expand: system replaces with formatted original
+   message content inline. Truncated to `compress.keepEmbedMaxChars`
+   (default 2000). Format by tool type: bash→`$ cmd\noutput`,
+   read→output, write/edit→`filePath:\ncontent`.
+
+2. `[[REF:mNNNNN|description]]` — Compact link: becomes
+   `[→ m00065: description]`. No expansion. Model can `decompress` later.
+
+Resolution runs after summary is finalized, before `wrapCompressedSummary`.
+
+### Compressible Ranges Listing
+
+Groups visible messages by conversation turn (user message = boundary).
+Each range shows: ref span, message count, token estimate, composition %.
+Injected into nudge alongside existing breakdown.
+
+## Files
+
+- `lib/compress/keep-markers.ts` — NEW: marker parsing + resolution
+- `lib/messages/inject/utils.ts` — NEW: `buildCompressibleRanges` + `formatCompressibleRanges`
+- `lib/messages/inject/inject.ts` — Hook ranges into nudge
+- `lib/compress/range.ts` — Call `resolveKeepMarkers` before storing summary
+- `lib/prompts/compress-range.ts` — Document KEEP/REF in tool prompt
+- `lib/config.ts` + `lib/config-validation.ts` — Add `keepEmbedMaxChars`
+- `tests/keep-markers.test.ts` — NEW: 7 tests

--- a/devlog/2026-07-11_compress-keep-ranges/WORKLOG.md
+++ b/devlog/2026-07-11_compress-keep-ranges/WORKLOG.md
@@ -1,36 +1,86 @@
 # WORKLOG
 
 ## Branch: `2026-07-11_compress-keep-ranges`
+## Commits: 7 (github/master..HEAD)
 
-### `lib/compress/keep-markers.ts` (NEW)
-- `resolveKeepMarkers(summary, messages, state, config)` — Parses `[[KEEP:mNNNNN]]` and `[[REF:mNNNNN|desc]]` markers from summary text
-- `formatByType(msg)` — Formats message content by tool type (bash, read, write, edit, etc.)
-- `truncate(text, maxChars)` — Truncates with `[truncated, N chars total]` suffix
-- Returns `{ summary, expandedCount, refCount, unresolvedRefs }`
+### Commit History
 
-### `lib/messages/inject/utils.ts`
-- `buildCompressibleRanges(messages, state, maxRanges=15)` — Groups messages by conversation turn (split at user messages with ≥3 msgs). Computes per-turn tokens + composition.
-- `formatCompressibleRanges(ranges)` — Formats as:
-  ```
-  Compressible ranges (oldest first):
-    m00050–m00071  22 msgs  17K  [tool 88% | text 12%]
-  ```
+1. `1e4a92d` feat: KEEP/REF markers + compressible ranges listing
+2. `5bca817` fix: add KEEP anti-pattern guidance to compress prompt
+3. `3d9c801` fix: move KEEP anti-pattern guidance to HOW TO COMPRESS rules
+4. `169e720` fix: compress detection overwrites disk baseline on restart
+5. `3a4ed2c` fix: notification summary empty for multi-block compressions
+6. `3f5bfbe` feat: inject nudge text to terminal when debug mode is on
+7. `3d3def4` fix: baseline leak after compress + Oracle review fixes
 
-### `lib/messages/inject/inject.ts`
-- Replaced `largestCodeRanges`/`largestMessageRanges` listing with compressible ranges listing
-- Kept `largestToolRanges` (top 10) — still useful for quick targeting
-- Added KEEP/REF hint when ranges are shown
+### Key Changes by Area
 
-### `lib/compress/range.ts`
-- Added `resolveKeepMarkers()` call after `preparedPlan.finalSummary`, before `wrapCompressedSummary`
+#### KEEP/REF Markers (`lib/compress/keep-markers.ts`)
+- `resolveKeepMarkers(summary, messages, state, config)` — Parses markers
+- `[[KEEP:mNNNNN]]` → auto-expand original content (truncated to 2000 chars)
+- `[[REF:mNNNNN|desc]]` → compact link `[→ mNNNNN: desc]`
+- Format by tool type: bash→`$ cmd\noutput`, read→output, write/edit→`filePath:\ncontent`
 
-### `lib/prompts/compress-range.ts`
-- Added KEEP AND REF MARKERS section with usage examples
+#### Compressible Ranges (`lib/messages/inject/utils.ts`)
+- `buildCompressibleRanges(messages, state)` — Groups by conversation turn
+- Gap detection: filters synthetic messages, splits on ref-number gaps
+- No maxRanges limit — shows ALL ranges
+- `formatCompressibleRanges(ranges)` — `m00050–m00071  22 msgs  17K [tool 88% | text 12%]`
 
-### Config
-- `compress.keepEmbedMaxChars` (default 2000) — max chars per KEEP expansion
-- Added to config type, defaults, merge, validation
+#### Baseline Leak Fix (`lib/messages/inject/inject.ts`)
+- `compressBaselineSet: boolean` lock in Nudges state
+- First compress detection: set baseline = currentTokens, lock = true
+- Subsequent transforms: skip (lock prevents inflation from continuation work)
+- New turn: release lock (`compressBaselineSet = false`)
+- Turn-wide scan: `messages.slice(currentTurnStart).some(...)` replaces last-message-only check
+- `baselineCorrected` flag for save condition (downward correction persistence)
 
-## Verification
-- 630 tests pass, typecheck OK
-- 7 new tests in `tests/keep-markers.test.ts`
+#### Compression Philosophy (`lib/prompts/compression-rules.ts`)
+- `COMPRESS_PHILOSOPHY` constant: 5 bullets (frugal/precious/need-based/work-from-summaries/curate-with-KEEP-REF)
+- Injected in efficiency nudge after `efficiencyNote`
+- Replaces old `buildContextUsageGuidance` inline philosophy
+
+#### Nudge Cleanup (`lib/messages/inject/inject.ts`)
+- Removed `toolOutputReminder` (bypassed adaptive threshold, caused over-compression)
+- Removed "Largest code messages" and "Largest text messages" listings
+- Removed "Compress incrementally, size alone is not a reason" hint
+- Replaced with compressible ranges + "compress ALL listed ranges" directive
+
+#### acp_status Enhancement (`lib/compress/status.ts`)
+- Default `scope:"uncompressed"` now shows ranges (matches nudge format)
+- `view:"messages"` for old per-message listing (size-sorted)
+- `tool` filter only works with `view:"messages"`
+- Overview includes compressible ranges alongside blocks
+
+#### System Prompt Fixes (`lib/prompts/system.ts`)
+1. `acp_status` description: mentions `view:"ranges"` vs `view:"messages"`
+2. "lean toward keeping" → "compress ALL listed ranges"
+3. Removed "aim for 20+ messages"
+4. Protected tools: "appended to summaries" → "hard-excluded"; listed `skill` only
+5. "Compress incrementally" → "Each compression creates a reusable summary block"
+
+#### Notification Fixes (`lib/ui/notification.ts`)
+- Multi-block: truncate each entry to `perEntryMax = budget/entries.length` before checking total
+- Bug 14 cap: `DETAILED_NOTIFICATION_SUMMARY_MAX_CHARS = 10000` for detailed mode
+
+#### Debug Nudge (`lib/hooks.ts`)
+- `config.debug: true` → nudge text sent to terminal via `sendIgnoredMessage`
+- Optional 7th param `debugNotify` callback to `injectCompressNudges`
+
+#### State Persistence (`lib/state/types.ts`, `persistence.ts`, `state.ts`, `utils.ts`)
+- Added `compressBaselineSet: boolean` to Nudges
+- Persisted to disk, loaded with `?? false` backward compat
+- Initialized in `createSessionState`, `resetSessionState`, `resetOnCompaction`
+
+### Oracle Review Results
+- Core fix correct (lock mechanism + turn-wide scan)
+- Critical staging issue found and fixed (regressed intermediates in index)
+- Bug 14 regression fixed (detailed notification cap)
+- Test name fidelity fixed ("post-compression" → "compress-calling assistant")
+- Restart safety verified (flag self-heals within one turn)
+
+### Verification
+- 630 tests pass, 0 failures
+- typecheck OK (0 errors)
+- Deployed to local cache, verified in live session
+- KEEP/REF markers tested with real compress calls — all working

--- a/devlog/2026-07-11_compress-keep-ranges/WORKLOG.md
+++ b/devlog/2026-07-11_compress-keep-ranges/WORKLOG.md
@@ -1,0 +1,36 @@
+# WORKLOG
+
+## Branch: `2026-07-11_compress-keep-ranges`
+
+### `lib/compress/keep-markers.ts` (NEW)
+- `resolveKeepMarkers(summary, messages, state, config)` — Parses `[[KEEP:mNNNNN]]` and `[[REF:mNNNNN|desc]]` markers from summary text
+- `formatByType(msg)` — Formats message content by tool type (bash, read, write, edit, etc.)
+- `truncate(text, maxChars)` — Truncates with `[truncated, N chars total]` suffix
+- Returns `{ summary, expandedCount, refCount, unresolvedRefs }`
+
+### `lib/messages/inject/utils.ts`
+- `buildCompressibleRanges(messages, state, maxRanges=15)` — Groups messages by conversation turn (split at user messages with ≥3 msgs). Computes per-turn tokens + composition.
+- `formatCompressibleRanges(ranges)` — Formats as:
+  ```
+  Compressible ranges (oldest first):
+    m00050–m00071  22 msgs  17K  [tool 88% | text 12%]
+  ```
+
+### `lib/messages/inject/inject.ts`
+- Replaced `largestCodeRanges`/`largestMessageRanges` listing with compressible ranges listing
+- Kept `largestToolRanges` (top 10) — still useful for quick targeting
+- Added KEEP/REF hint when ranges are shown
+
+### `lib/compress/range.ts`
+- Added `resolveKeepMarkers()` call after `preparedPlan.finalSummary`, before `wrapCompressedSummary`
+
+### `lib/prompts/compress-range.ts`
+- Added KEEP AND REF MARKERS section with usage examples
+
+### Config
+- `compress.keepEmbedMaxChars` (default 2000) — max chars per KEEP expansion
+- Added to config type, defaults, merge, validation
+
+## Verification
+- 630 tests pass, typecheck OK
+- 7 new tests in `tests/keep-markers.test.ts`

--- a/lib/compress/keep-markers.ts
+++ b/lib/compress/keep-markers.ts
@@ -1,0 +1,123 @@
+import type { WithParts } from "../state"
+import type { SessionState } from "../state"
+import type { PluginConfig } from "../config"
+
+const KEEP_REGEX = /\[\[KEEP:(m\d+)\]\]/g
+const REF_REGEX = /\[\[REF:(m\d+)\|([^\]]+)\]\]/g
+
+export interface KeepMarkerResult {
+    summary: string
+    expandedCount: number
+    refCount: number
+    unresolvedRefs: string[]
+}
+
+export function resolveKeepMarkers(
+    summary: string,
+    messages: WithParts[],
+    state: SessionState,
+    config: PluginConfig,
+): KeepMarkerResult {
+    const msgByRef = new Map<string, WithParts>()
+    for (const msg of messages) {
+        const ref = state.messageIds.byRawId.get(msg.info.id)
+        if (ref) msgByRef.set(ref, msg)
+    }
+
+    const maxChars = config.compress?.keepEmbedMaxChars ?? 2000
+    let expandedCount = 0
+    let refCount = 0
+    const unresolvedRefs: string[] = []
+
+    const expanded = summary
+        .replace(KEEP_REGEX, (match, ref: string) => {
+            const msg = msgByRef.get(ref)
+            if (!msg) {
+                unresolvedRefs.push(ref)
+                return match
+            }
+            expandedCount++
+            return formatKeptMessage(msg, ref, maxChars)
+        })
+        .replace(REF_REGEX, (_match, ref: string, desc: string) => {
+            const msg = msgByRef.get(ref)
+            if (!msg) {
+                unresolvedRefs.push(ref)
+                return _match
+            }
+            refCount++
+            return `[→ ${ref}: ${desc.trim()}]`
+        })
+
+    return { summary: expanded, expandedCount, refCount, unresolvedRefs }
+}
+
+function formatKeptMessage(msg: WithParts, ref: string, maxChars: number): string {
+    const formatted = formatByType(msg)
+    const truncated = truncate(formatted, maxChars)
+    return `\n--- [${ref}: ${labelForMessage(msg)}] ---\n${truncated}\n--- end ---\n`
+}
+
+function formatByType(msg: WithParts): string {
+    for (const part of msg.parts || []) {
+        if (part.type === "text" && typeof (part as any).text === "string") {
+            return (part as any).text as string
+        }
+        if (part.type === "tool") {
+            const tool = (part as any).tool || "unknown"
+            const state = (part as any).state || {}
+            const input = state.input || {}
+            const output = state.output || ""
+
+            switch (tool) {
+                case "bash":
+                case "interactive_bash": {
+                    const cmd = typeof input === "string" ? input : input.command || JSON.stringify(input)
+                    return `$ ${cmd}\n${output}`
+                }
+                case "read": {
+                    const fp = input.filePath || input.path || input.file || ""
+                    return output
+                }
+                case "write":
+                case "edit": {
+                    const fp = input.filePath || input.path || ""
+                    const content = input.content || input.newString || ""
+                    return `${fp}:\n${content}`
+                }
+                case "reply": {
+                    return output || "[reply posted]"
+                }
+                case "grep":
+                case "glob": {
+                    return output
+                }
+                default: {
+                    if (output && typeof output === "string" && output.length > 0) {
+                        return output
+                    }
+                    const compact = JSON.stringify({ tool, input }, null, 0)
+                    return compact.length > 500 ? compact.slice(0, 500) + "..." : compact
+                }
+            }
+        }
+    }
+    return "[empty message]"
+}
+
+function labelForMessage(msg: WithParts): string {
+    for (const part of msg.parts || []) {
+        if (part.type === "tool") {
+            const tool = (part as any).tool || "unknown"
+            const input = (part as any).state?.input || {}
+            const fp = input.filePath || input.path || input.command || ""
+            return fp ? `${tool}: ${String(fp).slice(0, 60)}` : tool
+        }
+    }
+    return msg.info.role === "user" ? "user" : "text"
+}
+
+function truncate(text: string, maxChars: number): string {
+    if (text.length <= maxChars) return text
+    return text.slice(0, maxChars) + `\n... [truncated, ${text.length} chars total]`
+}

--- a/lib/compress/range.ts
+++ b/lib/compress/range.ts
@@ -26,6 +26,7 @@ import {
     wrapCompressedSummary,
 } from "./state"
 import type { CompressRangeToolArgs } from "./types"
+import { resolveKeepMarkers } from "./keep-markers"
 
 function buildSchema(maxSummaryLengthHard: number) {
     return {
@@ -228,6 +229,13 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
 
             for (const preparedPlan of preparedPlans) {
                 const blockId = allocateBlockId(ctx.state)
+                const keepResult = resolveKeepMarkers(
+                    preparedPlan.finalSummary,
+                    rawMessages,
+                    ctx.state,
+                    ctx.config,
+                )
+                preparedPlan.finalSummary = keepResult.summary
                 const storedSummary = wrapCompressedSummary(blockId, preparedPlan.finalSummary)
                 const summaryTokens = countTokens(storedSummary)
 

--- a/lib/compress/status.ts
+++ b/lib/compress/status.ts
@@ -2,22 +2,20 @@ import { tool } from "@opencode-ai/plugin"
 import type { ToolContext } from "./types"
 import { formatAge } from "../ui/utils"
 import type { CompressionBlock, WithParts } from "../state/types"
-import { estimateContextComposition } from "../messages/inject/utils"
+import { estimateContextComposition, buildCompressibleRanges, formatCompressibleRanges } from "../messages/inject/utils"
 import { fetchSessionMessages } from "./search"
 
-const ACP_STATUS_TOOL_DESCRIPTION = `Show context status — overview or drill down into compressed/uncompressed sections.
+const ACP_STATUS_TOOL_DESCRIPTION = `Show context status — overview includes compressible ranges by default.
 
-No args: Overview of both visible (uncompressed) context and compressed blocks.
-scope:"uncompressed": Drill into all visible messages — list each with ref, tokens, tool type. Add tool:"bash" to filter by tool type.
+No args: Overview with totals, compressed blocks, and compressible ranges.
+scope:"uncompressed": Compressible ranges only (default view:"ranges"). Add view:"messages" for per-message listing with tool/sort filters.
 scope:"compressed": Drill into compressed blocks — list each with full details (age, generation, consumed lineage).
 
-Sort options: "size" (default, largest first), "time" (chronological), "tool" (group by tool type).
-
 Use this tool to:
-- See what's consuming context (overview)
-- Find all messages of a specific tool type to batch-compress
-- Check block details before decompressing
-- Find compression candidates when context grows`
+- See what's consuming context + compressible ranges in one call (no args)
+- Focus on ranges only (scope:"uncompressed")
+- Find all messages of a specific tool type (scope:"uncompressed", view:"messages", tool:"bash")
+- Check block details before decompressing (scope:"compressed")`
 
 function formatTokens(n: number): string {
     if (!Number.isFinite(n) || n <= 0) return "0"
@@ -120,6 +118,8 @@ function renderOverview(
     summaryTokens: number,
     blocks: CompressionBlock[],
     fetchFailed: boolean,
+    rawMessages: WithParts[],
+    ctx: ToolContext,
 ): string[] {
     const lines: string[] = []
 
@@ -181,10 +181,56 @@ function renderOverview(
         }
     }
 
+    if (!fetchFailed) {
+        const pruneMap = ctx.state.prune.messages.byMessageId
+        const visibleRaw = rawMessages.filter((msg) => {
+            const msgId = (msg.info as any)?.id || ""
+            const entry = pruneMap.get(msgId)
+            return !entry || entry.activeBlockIds.length === 0
+        })
+        const ranges = buildCompressibleRanges(visibleRaw, ctx.state)
+        if (ranges.length > 0) {
+            lines.push("")
+            lines.push(formatCompressibleRanges(ranges))
+        }
+    }
+
     lines.push("")
 
     const hintTool = topToolName || "bash"
-    lines.push(`Tip: acp_status({scope:"uncompressed", tool:"${hintTool}", sort:"size"}) — mix any params freely`)
+    lines.push(`Tip: acp_status({scope:"uncompressed", view:"messages", tool:"${hintTool}"}) for per-message listing`)
+
+    return lines
+}
+
+function renderUncompressedRanges(
+    rawMessages: WithParts[],
+    ctx: ToolContext,
+): string[] {
+    const pruneMap = ctx.state.prune.messages.byMessageId
+    const visibleMessages = rawMessages.filter((msg) => {
+        const msgId = (msg.info as any)?.id || ""
+        const entry = pruneMap.get(msgId)
+        return !entry || entry.activeBlockIds.length === 0
+    })
+
+    const ranges = buildCompressibleRanges(visibleMessages, ctx.state)
+    const totalTokens = ranges.reduce((s, r) => s + r.tokens, 0)
+    const totalMsgs = ranges.reduce((s, r) => s + r.count, 0)
+
+    const lines: string[] = []
+    lines.push(`UNCOMPRESSED — ${formatTokens(totalTokens)} | ${totalMsgs} msgs in ${ranges.length} ranges`)
+    lines.push("")
+
+    if (ranges.length === 0) {
+        lines.push("  (no compressible ranges)")
+    } else {
+        lines.push(formatCompressibleRanges(ranges))
+    }
+
+    lines.push("")
+    lines.push(`Per-message listing: acp_status({scope:"uncompressed", view:"messages"})`)
+    lines.push(`Filter by tool: acp_status({scope:"uncompressed", view:"messages", tool:"bash"})`)
 
     return lines
 }
@@ -331,10 +377,14 @@ export function createAcpStatusTool(ctx: ToolContext): ReturnType<typeof tool> {
                 .string()
                 .optional()
                 .describe('Drill down: "compressed" or "uncompressed". No arg = overview of both.'),
+            view: tool.schema
+                .string()
+                .optional()
+                .describe('Display format for scope:"uncompressed": "ranges" (default, grouped by turn — matches nudge format) or "messages" (per-message listing with sort/filter)'),
             tool: tool.schema
                 .string()
                 .optional()
-                .describe('Filter by tool type (only with scope:"uncompressed"). e.g., "bash", "todowrite", "write"'),
+                .describe('Filter by tool type (only with scope:"uncompressed", view:"messages"). e.g., "bash", "todowrite", "write"'),
             sort: tool.schema
                 .string()
                 .optional()
@@ -346,6 +396,7 @@ export function createAcpStatusTool(ctx: ToolContext): ReturnType<typeof tool> {
         },
         async execute(args, toolCtx) {
             const scope = args.scope === "compressed" || args.scope === "uncompressed" ? args.scope : undefined
+            const view = args.view === "messages" ? "messages" : "ranges"
             const toolFilter = typeof args.tool === "string" ? args.tool : undefined
             const sort = args.sort === "time" || args.sort === "tool" || args.sort === "age" ? args.sort : "size"
             const limit = Number.isFinite(args.limit) && args.limit! > 0 ? Math.min(args.limit!, 200) : 30
@@ -366,9 +417,10 @@ export function createAcpStatusTool(ctx: ToolContext): ReturnType<typeof tool> {
             let visibleMsgs: VisibleMessageInfo[] = []
             let summaryTokens = 0
             let fetchFailed = false
+            let rawMessages: WithParts[] = []
 
             try {
-                const rawMessages = await fetchSessionMessages(ctx.client, toolCtx.sessionID)
+                rawMessages = await fetchSessionMessages(ctx.client, toolCtx.sessionID)
                 const result = collectVisibleMessages(rawMessages, ctx)
                 visibleMsgs = result.messages
                 summaryTokens = result.summaryTokens
@@ -378,9 +430,13 @@ export function createAcpStatusTool(ctx: ToolContext): ReturnType<typeof tool> {
 
             if (scope === "uncompressed") {
                 if (fetchFailed) return "(unable to fetch messages)"
-                lines.push(...renderUncompressedDrilldown(visibleMsgs, toolFilter, sort, limit))
+                if (view === "messages") {
+                    lines.push(...renderUncompressedDrilldown(visibleMsgs, toolFilter, sort, limit))
+                } else {
+                    lines.push(...renderUncompressedRanges(rawMessages, ctx))
+                }
             } else {
-                lines.push(...renderOverview(visibleMsgs, summaryTokens, allBlocks, fetchFailed))
+                lines.push(...renderOverview(visibleMsgs, summaryTokens, allBlocks, fetchFailed, rawMessages, ctx))
             }
 
             return lines.join("\n")

--- a/lib/config-validation.ts
+++ b/lib/config-validation.ts
@@ -45,6 +45,7 @@ export const VALID_CONFIG_KEYS = new Set([
     "compress.maxSummaryLengthHard",
     "compress.minCompressRange",
     "compress.maxVisibleSegments",
+    "compress.keepEmbedMaxChars",
     "gc",
     "gc.algorithm",
     "gc.promotionThreshold",
@@ -435,6 +436,28 @@ export function validateConfigTypes(config: Record<string, any>): ValidationErro
                     key: "compress.maxVisibleSegments",
                     expected: "positive number (>= 1)",
                     actual: `${compress.maxVisibleSegments}`,
+                })
+            }
+
+            if (
+                compress.keepEmbedMaxChars !== undefined &&
+                typeof compress.keepEmbedMaxChars !== "number"
+            ) {
+                errors.push({
+                    key: "compress.keepEmbedMaxChars",
+                    expected: "number",
+                    actual: typeof compress.keepEmbedMaxChars,
+                })
+            }
+
+            if (
+                typeof compress.keepEmbedMaxChars === "number" &&
+                compress.keepEmbedMaxChars < 100
+            ) {
+                errors.push({
+                    key: "compress.keepEmbedMaxChars",
+                    expected: "positive number (>= 100)",
+                    actual: `${compress.keepEmbedMaxChars}`,
                 })
             }
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -35,6 +35,7 @@ export interface CompressConfig {
     maxSummaryLengthHard: number
     minCompressRange: number
     maxVisibleSegments: number
+    keepEmbedMaxChars: number
 }
 
 export interface Commands {
@@ -202,6 +203,7 @@ const defaultConfig: PluginConfig = {
         maxSummaryLengthHard: 10000,
         minCompressRange: 2000,
         maxVisibleSegments: 50,
+        keepEmbedMaxChars: 2000,
     },
     strategies: {
         deduplication: {
@@ -414,6 +416,7 @@ function mergeCompress(
         maxSummaryLengthHard: override.maxSummaryLengthHard ?? base.maxSummaryLengthHard,
         minCompressRange: override.minCompressRange ?? base.minCompressRange,
         maxVisibleSegments: override.maxVisibleSegments ?? base.maxVisibleSegments,
+        keepEmbedMaxChars: override.keepEmbedMaxChars ?? base.keepEmbedMaxChars,
     }
 }
 

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -41,6 +41,7 @@ import { type HostPermissionSnapshot } from "./host-permissions"
 import { compressPermission, syncCompressPermissionState } from "./compress-permission"
 import { checkSession, ensureSessionInitialized, saveSessionState, syncToolCache } from "./state"
 import { cacheSystemPromptTokens } from "./ui/utils"
+import { sendIgnoredMessage } from "./ui/notification"
 import { runTruncateGC, shouldRunMajorGC, getGCParams } from "./gc/truncate"
 import { runBatchCleanup } from "./gc/merge"
 import { getCurrentTokenUsage } from "./token-utils"
@@ -275,6 +276,17 @@ export function createChatMessageTransformHandler(
             output.messages,
             prompts.getRuntimePrompts(),
             compressionPriorities,
+            config.debug && state.sessionId
+                ? (text: string) => {
+                      sendIgnoredMessage(
+                          client,
+                          state.sessionId!,
+                          `[ACP Debug] Nudge injected:\n${text}`,
+                          {},
+                          logger,
+                      ).catch(() => {})
+                  }
+                : undefined,
         )
         injectMessageIds(state, config, output.messages, compressionPriorities)
         applyPendingManualTrigger(state, output.messages, logger)

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -69,6 +69,7 @@ export const injectCompressNudges = (
     messages: WithParts[],
     prompts: RuntimePrompts,
     compressionPriorities?: CompressionPriorityMap,
+    debugNotify?: (text: string) => void,
 ): void => {
     if (compressPermission(state, config) === "deny") {
         return
@@ -315,10 +316,18 @@ export const injectCompressNudges = (
     }
 
     if (suffixMessage) {
-        // [FIX #12] Nothing injected this turn → drop the empty synthetic user
-        // message. (appendToLastTextPart would no-op on "\n" anyway.)
         if (hasContent(suffixMessage)) {
             appendToLastTextPart(suffixMessage, "\n")
+            if (debugNotify) {
+                const text = suffixMessage.parts
+                    .filter((p) => p.type === "text")
+                    .map((p) => (p as any).text || "")
+                    .join("\n")
+                    .trim()
+                if (text) {
+                    debugNotify(text)
+                }
+            }
         } else {
             const idx = messages.lastIndexOf(suffixMessage)
             if (idx !== -1) {

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -24,11 +24,13 @@ import {
 import {
     addAnchor,
     applyAnchoredNudges,
+    buildCompressibleRanges,
     buildContextUsageGuidance,
     computeShouldNudge,
     countMessagesAfterIndex,
     estimateContextComposition,
     findLastNonIgnoredMessage,
+    formatCompressibleRanges,
     getIterationNudgeThreshold,
     getNudgeFrequency,
     getModelInfo,
@@ -255,13 +257,14 @@ export const injectCompressNudges = (
             if (composition.largestToolRanges.length > 0) {
                 breakdown += `\nLargest tool outputs: ${composition.largestToolRanges.slice(0, 10).map((r) => `${r.ref} (${fmt(r.tokens)})${r.tool ? " " + r.tool : ""}`).join(", ")}`
             }
-            if (composition.largestCodeRanges.length > 0) {
-                breakdown += `\nLargest code messages: ${composition.largestCodeRanges.map((r) => `${r.ref} (${fmt(r.tokens)})`).join(", ")}`
+
+            const ranges = buildCompressibleRanges(messages, state)
+            if (ranges.length > 0) {
+                breakdown += `\n\n${formatCompressibleRanges(ranges)}`
+                breakdown += `\n💡 Each range is a conversation turn. Compress whole ranges where the work is done. Use [[KEEP:mNNNNN]] in the summary to preserve critical content verbatim, [[REF:mNNNNN|desc]] for compact links.`
+            } else {
+                breakdown += `\n💡 Compress incrementally: target the ranges above whose content you have already extracted for this step. Size alone is not a reason to compress — if a large range is still needed in full, keep it.`
             }
-            if (composition.largestMessageRanges.length > 0) {
-                breakdown += `\nLargest text messages: ${composition.largestMessageRanges.map((r) => `${r.ref} (${fmt(r.tokens)})`).join(", ")}`
-            }
-            breakdown += `\n💡 Compress incrementally: target the ranges above whose content you have already extracted for this step. Size alone is not a reason to compress — if a large range is still needed in full, keep it.`
             if (decision.tipsVariant !== "maxLimit") {
                 breakdown += `\n\n${HOW_TO_COMPRESS_RULES}`
             }

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -91,7 +91,18 @@ export const injectCompressNudges = (
         messages,
     )
 
-    if (lastAssistantMessage && messageHasCompress(lastAssistantMessage)) {
+    // Only process compress detection if the compress-calling assistant message
+    // is from the CURRENT turn (after the last user message). On restart, the
+    // last assistant message may still have a compress call from a previous turn —
+    // re-processing it would overwrite the disk-loaded baseline with undefined.
+    const lastAssistantIdx = lastAssistantMessage
+        ? messages.lastIndexOf(lastAssistantMessage)
+        : -1
+    const lastUserIdx = messages.findLastIndex((message) => message.info.role === "user")
+    const isCurrentTurnCompress =
+        lastAssistantIdx >= 0 && lastAssistantIdx > lastUserIdx
+
+    if (isCurrentTurnCompress && lastAssistantMessage && messageHasCompress(lastAssistantMessage)) {
         state.nudges.contextLimitAnchors.clear()
         state.nudges.turnNudgeAnchors.clear()
         state.nudges.iterationNudgeAnchors.clear()

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -38,7 +38,7 @@ import {
     resolveAdaptiveNudgeGrowth,
 } from "./utils"
 import { buildCompressedBlockGuidance } from "../../prompts/extensions/nudge"
-import { HOW_TO_COMPRESS_RULES } from "../../prompts/compression-rules"
+import { HOW_TO_COMPRESS_RULES, COMPRESS_PHILOSOPHY } from "../../prompts/compression-rules"
 
 /**
  * Stable seed for the ACP dynamic guidance suffix message.
@@ -92,31 +92,40 @@ export const injectCompressNudges = (
         messages,
     )
 
-    // Only process compress detection if the compress-calling assistant message
-    // is from the CURRENT turn (after the last user message). On restart, the
-    // last assistant message may still have a compress call from a previous turn —
-    // re-processing it would overwrite the disk-loaded baseline with undefined.
-    const lastAssistantIdx = lastAssistantMessage
-        ? messages.lastIndexOf(lastAssistantMessage)
-        : -1
-    const lastUserIdx = messages.findLastIndex((message) => message.info.role === "user")
-    const isCurrentTurnCompress =
-        lastAssistantIdx >= 0 && lastAssistantIdx > lastUserIdx
+    const lastUserIdx = messages.findLastIndex(
+        (m) => m.info.role === "user" && !isIgnoredUserMessage(m),
+    )
+    const currentTurnStart = lastUserIdx >= 0 ? lastUserIdx + 1 : 0
+    const currentTurnHasCompress = messages
+        .slice(currentTurnStart)
+        .some((m) => m.info.role === "assistant" && messageHasCompress(m))
 
-    if (isCurrentTurnCompress && lastAssistantMessage && messageHasCompress(lastAssistantMessage)) {
+    if (currentTurnHasCompress) {
         state.nudges.contextLimitAnchors.clear()
         state.nudges.turnNudgeAnchors.clear()
         state.nudges.iterationNudgeAnchors.clear()
-        // currentTokens reflects PRE-compression context; baselines must wait
-        // for the next API response to capture the real post-compression level.
-        state.nudges.lastPerMessageNudgeTokens = undefined
+        state.nudges.lastNudgeShownTokens = undefined
         state.nudges.lastToolOutputNudgeTokens = undefined
+        // Set baseline to post-compression currentTokens ONLY on the first
+        // transform after compress. Subsequent transforms in the same turn
+        // (model continues working) must NOT update the baseline — otherwise
+        // the post-compression headroom leaks. E.g. compress drops context
+        // to 78K, model works to 150K in same turn: without this lock, the
+        // last transform sets baseline=150K, leaking 72K of headroom.
+        if (!state.nudges.compressBaselineSet) {
+            state.nudges.lastPerMessageNudgeTokens = currentTokens
+            state.nudges.compressBaselineSet = true
+        }
         saveSessionState(state, logger).catch(() => {})
         return
     }
 
+    // New turn (no compress) — release the lock
+    state.nudges.compressBaselineSet = false
+
     let anchorsChanged = false
     let baselineReEstablished = false
+    let baselineCorrected = false
 
     if (!overMinLimit) {
         const hadTurnAnchors = state.nudges.turnNudgeAnchors.size > 0
@@ -198,16 +207,25 @@ export const injectCompressNudges = (
         currentTokens < state.nudges.lastPerMessageNudgeTokens - nudgeGrowthTokens
     ) {
         state.nudges.lastPerMessageNudgeTokens = currentTokens
+        state.nudges.lastNudgeShownTokens = undefined
+        baselineCorrected = true
     }
+
+    const hasPendingNudge = state.nudges.lastNudgeShownTokens !== undefined
+    const effectiveThreshold = hasPendingNudge
+        ? Math.floor(nudgeGrowthTokens / 2)
+        : nudgeGrowthTokens
+    const growthReference =
+        state.nudges.lastNudgeShownTokens ?? state.nudges.lastPerMessageNudgeTokens
 
     const decision = computeShouldNudge({
         currentTokens,
         modelContextLimit,
         overMinLimit,
         overMaxLimit,
-        lastNudgeTokens: state.nudges.lastPerMessageNudgeTokens,
+        lastNudgeTokens: growthReference,
         minNudgeContextPercent: config.compress?.minNudgeContextPercent ?? 15,
-        nudgeGrowthTokens,
+        nudgeGrowthTokens: effectiveThreshold,
     })
 
     state.nudges.shouldInjectThisTurn = decision.shouldNudge
@@ -221,25 +239,6 @@ export const injectCompressNudges = (
     }
 
     const composition = estimateContextComposition(messages, state)
-    // Adaptive: follows nudgeGrowthTokens (5% of context, clamped [6K, 50K]). Do NOT
-    // revert to a constant — a fixed 5000 fired ~10x too often on 1M models (issue #18).
-    const toolOutputThreshold = config.compress?.toolOutputNudgeThreshold ?? nudgeGrowthTokens
-    let toolOutputReminder: string | null = null
-
-    if (composition.toolTokens > 0) {
-        if (state.nudges.lastToolOutputNudgeTokens === undefined) {
-            state.nudges.lastToolOutputNudgeTokens = composition.toolTokens
-        } else {
-            const toolGrowth = composition.toolTokens - state.nudges.lastToolOutputNudgeTokens
-            if (toolGrowth >= toolOutputThreshold) {
-                const fmt = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n))
-                const topRanges = composition.largestRanges.slice(0, 15).map((r) => `${r.ref} (${fmt(r.tokens)})`).join(", ")
-                toolOutputReminder = `\n\n⚠️ ${fmt(toolGrowth)} new tool outputs accumulated (${fmt(composition.toolTokens)} total). Largest: ${topRanges}. Use compress tool to compress these ranges now.`
-                state.nudges.lastToolOutputNudgeTokens = composition.toolTokens
-                anchorsChanged = true
-            }
-        }
-    }
 
     let tipsText: string | null = null
 
@@ -257,26 +256,15 @@ export const injectCompressNudges = (
             // Soft nudges (growth/min-limit) are efficiency prompts, not overflow
             // warnings — a separate, stronger alert fires at maxLimit (below).
             const efficiencyNote = decision.tipsVariant !== "maxLimit"
-                ? `\nThis is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.`
+                ? `\nThis is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.\n\n${COMPRESS_PHILOSOPHY}`
                 : ""
             let breakdown = `${efficiencyNote}\nBreakdown: ${fmt(composition.toolTokens)} tool (${pct(composition.toolTokens)}%) | ${fmt(composition.summaryTokens)} summaries (${pct(composition.summaryTokens)}%) | ${fmt(composition.codeTokens)} code (${pct(composition.codeTokens)}%) | ${fmt(plainTextTokens)} text (${pct(plainTextTokens)}%)${growthStr}`
-
-            const topToolTypes = composition.toolTypeBreakdown.slice(0, 3)
-            if (topToolTypes.length > 0) {
-                breakdown += `\nTop tools: ${topToolTypes.map((t) => `${t.tool} (${pct(t.tokens)}%)`).join(", ")}`
-            }
-
-            if (composition.largestToolRanges.length > 0) {
-                breakdown += `\nLargest tool outputs: ${composition.largestToolRanges.slice(0, 10).map((r) => `${r.ref} (${fmt(r.tokens)})${r.tool ? " " + r.tool : ""}`).join(", ")}`
-            }
 
             const ranges = buildCompressibleRanges(messages, state)
             if (ranges.length > 0) {
                 breakdown += `\n\n${formatCompressibleRanges(ranges)}`
-                breakdown += `\n💡 Each range is a conversation turn. Compress whole ranges where the work is done. Use [[KEEP:mNNNNN]] in the summary to preserve critical content verbatim, [[REF:mNNNNN|desc]] for compact links.`
-            } else {
-                breakdown += `\n💡 Compress incrementally: target the ranges above whose content you have already extracted for this step. Size alone is not a reason to compress — if a large range is still needed in full, keep it.`
             }
+
             if (decision.tipsVariant !== "maxLimit") {
                 breakdown += `\n\n${HOW_TO_COMPRESS_RULES}`
             }
@@ -286,9 +274,9 @@ export const injectCompressNudges = (
         if (decision.tipsVariant === "maxLimit") {
             tipsText = "\n\n⚠️ Context limit reached — compress now. Prioritize consumed tool outputs.\n\n{ \"topic\": \"...\", \"content\": [{ \"startId\": \"<ID>\", \"endId\": \"<ID>\", \"summary\": \"...\" }] }\n\nOnly use IDs from visible messages above. Compress older work first."
         }
-        state.nudges.lastPerMessageNudgeTokens = currentTokens
-        state.nudges.lastPerMessageNudgeTurn = state.currentTurn ?? 0
-
+        // Intentionally do NOT update lastPerMessageNudgeTokens here — nudges
+        // repeat every turn until the model actually compresses.
+        state.nudges.lastNudgeShownTokens = currentTokens
         if (config.compress.mode !== "message") {
             const visibleMessageIds = new Set<string>(
                 messages.map((message) => message.info.id),
@@ -311,11 +299,9 @@ export const injectCompressNudges = (
         injectVisibleIdRange(state, config, messages, suffixMessage)
     }
 
-    if (toolOutputReminder && suffixMessage) {
-        appendToLastTextPart(suffixMessage, toolOutputReminder)
-    }
-
     if (suffixMessage) {
+        // [FIX #12] Nothing injected this turn → drop the empty synthetic user
+        // message. (appendToLastTextPart would no-op on "\n" anyway.)
         if (hasContent(suffixMessage)) {
             appendToLastTextPart(suffixMessage, "\n")
             if (debugNotify) {
@@ -340,7 +326,7 @@ export const injectCompressNudges = (
     // baseline (above) but anchorsChanged stays false when anchor sets are
     // saturated, so the on-disk baseline went stale and the nudge refired every
     // turn after restart.
-    if (anchorsChanged || decision.shouldNudge || baselineReEstablished) {
+    if (anchorsChanged || decision.shouldNudge || baselineReEstablished || baselineCorrected) {
         saveSessionState(state, logger).catch(() => {})
     }
 }

--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -666,3 +666,102 @@ export function estimateContextComposition(
         toolTypeBreakdown,
     }
 }
+
+export interface CompressibleRange {
+    startRef: string
+    endRef: string
+    msgCount: number
+    tokens: number
+    toolPct: number
+    textPct: number
+    summaryPct: number
+}
+
+export function buildCompressibleRanges(
+    messages: WithParts[],
+    state: SessionState,
+    maxRanges: number = 15,
+): CompressibleRange[] {
+    const isSynthetic = (msg: WithParts) => {
+        const id = msg.info.id || ""
+        return id.startsWith("msg_acp_recap") || id.startsWith("msg_dcp_summary") ||
+            id.startsWith("msg_acp_suffix") || id.startsWith("msg_dcp_suffix")
+    }
+
+    const segments: CompressibleRange[] = []
+    let current: { msgs: WithParts[]; startRef: string; endRef: string } | null = null
+
+    for (const msg of messages) {
+        const ref = state.messageIds.byRawId.get(msg.info.id)
+        if (!ref) continue
+        if (isSynthetic(msg)) continue
+
+        const isUser = msg.info.role === "user"
+        if (isUser && current && current.msgs.length >= 3) {
+            segments.push(buildRange(current))
+            current = null
+        }
+        if (!current) {
+            current = { msgs: [], startRef: ref, endRef: ref }
+        }
+        current.msgs.push(msg)
+        current.endRef = ref
+    }
+    if (current && current.msgs.length >= 3) {
+        segments.push(buildRange(current))
+    }
+
+    segments.sort((a, b) => {
+        const refA = parseInt(a.startRef.slice(1), 10)
+        const refB = parseInt(b.startRef.slice(1), 10)
+        return refA - refB
+    })
+
+    return segments.slice(0, maxRanges)
+}
+
+function buildRange(current: { msgs: WithParts[]; startRef: string; endRef: string }): CompressibleRange {
+    let toolTokens = 0
+    let textTokens = 0
+    let summaryTokens = 0
+
+    for (const msg of current.msgs) {
+        const id = msg.info.id || ""
+        const isSummary = id.startsWith("msg_acp_recap") || id.startsWith("msg_dcp_summary")
+        for (const part of msg.parts || []) {
+            if (part.type === "text" && typeof (part as any).text === "string") {
+                const t = Math.round(((part as any).text as string).length / 4)
+                if (isSummary) summaryTokens += t
+                else textTokens += t
+            } else if (part.type === "tool") {
+                toolTokens += Math.round(JSON.stringify(part).length / 4)
+            }
+        }
+    }
+
+    const total = toolTokens + textTokens + summaryTokens || 1
+    return {
+        startRef: current.startRef,
+        endRef: current.endRef,
+        msgCount: current.msgs.length,
+        tokens: total,
+        toolPct: Math.round((toolTokens / total) * 100),
+        textPct: Math.round((textTokens / total) * 100),
+        summaryPct: Math.round((summaryTokens / total) * 100),
+    }
+}
+
+export function formatCompressibleRanges(ranges: CompressibleRange[]): string {
+    if (ranges.length === 0) return ""
+    const fmt = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n))
+    const lines = ranges.map((r) => {
+        const span = r.startRef === r.endRef ? r.startRef : `${r.startRef}–${r.endRef}`
+        const comps: string[] = []
+        if (r.toolPct > 0) comps.push(`tool ${r.toolPct}%`)
+        if (r.textPct > 0) comps.push(`text ${r.textPct}%`)
+        if (r.summaryPct > 0) comps.push(`summary ${r.summaryPct}%`)
+        const compStr = comps.length > 0 ? ` [${comps.join(", ")}]` : ""
+        return `  ${span.padEnd(16)} ${String(r.msgCount).padStart(3)} msgs  ${fmt(r.tokens).padStart(6)}${compStr}`
+    })
+    return `Compressible ranges (oldest first):\n${lines.join("\n")}`
+}

--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -452,7 +452,7 @@ export function buildContextUsageGuidance(
 
     const formatK = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n))
 
-    return `\n\nContext: ${formatK(currentTokens)} tokens.\nAll compression serves the primary task, but be frugal. Context capacity is precious. Save context by compressing consumed outputs, not by avoiding tools. Compress by need, not by percentage.`
+    return `\n\nContext: ${formatK(currentTokens)} tokens.`
 }
 
 export function applyAnchoredNudges(
@@ -670,98 +670,83 @@ export function estimateContextComposition(
 export interface CompressibleRange {
     startRef: string
     endRef: string
-    msgCount: number
+    count: number
     tokens: number
     toolPct: number
     textPct: number
-    summaryPct: number
+}
+
+function refNum(ref: string): number {
+    const n = parseInt(ref.slice(1), 10)
+    return Number.isNaN(n) ? -1 : n
 }
 
 export function buildCompressibleRanges(
     messages: WithParts[],
     state: SessionState,
-    maxRanges: number = 15,
 ): CompressibleRange[] {
-    const isSynthetic = (msg: WithParts) => {
-        const id = msg.info.id || ""
-        return id.startsWith("msg_acp_recap") || id.startsWith("msg_dcp_summary") ||
-            id.startsWith("msg_acp_suffix") || id.startsWith("msg_dcp_suffix")
-    }
-
-    const segments: CompressibleRange[] = []
-    let current: { msgs: WithParts[]; startRef: string; endRef: string } | null = null
-
+    const msgInfo: { ref: string; refNum: number; tokens: number; isTool: boolean; isUser: boolean }[] = []
     for (const msg of messages) {
+        if (isSyntheticMessage(msg)) continue
         const ref = state.messageIds.byRawId.get(msg.info.id)
         if (!ref) continue
-        if (isSynthetic(msg)) continue
-
-        const isUser = msg.info.role === "user"
-        if (isUser && current && current.msgs.length >= 3) {
-            segments.push(buildRange(current))
-            current = null
-        }
-        if (!current) {
-            current = { msgs: [], startRef: ref, endRef: ref }
-        }
-        current.msgs.push(msg)
-        current.endRef = ref
-    }
-    if (current && current.msgs.length >= 3) {
-        segments.push(buildRange(current))
-    }
-
-    segments.sort((a, b) => {
-        const refA = parseInt(a.startRef.slice(1), 10)
-        const refB = parseInt(b.startRef.slice(1), 10)
-        return refA - refB
-    })
-
-    return segments.slice(0, maxRanges)
-}
-
-function buildRange(current: { msgs: WithParts[]; startRef: string; endRef: string }): CompressibleRange {
-    let toolTokens = 0
-    let textTokens = 0
-    let summaryTokens = 0
-
-    for (const msg of current.msgs) {
-        const id = msg.info.id || ""
-        const isSummary = id.startsWith("msg_acp_recap") || id.startsWith("msg_dcp_summary")
+        let tokens = 0
+        let isTool = false
         for (const part of msg.parts || []) {
             if (part.type === "text" && typeof (part as any).text === "string") {
-                const t = Math.round(((part as any).text as string).length / 4)
-                if (isSummary) summaryTokens += t
-                else textTokens += t
-            } else if (part.type === "tool") {
-                toolTokens += Math.round(JSON.stringify(part).length / 4)
+                tokens += Math.round(((part as any).text as string).length / 4)
+            } else if (part.type !== "text" && part.type !== "reasoning") {
+                tokens += Math.round(JSON.stringify(part).length / 4)
+                isTool = true
             }
         }
+        const refNum = parseInt(ref.slice(1), 10)
+        msgInfo.push({ ref, refNum, tokens, isTool, isUser: msg.info.role === "user" })
     }
+    if (msgInfo.length === 0) return []
 
-    const total = toolTokens + textTokens + summaryTokens || 1
-    return {
-        startRef: current.startRef,
-        endRef: current.endRef,
-        msgCount: current.msgs.length,
-        tokens: total,
-        toolPct: Math.round((toolTokens / total) * 100),
-        textPct: Math.round((textTokens / total) * 100),
-        summaryPct: Math.round((summaryTokens / total) * 100),
+    const groups: CompressibleRange[] = []
+    let cur: CompressibleRange | null = null
+    let prevRefNum = -2
+    for (const info of msgInfo) {
+        const hasGap = info.refNum > prevRefNum + 1
+        if (cur && ((info.isUser && cur.count >= 3) || hasGap)) {
+            groups.push(cur)
+            cur = null
+        }
+        prevRefNum = info.refNum
+        if (!cur) {
+            cur = {
+                startRef: info.ref,
+                endRef: info.ref,
+                count: 1,
+                tokens: info.tokens,
+                toolPct: info.isTool ? 100 : 0,
+                textPct: info.isTool ? 0 : 100,
+            }
+        } else {
+            cur.endRef = info.ref
+            cur.count++
+            cur.tokens += info.tokens
+            if (info.isTool) {
+                cur.toolPct = Math.round((cur.toolPct * (cur.count - 1) + 100) / cur.count)
+            } else {
+                cur.toolPct = Math.round((cur.toolPct * (cur.count - 1)) / cur.count)
+            }
+            cur.textPct = 100 - cur.toolPct
+        }
     }
+    if (cur) groups.push(cur)
+
+    return groups.filter((g) => g.tokens > 0)
 }
 
 export function formatCompressibleRanges(ranges: CompressibleRange[]): string {
     if (ranges.length === 0) return ""
     const fmt = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n))
-    const lines = ranges.map((r) => {
-        const span = r.startRef === r.endRef ? r.startRef : `${r.startRef}–${r.endRef}`
-        const comps: string[] = []
-        if (r.toolPct > 0) comps.push(`tool ${r.toolPct}%`)
-        if (r.textPct > 0) comps.push(`text ${r.textPct}%`)
-        if (r.summaryPct > 0) comps.push(`summary ${r.summaryPct}%`)
-        const compStr = comps.length > 0 ? ` [${comps.join(", ")}]` : ""
-        return `  ${span.padEnd(16)} ${String(r.msgCount).padStart(3)} msgs  ${fmt(r.tokens).padStart(6)}${compStr}`
+    const lines = ranges.map((r, i) => {
+        const suffix = i === ranges.length - 1 ? "  (recent — may still be in active use)" : ""
+        return `  ${r.startRef}–${r.endRef}  ${r.count} msgs  ${fmt(r.tokens)} [tool ${r.toolPct}% | text ${r.textPct}%]${suffix}`
     })
     return `Compressible ranges (oldest first):\n${lines.join("\n")}`
 }

--- a/lib/prompts/compress-range.ts
+++ b/lib/prompts/compress-range.ts
@@ -51,4 +51,6 @@ The rest of the bash calls were repetitive export commands. See [[REF:m00078|tes
 \`\`\`
 
 Use KEEP sparingly — each expansion adds to the summary length. Prefer REF for content that is important but not immediately critical.
+
+Do NOT use KEEP for verbose command output, diagnostic scripts, log dumps, or any content whose VALUE is in the conclusion rather than the raw output — these should be summarized or referenced with REF instead.
 `

--- a/lib/prompts/compress-range.ts
+++ b/lib/prompts/compress-range.ts
@@ -34,4 +34,21 @@ Rules:
 
 BATCHING
 When multiple independent ranges are ready and their boundaries do not overlap, include all of them as separate entries in the \`content\` array of a single tool call. Each entry should have its own \`startId\`, \`endId\`, and \`summary\`.
+
+KEEP AND REF MARKERS
+When writing a summary, you may embed markers that reference specific messages in the compressed range. The system resolves them automatically:
+
+- \`[[KEEP:mNNNNN]]\` — Expands to the original message content inline (truncated to a max length). Use for critical content you want preserved verbatim in the summary without re-typing it: key function definitions, important error messages, essential file contents.
+- \`[[REF:mNNNNN|short description]]\` — Creates a compact link like \`[→ m00065: key function definition]\`. Use for content the reader can decompress later if needed. Does not expand — saves space.
+
+Example:
+\`\`\`
+Implemented the QuotaMonitor feature. Key design: observer pattern.
+
+[[KEEP:m00065]]
+
+The rest of the bash calls were repetitive export commands. See [[REF:m00078|test results]] for details.
+\`\`\`
+
+Use KEEP sparingly — each expansion adds to the summary length. Prefer REF for content that is important but not immediately critical.
 `

--- a/lib/prompts/compress-range.ts
+++ b/lib/prompts/compress-range.ts
@@ -51,6 +51,4 @@ The rest of the bash calls were repetitive export commands. See [[REF:m00078|tes
 \`\`\`
 
 Use KEEP sparingly — each expansion adds to the summary length. Prefer REF for content that is important but not immediately critical.
-
-Do NOT use KEEP for verbose command output, diagnostic scripts, log dumps, or any content whose VALUE is in the conclusion rather than the raw output — these should be summarized or referenced with REF instead.
 `

--- a/lib/prompts/compression-rules.ts
+++ b/lib/prompts/compression-rules.ts
@@ -38,6 +38,8 @@ DROP — extract the signal, discard the vessel:
 
 For each significant item you DROP (scripts, reports, large analyses, long tool outputs), add a one-line CONTENT description of what it covers — not where it lives. Bad: "probe script at /path/probe_kvnet.py". Good: "probe_kvnet.py: tests n-gram baseline, generation quality, long-range dependency, position sensitivity, op pipeline, QUERY attention." This lets a later decompress target the right block by relevance, not by guessing locations.
 
+KEEP MARKERS: \`[[KEEP:mNNNNN]]\` expands original message content into the summary (truncated to a max length). Do NOT use KEEP for verbose command output, diagnostic scripts, log dumps, or any content whose value is in the conclusion rather than the raw output — summarize these or use \`[[REF:mNNNNN|desc]]\` instead.
+
 PRIORITY — when the summary must be compact, preserve in this order:
 1. User's overall goal, goal evolution, intent, and hard constraints (losing these changes the task).
 2. Decisions and rationale.

--- a/lib/prompts/compression-rules.ts
+++ b/lib/prompts/compression-rules.ts
@@ -1,4 +1,16 @@
 /**
+ * Compression philosophy — the high-level principles injected in efficiency
+ * nudges. Points 4-5 are need-based guidance: compress everything listed,
+ * use KEEP/REF to preserve critical content within summaries.
+ */
+export const COMPRESS_PHILOSOPHY = `Compression Philosophy:
+- All compression serves the primary task, but be frugal.
+- Context capacity is precious. Save context by compressing consumed outputs, not by avoiding tools.
+- Compress by need, not by percentage.
+- Work from summaries, not raw tool outputs. All listed ranges (user prompts, tool outputs, code, logs, exploration, intermediate steps) should be compressed to summary format \u2014 the ONLY exceptions are protected content, content the current step is actively using, or critical content you cannot reconstruct.
+- Curate summaries like a well-structured document. User prompts, compressed tool outputs, code, logs, or skill-call intermediate results that are critically important should be preserved \u2014 not by exempting them from compression, but by embedding them in the summary via [[KEEP:mNNNNN]] (auto-expanded verbatim) and [[REF:mNNNNN|description]] (compact link).`
+
+/**
  * Full compression rules — the single source of truth for HOW TO COMPRESS.
  *
  * Used in:

--- a/lib/prompts/system.ts
+++ b/lib/prompts/system.ts
@@ -26,7 +26,7 @@ You have five context-management tools:
 - \`decompress\` — Restore a previously compressed block's full original content, optionally to a file for large blocks. Use when a summary lacks the exact detail you need. Example: \`decompress({ blockId: "b5" })\` or \`decompress({ blockId: "b5", toFile: "path" })\`.
 - \`search_context\` — Search compressed block summaries (and optionally visible messages) by keyword. Use BEFORE decompressing to find the right block. Example: \`search_context({ query: "auth token refresh" })\`.
 - \`prune\` — Remove old tool outputs by tool type, keeping only recent calls. Unlike compress (which creates summaries), prune directly strips outputs. Use for disposable outputs like old todowrite states or edit echoes. Example: \`prune({ toolType: "todowrite", keepLatest: 3 })\`.
-- \`acp_status\` — Context status with drilldown. No args = overview. \`scope:"uncompressed"\` lists all visible messages; add \`tool:"bash"\` to filter by tool type. \`scope:"compressed"\` shows block details. Example: \`acp_status({scope:"uncompressed", tool:"todowrite"})\`.
+- \`acp_status\` — Context status with compressible ranges. No args = overview + ranges. \`scope:"uncompressed"\` for range view; add \`view:"messages"\` for per-message listing with \`tool\`/\`sort\` filters. \`scope:"compressed"\` for block details.
 
 COMPRESSION PHILOSOPHY
 
@@ -34,9 +34,9 @@ Two failure modes to avoid:
 - Over-compression: Compressing too aggressively loses critical details, decisions, and state needed for your task. This directly harms task quality.
 - Under-compression: Failing to compress verbose outputs causes context overflow, reducing accuracy and eventually blocking your work.
 
-Balance is key. The single test for whether to compress is: "Is this content still needed by the current task step?" If yes, keep it. If no, it is a candidate. When uncertain, lean toward keeping content.
+Balance is key. The single test for whether to compress is: "Is this content still needed by the current task step?" If yes, keep it. If no, compress it. All ranges listed in the context breakdown should be compressed to summary format \u2014 the only exceptions are protected content, content the current step is actively using, or critical content you cannot reconstruct.
 
-Be frugal with context. Compress obvious waste proactively — verbose outputs you have already used, duplicate reads, abandoned explorations. Do not wait until context is critically full; that harms retrieval quality and risks overflow. When compressing, cover the largest range you can in a single call — aim for 20+ messages. Compressing 3-5 messages at a time creates many small summaries that collectively waste more tokens than they save. But never let the urge to compress distract from the actual task.
+Be frugal with context. Compress obvious waste proactively — verbose outputs you have already used, duplicate reads, abandoned explorations. Do not wait until context is critically full; that harms retrieval quality and risks overflow. But never let the urge to compress distract from the actual task.
 
 WHEN TO COMPRESS
 
@@ -53,7 +53,7 @@ WHEN NOT TO COMPRESS
 
 - Content the current task step is actively reading or reasoning about.
 - Important user messages — preserve their exact intent, constraints, and acceptance criteria verbatim, not just the most recent one.
-- Outputs from protected tools (e.g. \`task\`, \`skill\`, \`todowrite\`, \`write\`, \`edit\`) — these are appended to summaries automatically, not compressed away.
+- Protected tool outputs (default: \`skill\` only) — hard-excluded from compression ranges, survive intact in visible context.
 
 ${HOW_TO_COMPRESS_RULES}
 
@@ -78,7 +78,7 @@ Breakdown: 12.3K tool (40%) | 3.1K summaries (10%) | 8.5K code (28%) | 6.5K text
 - "code" = messages containing code blocks
 - "text" = plain text messages
 
-Below the breakdown, the system lists the largest ranges in each category (e.g. \`Largest tool outputs: m00175 (20.7K), m00200 (8.1K)\`). These are high-value compression candidates — compress those whose content you have already consumed (extracted the facts you need). Keep any you still need to reference.
+Below the breakdown, the system lists compressible ranges grouped by conversation turn. All listed ranges should be compressed to summary format — the only exceptions are protected content, content the current step is actively using, or critical content you cannot reconstruct. Compress the largest ranges first when the current step no longer needs them.
 
-Compress incrementally: target one large consumed range per compress call (e.g. m00150–m00200), not the entire context at once. Each compression creates a reusable summary block you can decompress later if needed.
+Each compression creates a reusable summary block you can decompress later if needed.
 `

--- a/lib/state/persistence.ts
+++ b/lib/state/persistence.ts
@@ -45,7 +45,9 @@ export interface PersistedNudges {
     iterationNudgeAnchors?: string[]
     lastPerMessageNudgeTurn?: number
     lastPerMessageNudgeTokens?: number
+    lastNudgeShownTokens?: number
     lastToolOutputNudgeTokens?: number
+    compressBaselineSet?: boolean
 }
 
 export interface PersistedMessageIds {
@@ -146,7 +148,9 @@ export async function saveSessionState(
             iterationNudgeAnchors: Array.from(sessionState.nudges.iterationNudgeAnchors),
             lastPerMessageNudgeTurn: sessionState.nudges.lastPerMessageNudgeTurn ?? 0,
             lastPerMessageNudgeTokens: sessionState.nudges.lastPerMessageNudgeTokens,
+            lastNudgeShownTokens: sessionState.nudges.lastNudgeShownTokens,
             lastToolOutputNudgeTokens: sessionState.nudges.lastToolOutputNudgeTokens,
+            compressBaselineSet: sessionState.nudges.compressBaselineSet,
         },
         stats: sessionState.stats,
         lastUpdated: new Date().toISOString(),

--- a/lib/state/state.ts
+++ b/lib/state/state.ts
@@ -84,8 +84,10 @@ export function createSessionState(): SessionState {
             iterationNudgeAnchors: new Set<string>(),
             lastPerMessageNudgeTurn: 0,
             lastPerMessageNudgeTokens: undefined,
+            lastNudgeShownTokens: undefined,
             lastToolOutputNudgeTokens: undefined,
             shouldInjectThisTurn: undefined,
+            compressBaselineSet: false,
         },
         stats: {
             pruneTokenCounter: 0,
@@ -126,8 +128,10 @@ export function resetSessionState(state: SessionState): void {
         iterationNudgeAnchors: new Set<string>(),
         lastPerMessageNudgeTurn: 0,
         lastPerMessageNudgeTokens: undefined,
+        lastNudgeShownTokens: undefined,
         lastToolOutputNudgeTokens: undefined,
         shouldInjectThisTurn: undefined,
+        compressBaselineSet: false,
     }
     state.stats = {
         pruneTokenCounter: 0,
@@ -197,7 +201,9 @@ export async function ensureSessionInitialized(
     )
     state.nudges.lastPerMessageNudgeTurn = persisted.nudges.lastPerMessageNudgeTurn ?? 0
     state.nudges.lastPerMessageNudgeTokens = persisted.nudges.lastPerMessageNudgeTokens
+    state.nudges.lastNudgeShownTokens = persisted.nudges.lastNudgeShownTokens
     state.nudges.lastToolOutputNudgeTokens = persisted.nudges.lastToolOutputNudgeTokens
+    state.nudges.compressBaselineSet = persisted.nudges.compressBaselineSet ?? false
     state.stats = {
         pruneTokenCounter: persisted.stats?.pruneTokenCounter || 0,
         totalPruneTokens: persisted.stats?.totalPruneTokens || 0,

--- a/lib/state/types.ts
+++ b/lib/state/types.ts
@@ -95,9 +95,19 @@ export interface Nudges {
     iterationNudgeAnchors: Set<string>
     lastPerMessageNudgeTurn: number
     lastPerMessageNudgeTokens: number | undefined
+    lastNudgeShownTokens: number | undefined
     lastToolOutputNudgeTokens: number | undefined
     /** Set by injectCompressNudges; read by system prompt handler next turn (1-turn lag). Undefined = first turn. */
     shouldInjectThisTurn: boolean | undefined
+    /**
+     * Lock flag: prevents baseline leak after compress.
+     *
+     * When compress is detected in the current turn, the baseline is set to
+     * currentTokens ONLY on the first transform (before continuation work
+     * inflates it). Subsequent transforms in the same turn skip the update.
+     * Reset to false when compress is NOT in the current turn.
+     */
+    compressBaselineSet: boolean
 }
 
 export interface SessionState {

--- a/lib/state/utils.ts
+++ b/lib/state/utils.ts
@@ -359,8 +359,10 @@ export function resetOnCompaction(state: SessionState): void {
         iterationNudgeAnchors: new Set<string>(),
         lastPerMessageNudgeTurn: 0,
         lastPerMessageNudgeTokens: undefined,
+        lastNudgeShownTokens: undefined,
         lastToolOutputNudgeTokens: undefined,
         shouldInjectThisTurn: undefined,
+        compressBaselineSet: false,
     }
     // [FIX] Reset message IDs on compaction — old mappings are stale after
     // compaction replaces messages with a summary. Keeping them causes

--- a/lib/ui/notification.ts
+++ b/lib/ui/notification.ts
@@ -55,6 +55,7 @@ function buildDetailedMessage(
 const TOAST_BODY_MAX_LINES = 12
 const TOAST_SUMMARY_MAX_CHARS = 600
 const NOTIFICATION_SUMMARY_MAX_CHARS = 1500
+const DETAILED_NOTIFICATION_SUMMARY_MAX_CHARS = 10000
 
 function truncateToastBody(body: string, maxLines: number = TOAST_BODY_MAX_LINES): string {
     const lines = body.split("\n")
@@ -238,9 +239,12 @@ export async function sendCompressNotification(
             message += ` compressed`
         }
         if (config.compress.showCompression) {
+            const maxChars = config.pruneNotification === "detailed"
+                ? DETAILED_NOTIFICATION_SUMMARY_MAX_CHARS
+                : NOTIFICATION_SUMMARY_MAX_CHARS
             const displaySummary =
-                summary.length > NOTIFICATION_SUMMARY_MAX_CHARS
-                    ? truncateToastSummary(summary, NOTIFICATION_SUMMARY_MAX_CHARS)
+                summary.length > maxChars
+                    ? truncateToastSummary(summary, maxChars)
                     : summary
             message += `\n→ Compression (~${summaryTokensStr}): ${displaySummary}`
         }

--- a/lib/ui/notification.ts
+++ b/lib/ui/notification.ts
@@ -81,16 +81,26 @@ function buildCompressionSummary(
         return entries[0]?.summary ?? ""
     }
 
+    const perEntryMax = Math.floor(NOTIFICATION_SUMMARY_MAX_CHARS / entries.length)
     let result = ""
-    for (const entry of entries) {
+    let shown = 0
+    for (let i = 0; i < entries.length; i++) {
+        const entry = entries[i]
         const topic =
             state.prune.messages.blocksById.get(entry.blockId)?.topic ?? "(unknown topic)"
-        const section = `### ${topic}\n${entry.summary}`
+        const truncated = entry.summary.length > perEntryMax
+            ? entry.summary.slice(0, perEntryMax - 3) + "..."
+            : entry.summary
+        const section = `### ${topic}\n${truncated}`
         if (result.length + section.length + 2 > NOTIFICATION_SUMMARY_MAX_CHARS) {
-            result += `\n\n... and ${entries.length - entries.indexOf(entry)} more`
+            const remaining = entries.length - shown
+            if (remaining > 0) {
+                result += (result ? "\n\n" : "") + `... and ${remaining} more`
+            }
             break
         }
         result += (result ? "\n\n" : "") + section
+        shown++
     }
     return result
 }

--- a/tests/acp-status.test.ts
+++ b/tests/acp-status.test.ts
@@ -112,7 +112,7 @@ function blocksMap(...blocks: CompressionBlock[]): Map<number, CompressionBlock>
 async function runStatus(
     activeIds: number[],
     blocks: Map<number, CompressionBlock>,
-    args: { scope?: string; tool?: string; sort?: string; limit?: number } = {},
+    args: { scope?: string; view?: string; tool?: string; sort?: string; limit?: number } = {},
     client?: any,
 ): Promise<string> {
     const ctx = makeToolContext(activeIds, blocks, client)
@@ -266,7 +266,7 @@ test("acp_status: scope=compressed includes decompress hint", async () => {
     assert.match(result, /search_context/)
 })
 
-test("acp_status: scope=uncompressed shows message list header", async () => {
+test("acp_status: scope=uncompressed defaults to ranges view", async () => {
     const mockMsgs = [
         { info: { id: "raw-1", role: "assistant" }, parts: [{ type: "text", text: "hello world" }] },
     ]
@@ -284,10 +284,31 @@ test("acp_status: scope=uncompressed shows message list header", async () => {
     const result = await statusTool.execute({ scope: "uncompressed" } as any, { sessionID: SID } as any)
 
     assert.match(result, /UNCOMPRESSED/)
+    assert.match(result, /ranges/)
+})
+
+test("acp_status: scope=uncompressed view=messages shows per-message listing", async () => {
+    const mockMsgs = [
+        { info: { id: "raw-1", role: "assistant" }, parts: [{ type: "text", text: "hello world" }] },
+    ]
+    const mockClient = makeMockClient(mockMsgs)
+    const state = makeState([], new Map())
+    state.messageIds.byRawId.set("raw-1", "m00001")
+    const ctx: ToolContext = {
+        client: mockClient,
+        state,
+        logger: { enabled: false } as any,
+        config: {} as any,
+        prompts: { reload: () => {} } as any,
+    }
+    const statusTool = createAcpStatusTool(ctx)
+    const result = await statusTool.execute({ scope: "uncompressed", view: "messages" } as any, { sessionID: SID } as any)
+
+    assert.match(result, /UNCOMPRESSED/)
     assert.match(result, /Sorted by/)
 })
 
-test("acp_status: scope=uncompressed with tool filter shows filter in header", async () => {
+test("acp_status: scope=uncompressed view=messages with tool filter shows filter in header", async () => {
     const mockMsgs = [
         {
             info: { id: "raw-1", role: "assistant" },
@@ -305,7 +326,7 @@ test("acp_status: scope=uncompressed with tool filter shows filter in header", a
         prompts: { reload: () => {} } as any,
     }
     const statusTool = createAcpStatusTool(ctx)
-    const result = await statusTool.execute({ scope: "uncompressed", tool: "bash" } as any, { sessionID: SID } as any)
+    const result = await statusTool.execute({ scope: "uncompressed", view: "messages", tool: "bash" } as any, { sessionID: SID } as any)
 
     assert.match(result, /UNCOMPRESSED — bash:/)
 })

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -197,6 +197,76 @@ test("injectCompressNudges clears anchors when compress tool is detected", () =>
     assert.equal(state.nudges.iterationNudgeAnchors.size, 0, "iterationNudgeAnchors should be cleared")
 })
 
+test("stale compress from previous turn does NOT clobber baseline (restart fix)", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 240_000
+    const config = buildConfig()
+    config.compress.maxContextLimit = 300_000
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 50_000 }, [
+            compressToolPart("c1", "compressed"),
+        ]),
+        userMsg("u2", "next question"),
+    ]
+    injectCompressNudges(state, config, logger, messages, {} as any)
+    assert.notEqual(
+        state.nudges.lastPerMessageNudgeTokens,
+        undefined,
+        "stale compress must not reset baseline to undefined",
+    )
+    assert.equal(
+        state.nudges.contextLimitAnchors.size,
+        0,
+        "anchors must not be cleared by stale compress",
+    )
+})
+
+test("compress in current turn sets baseline to compress-calling assistant's currentTokens", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 200_000
+    state.nudges.contextLimitAnchors.add("anchor-1")
+    const config = buildConfig()
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 50_000 }, [
+            compressToolPart("c1", "compressed"),
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, messages, {} as any)
+    assert.equal(
+        state.nudges.lastPerMessageNudgeTokens,
+        250_000,
+        "current-turn compress sets baseline to compress-calling assistant's currentTokens (input+output)",
+    )
+    assert.equal(state.nudges.compressBaselineSet, true, "lock must be set to prevent leak from continuation work")
+    assert.equal(state.nudges.contextLimitAnchors.size, 0, "anchors must be cleared")
+})
+
+test("compress followed by continuation assistant sets baseline to continuation tokens (issue #23)", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 200_000
+    state.nudges.contextLimitAnchors.add("anchor-1")
+    const config = buildConfig()
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "compressing", { input: 200_000, output: 50_000 }, [
+            compressToolPart("c1", "compressed"),
+        ]),
+        assistantMsgWithTokens("a2", "now continuing the task", { input: 150_000, output: 1_000 }),
+    ]
+    injectCompressNudges(state, config, logger, messages, {} as any)
+    assert.equal(
+        state.nudges.lastPerMessageNudgeTokens,
+        151_000,
+        "compress detected in current turn — baseline set to latest assistant currentTokens",
+    )
+    assert.equal(state.nudges.contextLimitAnchors.size, 0, "anchors must be cleared")
+})
+
 test("formatMessageIdTag produces dcp-message-id tag", () => {
     const tag = formatMessageIdTag("m00001")
     assert.ok(tag.includes("m00001"))
@@ -233,7 +303,7 @@ test("createSyntheticUserMessage produces an all-synthetic user message that ens
     )
 })
 
-test("injectCompressNudges: after compress, baseline cleared to undefined for re-establishment", () => {
+test("injectCompressNudges: after compress, baseline set to compress-calling assistant's currentTokens", () => {
     const state = createSessionState()
     state.modelContextLimit = 1_000_000
     const config = buildConfig()
@@ -249,19 +319,20 @@ test("injectCompressNudges: after compress, baseline cleared to undefined for re
 
     assert.equal(
         state.nudges.lastPerMessageNudgeTokens,
-        undefined,
-        "lastPerMessageNudgeTokens must be undefined after compress — currentTokens reflects pre-compression context, not post-compression",
+        250_000,
+        "baseline set to compress-calling assistant's currentTokens (input+output) — prevents leak from continuation work",
     )
+    assert.equal(state.nudges.compressBaselineSet, true, "lock must be set")
 })
 
-test("injectCompressNudges: post-compress baseline re-establishment then small growth does NOT re-nudge", () => {
+test("injectCompressNudges: post-compress baseline then small growth does NOT re-nudge", () => {
     const state = createSessionState()
     state.modelContextLimit = 1_000_000
     const config = buildConfig()
     config.compress.maxContextLimit = 800_000
     config.compress.minContextLimit = 550_000
 
-    // Turn 1: compress detected → baseline cleared to undefined
+    // Turn 1: compress detected → baseline set to 250K (200K input + 50K output)
     const turn1: WithParts[] = [
         userMsg("u1", "hello"),
         assistantMsgWithTokens("a1", "done", { input: 200_000, output: 50_000 }, [
@@ -269,9 +340,9 @@ test("injectCompressNudges: post-compress baseline re-establishment then small g
         ]),
     ]
     injectCompressNudges(state, config, logger, turn1, {} as any)
-    assert.equal(state.nudges.lastPerMessageNudgeTokens, undefined)
+    assert.equal(state.nudges.lastPerMessageNudgeTokens, 250_000)
 
-    // Turn 2: baseline re-established from post-compression API tokens, no nudge
+    // Turn 2: small growth (253K - 250K = 3K < 50K threshold) → no nudge
     const turn2: WithParts[] = [
         userMsg("u2", "next"),
         assistantMsgWithTokens("a2", "response", { input: 247_000, output: 6_000 }),
@@ -281,17 +352,18 @@ test("injectCompressNudges: post-compress baseline re-establishment then small g
     assert.equal(
         state.nudges.shouldInjectThisTurn,
         false,
-        "baseline re-establishment turn — should NOT nudge",
+        "3K growth from compress baseline — should NOT nudge",
     )
 })
 
-test("injectCompressNudges: post-compress baseline re-establishment then large growth DOES nudge", () => {
+test("injectCompressNudges: post-compress baseline then large growth DOES nudge", () => {
     const state = createSessionState()
     state.modelContextLimit = 1_000_000
     const config = buildConfig()
     config.compress.maxContextLimit = 800_000
     config.compress.minContextLimit = 550_000
 
+    // Turn 1: compress → baseline set to 250K
     const turn1: WithParts[] = [
         userMsg("u1", "hello"),
         assistantMsgWithTokens("a1", "done", { input: 200_000, output: 50_000 }, [
@@ -300,6 +372,7 @@ test("injectCompressNudges: post-compress baseline re-establishment then large g
     ]
     injectCompressNudges(state, config, logger, turn1, {} as any)
 
+    // Turn 2: 55K growth (305K - 250K) >= 50K threshold → nudge fires
     const turn2: WithParts[] = [
         userMsg("u2", "next"),
         assistantMsgWithTokens("a2", "baseline", { input: 250_000, output: 55_000 }),
@@ -307,114 +380,62 @@ test("injectCompressNudges: post-compress baseline re-establishment then large g
     injectCompressNudges(state, config, logger, turn2, {} as any)
     assert.equal(
         state.nudges.shouldInjectThisTurn,
-        false,
-        "baseline establishment turn — should NOT nudge",
-    )
-    assert.equal(state.nudges.lastPerMessageNudgeTokens, 305_000)
-
-    const turn3: WithParts[] = [
-        userMsg("u3", "more"),
-        assistantMsgWithTokens("a3", "growth", { input: 356_000, output: 5_000 }),
-    ]
-    injectCompressNudges(state, config, logger, turn3, {} as any)
-
-    assert.equal(
-        state.nudges.shouldInjectThisTurn,
         true,
-        "56K growth after baseline re-establishment (> 50K adaptive threshold) — should nudge",
+        "55K growth from compress baseline (250K→305K, >50K threshold) — should nudge",
     )
-    assert.equal(state.nudges.lastPerMessageNudgeTokens, 361_000)
+    assert.equal(state.nudges.lastPerMessageNudgeTokens, 250_000, "baseline NOT updated after nudge — only compress resets")
 })
 
-test("injectCompressNudges: after compress, tool-output baseline cleared to undefined for re-establishment", () => {
+test("nudge threshold halves after first nudge without compress (issue #23)", () => {
     const state = createSessionState()
     state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 100_000
     const config = buildConfig()
     config.compress.maxContextLimit = 800_000
-    config.compress.minContextLimit = 550_000
+    config.compress.minContextLimit = 200_000
 
-    // Turn 1: seed tool-output baseline (~15K tokens from 60K chars)
-    const turn1: WithParts[] = [
+    const messages1: WithParts[] = [
         userMsg("u1", "hello"),
-        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 50_000 }, [
-            toolPart("t1", "x".repeat(60_000)),
-        ]),
+        assistantMsgWithTokens("a1", "done", { input: 100_000, output: 50_000 }),
     ]
-    injectCompressNudges(state, config, logger, turn1, {} as any)
-    assert.ok(
-        state.nudges.lastToolOutputNudgeTokens !== undefined,
-        "tool-output baseline must be seeded before compress",
-    )
+    injectCompressNudges(state, config, logger, messages1, {} as any)
+    assert.equal(state.nudges.shouldInjectThisTurn, true, "50K growth >= 50K threshold → first nudge")
+    assert.equal(state.nudges.lastNudgeShownTokens, 150_000, "lastNudgeShownTokens set to currentTokens")
 
-    // Turn 2: compress detected → tool-output baseline cleared to undefined
-    const turn2: WithParts[] = [
-        userMsg("u2", "compress now"),
-        assistantMsgWithTokens("a2", "compressed", { input: 200_000, output: 50_000 }, [
+    const messages2: WithParts[] = [
+        userMsg("u2", "more"),
+        assistantMsgWithTokens("a2", "work", { input: 160_000, output: 5_000 }),
+    ]
+    injectCompressNudges(state, config, logger, messages2, {} as any)
+    assert.equal(state.nudges.shouldInjectThisTurn, false, "15K growth from lastShown < 25K (halved) → no nudge")
+
+    const messages3: WithParts[] = [
+        userMsg("u3", "more"),
+        assistantMsgWithTokens("a3", "work", { input: 170_000, output: 5_000 }),
+    ]
+    injectCompressNudges(state, config, logger, messages3, {} as any)
+    assert.equal(state.nudges.shouldInjectThisTurn, true, "25K growth from lastShown >= 25K (halved) → nudge fires")
+    assert.equal(state.nudges.lastNudgeShownTokens, 175_000)
+})
+
+test("nudge threshold restores to full after compress (issue #23)", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 100_000
+    state.nudges.lastNudgeShownTokens = 150_000
+    const config = buildConfig()
+    config.compress.maxContextLimit = 800_000
+    config.compress.minContextLimit = 200_000
+
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 100_000, output: 50_000 }, [
             compressToolPart("c1", "compressed"),
         ]),
     ]
-    injectCompressNudges(state, config, logger, turn2, {} as any)
-
-    assert.equal(
-        state.nudges.lastToolOutputNudgeTokens,
-        undefined,
-        "lastToolOutputNudgeTokens must be undefined after compress — composition.toolTokens reflects pre-compression context, not post-compression",
-    )
-})
-
-test("injectCompressNudges: post-compress tool-output baseline re-establishment then large growth DOES fire reminder", () => {
-    const state = createSessionState()
-    state.modelContextLimit = 1_000_000
-    const config = buildConfig()
-    config.compress.maxContextLimit = 800_000
-    config.compress.minContextLimit = 550_000
-
-    // Turn 1: seed tool-output baseline
-    const turn1: WithParts[] = [
-        userMsg("u1", "hello"),
-        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 50_000 }, [
-            toolPart("t1", "x".repeat(60_000)),
-        ]),
-    ]
-    injectCompressNudges(state, config, logger, turn1, {} as any)
-
-    // Turn 2: compress → tool-output baseline cleared
-    const turn2: WithParts[] = [
-        userMsg("u2", "compress now"),
-        assistantMsgWithTokens("a2", "compressed", { input: 200_000, output: 50_000 }, [
-            compressToolPart("c1", "compressed"),
-        ]),
-    ]
-    injectCompressNudges(state, config, logger, turn2, {} as any)
-    assert.equal(state.nudges.lastToolOutputNudgeTokens, undefined)
-
-    // Turn 3: baseline re-established from post-compression tool tokens (~5K from 20K chars), no reminder
-    const turn3: WithParts[] = [
-        userMsg("u3", "next"),
-        assistantMsgWithTokens("a3", "response", { input: 100_000, output: 10_000 }, [
-            toolPart("t2", "x".repeat(20_000)),
-        ]),
-    ]
-    injectCompressNudges(state, config, logger, turn3, {} as any)
-    assert.ok(
-        state.nudges.lastToolOutputNudgeTokens !== undefined,
-        "tool-output baseline re-established from post-compression composition",
-    )
-    const reestablished = state.nudges.lastToolOutputNudgeTokens
-
-    // Turn 4: large tool growth (~70K from 280K chars) → growth 65K > 50K threshold → reminder fires
-    const turn4: WithParts[] = [
-        userMsg("u4", "more"),
-        assistantMsgWithTokens("a4", "response", { input: 100_000, output: 10_000 }, [
-            toolPart("t3", "x".repeat(280_000)),
-        ]),
-    ]
-    injectCompressNudges(state, config, logger, turn4, {} as any)
-    assert.notEqual(
-        state.nudges.lastToolOutputNudgeTokens,
-        reestablished,
-        "large tool growth >= 50K adaptive threshold after re-establishment — reminder must fire and advance baseline",
-    )
+    injectCompressNudges(state, config, logger, messages, {} as any)
+    assert.equal(state.nudges.lastNudgeShownTokens, undefined, "compress resets lastNudgeShownTokens")
+    assert.equal(state.nudges.lastPerMessageNudgeTokens, 150_000, "compress sets baseline to post-compression currentTokens")
 })
 
 test("injectCompressNudges persists new nudge baseline to disk when a growth nudge fires without anchor changes (#60)", async () => {
@@ -449,7 +470,7 @@ test("injectCompressNudges persists new nudge baseline to disk when a growth nud
     injectCompressNudges(state, config, logger, messages, {} as any)
 
     assert.equal(state.nudges.shouldInjectThisTurn, true, "growth nudge should fire (55K >= 50K adaptive)")
-    assert.equal(state.nudges.lastPerMessageNudgeTokens, 255_000, "in-memory baseline updated to currentTokens")
+    assert.equal(state.nudges.lastPerMessageNudgeTokens, 200_000, "baseline NOT updated after nudge — nudges repeat until compress")
 
     // saveSessionState is fire-and-forget inside injectCompressNudges (.catch(()=>{})); flush before reload.
     await new Promise((resolve) => setTimeout(resolve, 50))
@@ -458,13 +479,13 @@ test("injectCompressNudges persists new nudge baseline to disk when a growth nud
     assert.ok(reloaded, "state must be persisted when a nudge fires")
     assert.equal(
         reloaded!.nudges.lastPerMessageNudgeTokens,
-        255_000,
-        "[#60] new baseline must reach disk — otherwise restart reloads the stale 200K and the nudge refires every turn",
+        200_000,
+        "baseline unchanged on disk — nudges repeat every turn until model actually compresses",
     )
     await cleanupPersistSession()
 })
 
-test("E2E: nudge survives compress → restart → re-establishment → growth (issue #23)", async () => {
+test("E2E: nudge survives compress → restart → growth (issue #23)", async () => {
     await cleanupPersistSession()
 
     const state = createSessionState()
@@ -474,7 +495,7 @@ test("E2E: nudge survives compress → restart → re-establishment → growth (
     config.compress.maxContextLimit = 800_000
     config.compress.minContextLimit = 200_000
 
-    // Turn 1: model calls compress → baseline cleared to undefined
+    // Turn 1: model calls compress → baseline set to 250K (200K+50K)
     const turn1: WithParts[] = [
         userMsg("u1", "hello"),
         assistantMsgWithTokens("a1", "done", { input: 200_000, output: 50_000 }, [
@@ -482,34 +503,35 @@ test("E2E: nudge survives compress → restart → re-establishment → growth (
         ]),
     ]
     injectCompressNudges(state, config, logger, turn1, {} as any)
-    assert.equal(state.nudges.lastPerMessageNudgeTokens, undefined, "compress should clear baseline")
+    assert.equal(state.nudges.lastPerMessageNudgeTokens, 250_000, "compress sets baseline to post-compression tokens")
 
     // Simulate restart: load from disk
     await new Promise((resolve) => setTimeout(resolve, 50))
     const loaded1 = await loadSessionState(PERSIST_SESSION, logger)
-    assert.equal(loaded1!.nudges.lastPerMessageNudgeTokens, undefined, "on-disk baseline must be undefined after compress")
+    assert.equal(loaded1!.nudges.lastPerMessageNudgeTokens, 250_000, "on-disk baseline must be 250K after compress")
 
     const state2 = createSessionState()
     state2.sessionId = PERSIST_SESSION
     state2.modelContextLimit = 1_000_000
     state2.nudges.lastPerMessageNudgeTokens = loaded1!.nudges.lastPerMessageNudgeTokens
+    state2.nudges.compressBaselineSet = loaded1!.nudges.compressBaselineSet ?? false
 
-    // Turn 2: post-compress turn → baseline re-established (no nudge)
+    // Turn 2: post-compress turn, context dropped to 155K — baseline correction adjusts
     const turn2: WithParts[] = [
         userMsg("u2", "next"),
         assistantMsgWithTokens("a2", "response", { input: 150_000, output: 5_000 }),
     ]
     injectCompressNudges(state2, config, logger, turn2, {} as any)
-    assert.equal(state2.nudges.shouldInjectThisTurn, false, "baseline re-establishment turn should NOT nudge")
-    assert.equal(state2.nudges.lastPerMessageNudgeTokens, 155_000, "baseline re-established to real post-compression tokens")
+    // 155K < 250K - 50K = 200K → baseline corrected to 155K
+    assert.equal(state2.nudges.lastPerMessageNudgeTokens, 155_000, "baseline corrected down to actual post-compression level")
 
-    // Simulate restart AGAIN: the bug was that baseline was NOT persisted here
+    // Simulate restart AGAIN: baseline must persist
     await new Promise((resolve) => setTimeout(resolve, 50))
     const loaded2 = await loadSessionState(PERSIST_SESSION, logger)
     assert.equal(
         loaded2!.nudges.lastPerMessageNudgeTokens,
         155_000,
-        "baseline re-establishment MUST persist to disk — otherwise nudges never fire after restart following compress",
+        "corrected baseline MUST persist to disk",
     )
 
     // Turn 3: load persisted baseline, then grow past threshold → nudge MUST fire
@@ -526,7 +548,7 @@ test("E2E: nudge survives compress → restart → re-establishment → growth (
     assert.equal(
         state3.nudges.shouldInjectThisTurn,
         true,
-        "55K growth past re-established baseline (155K→210K, >50K threshold) — nudge MUST fire",
+        "55K growth past corrected baseline (155K→210K, >50K threshold) — nudge MUST fire",
     )
 
     await cleanupPersistSession()
@@ -566,113 +588,6 @@ function suffixText(messages: WithParts[]): string {
         .map((m) => m.parts.map((p: any) => (typeof p.text === "string" ? p.text : "")).join(""))
         .join("")
 }
-
-test("toolOutput reminder does NOT fire for small tool growth on large-context model (#18 regression)", () => {
-    const state = createSessionState()
-    state.modelContextLimit = 1_000_000
-    const config = buildConfig()
-    config.compress.maxContextLimit = 900_000
-    config.compress.minContextLimit = 800_000
-
-    // Turn 1: seed tool baseline (~6K tokens of tool output content).
-    const turn1: WithParts[] = [
-        userMsg("u1", "hi"),
-        assistantMsgWithTokens("a1", "ok", { input: 50_000, output: 10_000 }, [
-            toolPart("c1", "x".repeat(24_000)),
-        ]),
-    ]
-    injectCompressNudges(state, config, logger, turn1, {} as any)
-    const baseline = state.nudges.lastToolOutputNudgeTokens
-    assert.ok(baseline !== undefined, "tool baseline seeded on first call")
-
-    // Turn 2: ~9K new tool growth. Old hardcoded 5000 → would fire; 50K adaptive → must NOT.
-    const turn2: WithParts[] = [
-        userMsg("u2", "more"),
-        assistantMsgWithTokens("a2", "ok", { input: 50_000, output: 10_000 }, [
-            toolPart("c2", "x".repeat(60_000)),
-        ]),
-    ]
-    injectCompressNudges(state, config, logger, turn2, {} as any)
-
-    assert.equal(
-        state.nudges.lastToolOutputNudgeTokens,
-        baseline,
-        "9K tool growth < 50K adaptive threshold — reminder must NOT fire (issue #18)",
-    )
-    assert.ok(
-        !suffixText(turn2).includes("new tool outputs accumulated"),
-        "no accumulation reminder text injected",
-    )
-})
-
-test("toolOutput reminder DOES fire when tool growth crosses adaptive threshold", () => {
-    const state = createSessionState()
-    state.modelContextLimit = 1_000_000
-    const config = buildConfig()
-    config.compress.maxContextLimit = 900_000
-    config.compress.minContextLimit = 800_000
-
-    const turn1: WithParts[] = [
-        userMsg("u1", "hi"),
-        assistantMsgWithTokens("a1", "ok", { input: 50_000, output: 10_000 }, [
-            toolPart("c1", "x".repeat(24_000)),
-        ]),
-    ]
-    injectCompressNudges(state, config, logger, turn1, {} as any)
-    const baseline = state.nudges.lastToolOutputNudgeTokens
-
-    // Turn 2: ~64K new tool growth — crosses the 50K adaptive threshold.
-    const turn2: WithParts[] = [
-        userMsg("u2", "more"),
-        assistantMsgWithTokens("a2", "ok", { input: 50_000, output: 10_000 }, [
-            toolPart("c2", "x".repeat(280_000)),
-        ]),
-    ]
-    injectCompressNudges(state, config, logger, turn2, {} as any)
-
-    assert.notEqual(
-        state.nudges.lastToolOutputNudgeTokens,
-        baseline,
-        "64K tool growth >= 50K adaptive threshold — reminder must fire and advance baseline",
-    )
-    assert.ok(
-        suffixText(turn2).includes("new tool outputs accumulated"),
-        "accumulation reminder text must be injected when threshold crossed",
-    )
-})
-
-test("explicit toolOutputNudgeThreshold override is respected", () => {
-    const state = createSessionState()
-    state.modelContextLimit = 1_000_000
-    const config = buildConfig()
-    config.compress.maxContextLimit = 900_000
-    config.compress.minContextLimit = 800_000
-    config.compress.toolOutputNudgeThreshold = 8_000
-
-    const turn1: WithParts[] = [
-        userMsg("u1", "hi"),
-        assistantMsgWithTokens("a1", "ok", { input: 50_000, output: 10_000 }, [
-            toolPart("c1", "x".repeat(24_000)),
-        ]),
-    ]
-    injectCompressNudges(state, config, logger, turn1, {} as any)
-    const baseline = state.nudges.lastToolOutputNudgeTokens
-
-    // ~9K tool growth: below the 50K adaptive default but above the 8K override → fires.
-    const turn2: WithParts[] = [
-        userMsg("u2", "more"),
-        assistantMsgWithTokens("a2", "ok", { input: 50_000, output: 10_000 }, [
-            toolPart("c2", "x".repeat(60_000)),
-        ]),
-    ]
-    injectCompressNudges(state, config, logger, turn2, {} as any)
-
-    assert.notEqual(
-        state.nudges.lastToolOutputNudgeTokens,
-        baseline,
-        "9K growth >= 8K override — reminder must fire (override wins over adaptive default)",
-    )
-})
 
 // --- modelContextLimit persistence (issue #18) ---
 // modelContextLimit must survive restart so adaptive thresholds (nudgeGrowthTokens,
@@ -720,38 +635,3 @@ test("ensureSessionInitialized restores persisted modelContextLimit after restar
     await cleanupModelLimitSession()
 })
 
-test("nudge thresholds scale with modelContextLimit — fixed thresholds must not bypass 5% protection (#18 systemic guard)", () => {
-    const seedChars = 16_000
-    const growthChars = 76_000
-
-    function reminderFiresAt(limit: number): boolean {
-        const state = createSessionState()
-        state.modelContextLimit = limit
-        const config = buildConfig()
-        config.compress.maxContextLimit = limit * 2
-        config.compress.minContextLimit = limit * 2
-
-        injectCompressNudges(state, config, logger, [
-            userMsg("u1", "hi"),
-            assistantMsgWithTokens("a1", "ok", { input: 1_000, output: 1_000 }, [
-                toolPart("c1", "x".repeat(seedChars)),
-            ]),
-        ], {} as any)
-        const baseline = state.nudges.lastToolOutputNudgeTokens
-
-        injectCompressNudges(state, config, logger, [
-            userMsg("u2", "more"),
-            assistantMsgWithTokens("a2", "ok", { input: 1_000, output: 1_000 }, [
-                toolPart("c2", "x".repeat(growthChars)),
-            ]),
-        ], {} as any)
-
-        return state.nudges.lastToolOutputNudgeTokens !== baseline
-    }
-
-    assert.ok(reminderFiresAt(200_000), "15K growth > 10K threshold (200K × 5%) → must fire")
-    assert.ok(
-        !reminderFiresAt(400_000),
-        "15K growth < 20K threshold (400K × 5%) → must NOT fire (a fixed threshold like the old 5000 would fire here → regression)",
-    )
-})

--- a/tests/keep-markers.test.ts
+++ b/tests/keep-markers.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { resolveKeepMarkers } from "../lib/compress/keep-markers"
+import { buildCompressibleRanges, formatCompressibleRanges } from "../lib/messages/inject/utils"
+import { createSessionState, type WithParts } from "../lib/state"
+import type { PluginConfig } from "../lib/config"
+
+function buildConfig(): PluginConfig {
+    return {
+        enabled: true,
+        autoUpdate: true,
+        debug: false,
+        pruneNotification: "off",
+        pruneNotificationType: "chat",
+        commands: { enabled: true, protectedTools: [] },
+        manualMode: { enabled: false, automaticStrategies: true },
+        turnProtection: { enabled: false, turns: 4 },
+        experimental: { allowSubAgents: false, customPrompts: false },
+        protectedFilePatterns: [],
+        compress: {
+            mode: "range", permission: "allow", showCompression: false, summaryBuffer: true,
+            maxContextLimit: 150000, minContextLimit: 50000,
+            nudgeFrequency: 5, iterationNudgeThreshold: 15, nudgeForce: "soft",
+            protectedTools: [], protectTags: false, protectUserMessages: false,
+        },
+        strategies: {
+            deduplication: { enabled: true, protectedTools: [] },
+            purgeErrors: { enabled: true, turns: 4, protectedTools: [] },
+        },
+        gc: { algorithm: "truncate", promotionThreshold: 5, maxBlockAge: 15, maxOldGenSummaryLength: 3000, majorGcThresholdPercent: "100%", batchCleanup: { lowThreshold: "60%", highThreshold: "75%", forceThreshold: "90%" } },
+    }
+}
+
+function mkMsg(id: string, role: "user" | "assistant", parts: any[]): WithParts {
+    return {
+        info: { id, role, sessionID: "s", agent: "a", time: { created: 1 } } as any,
+        parts,
+    }
+}
+
+function textPart(id: string, text: string) {
+    return { id: `${id}-p`, messageID: id, sessionID: "s", type: "text" as const, text }
+}
+
+function toolPart(callID: string, tool: string, output: string, input: any = {}) {
+    return {
+        id: `p-${callID}`, messageID: "m", sessionID: "s",
+        type: "tool" as const, tool, callID,
+        state: { status: "completed" as const, output, input },
+    }
+}
+
+test("resolveKeepMarkers: expands [[KEEP:mNNNNN]] with formatted content", () => {
+    const state = createSessionState()
+    state.messageIds.byRawId.set("msg1", "m00001")
+    state.messageIds.byRawId.set("msg2", "m00002")
+    const config = buildConfig()
+    const messages: WithParts[] = [
+        mkMsg("msg1", "assistant", [toolPart("c1", "bash", "test output")]),
+        mkMsg("msg2", "assistant", [textPart("msg2", "important text")]),
+    ]
+    const summary = "Did work. [[KEEP:m00001]] Then more. [[KEEP:m00002]]"
+    const result = resolveKeepMarkers(summary, messages, state, config)
+
+    assert.equal(result.expandedCount, 2)
+    assert.ok(result.summary.includes("test output"), "KEEP must expand bash output")
+    assert.ok(result.summary.includes("important text"), "KEEP must expand text content")
+    assert.ok(result.summary.includes("[m00001:"), "KEEP must label with ref")
+    assert.ok(result.summary.includes("[m00002:"), "KEEP must label with ref")
+})
+
+test("resolveKeepMarkers: converts [[REF:mNNNNN|desc]] to compact link", () => {
+    const state = createSessionState()
+    state.messageIds.byRawId.set("msg1", "m00001")
+    const config = buildConfig()
+    const messages: WithParts[] = [
+        mkMsg("msg1", "assistant", [toolPart("c1", "bash", "result")]),
+    ]
+    const summary = "See [[REF:m00001|test results]] for details."
+    const result = resolveKeepMarkers(summary, messages, state, config)
+
+    assert.equal(result.refCount, 1)
+    assert.ok(result.summary.includes("[→ m00001: test results]"), "REF must become compact link")
+    assert.ok(!result.summary.includes("$ undefined"), "REF must NOT expand the bash command")
+})
+
+test("resolveKeepMarkers: leaves unresolved markers intact", () => {
+    const state = createSessionState()
+    const config = buildConfig()
+    const messages: WithParts[] = []
+    const summary = "[[KEEP:m99999]] and [[REF:m99998|missing]]"
+    const result = resolveKeepMarkers(summary, messages, state, config)
+
+    assert.equal(result.expandedCount, 0)
+    assert.equal(result.refCount, 0)
+    assert.deepEqual(result.unresolvedRefs, ["m99999", "m99998"])
+    assert.ok(summary.includes("[[KEEP:m99999]]"), "unresolved KEEP stays as-is")
+})
+
+test("resolveKeepMarkers: truncates long content to keepEmbedMaxChars", () => {
+    const state = createSessionState()
+    state.messageIds.byRawId.set("msg1", "m00001")
+    const config = buildConfig()
+    config.compress.keepEmbedMaxChars = 100
+    const longOutput = "x".repeat(500)
+    const messages: WithParts[] = [
+        mkMsg("msg1", "assistant", [toolPart("c1", "bash", longOutput)]),
+    ]
+    const summary = "[[KEEP:m00001]]"
+    const result = resolveKeepMarkers(summary, messages, state, config)
+
+    assert.ok(result.summary.includes("[truncated"), "must indicate truncation")
+    assert.ok(/chars total/.test(result.summary), "must show original length")
+})
+
+test("resolveKeepMarkers: formats bash as $ command + output", () => {
+    const state = createSessionState()
+    state.messageIds.byRawId.set("msg1", "m00001")
+    const config = buildConfig()
+    const messages: WithParts[] = [
+        mkMsg("msg1", "assistant", [toolPart("c1", "bash", "pass", { command: "npm test" })]),
+    ]
+    const result = resolveKeepMarkers("[[KEEP:m00001]]", messages, state, config)
+    assert.ok(result.summary.includes("$ npm test"), "bash must show command with $ prefix")
+    assert.ok(result.summary.includes("pass"), "bash must show output")
+})
+
+test("buildCompressibleRanges: groups by conversation turns", () => {
+    const state = createSessionState()
+    for (let i = 1; i <= 10; i++) {
+        state.messageIds.byRawId.set(`msg${i}`, `m${String(i).padStart(5, "0")}`)
+    }
+    const messages: WithParts[] = [
+        mkMsg("msg1", "user", [textPart("msg1", "hello")]),
+        mkMsg("msg2", "assistant", [textPart("msg2", "hi"), toolPart("c1", "bash", "x".repeat(100))]),
+        mkMsg("msg3", "assistant", [textPart("msg3", "done")]),
+        mkMsg("msg4", "user", [textPart("msg4", "next")]),
+        mkMsg("msg5", "assistant", [textPart("msg5", "result"), toolPart("c2", "bash", "y".repeat(100))]),
+        mkMsg("msg6", "assistant", [textPart("msg6", "finished")]),
+    ]
+    const ranges = buildCompressibleRanges(messages, state)
+    assert.ok(ranges.length >= 1, "should produce at least 1 range")
+    assert.ok(ranges[0].msgCount >= 3, "first range should contain multiple messages")
+    assert.ok(ranges[0].tokens > 0, "range should have positive token count")
+})
+
+test("formatCompressibleRanges: produces formatted output", () => {
+    const state = createSessionState()
+    state.messageIds.byRawId.set("msg1", "m00001")
+    state.messageIds.byRawId.set("msg2", "m00002")
+    state.messageIds.byRawId.set("msg3", "m00003")
+    const messages: WithParts[] = [
+        mkMsg("msg1", "user", [textPart("msg1", "hello")]),
+        mkMsg("msg2", "assistant", [textPart("msg2", "response"), toolPart("c1", "bash", "x".repeat(200))]),
+        mkMsg("msg3", "assistant", [textPart("msg3", "done")]),
+    ]
+    const ranges = buildCompressibleRanges(messages, state)
+    const formatted = formatCompressibleRanges(ranges)
+    assert.ok(formatted.includes("Compressible ranges"), "must have header")
+    assert.ok(formatted.includes("m00001"), "must show start ref")
+})

--- a/tests/keep-markers.test.ts
+++ b/tests/keep-markers.test.ts
@@ -140,7 +140,7 @@ test("buildCompressibleRanges: groups by conversation turns", () => {
     ]
     const ranges = buildCompressibleRanges(messages, state)
     assert.ok(ranges.length >= 1, "should produce at least 1 range")
-    assert.ok(ranges[0].msgCount >= 3, "first range should contain multiple messages")
+    assert.ok(ranges[0].count >= 3, "first range should contain multiple messages")
     assert.ok(ranges[0].tokens > 0, "range should have positive token count")
 })
 

--- a/tests/nudge-text.test.ts
+++ b/tests/nudge-text.test.ts
@@ -112,7 +112,7 @@ test("buildContextUsageGuidance returns context number without compression guida
     assert.match(mid, /Context:/)
     assert.match(high, /Context:/)
 
-    assert.match(low, /be frugal/i)
+    assert.doesNotMatch(low, /be frugal/i)
     assert.doesNotMatch(low, /MUST|aggressive|critical/i)
     assert.doesNotMatch(mid, /growing|MUST|aggressive/i)
     assert.doesNotMatch(high, /aggressive|MUST/i)


### PR DESCRIPTION
## Summary

Comprehensive fix for issue #23 (ACP context memory leak). 7 commits, 22 files, 851 insertions, 327 deletions.

### Baseline Leak Fix (`compressBaselineSet` lock)

**Problem**: Compress drops context to 78K → model works to 150K in same turn → baseline re-establishes to 150K → 72K headroom leaked.

**Fix**: Lock flag prevents mid-turn baseline inflation. First compress detection sets baseline to `currentTokens`; subsequent transforms in same turn skip. Turn-wide scan (`messages.slice(currentTurnStart).some(...)`) replaces last-message-only check.

### KEEP/REF Markers

Model over-summarizes because it can't retype large content. Two markers:
- `[[KEEP:mNNNNN]]` — Auto-expand original content (truncated to 2000 chars)
- `[[REF:mNNNNN|description]]` — Compact link `[→ mNNNNN: desc]`

### Compressible Ranges Listing

Replaces size-based "Largest code/text messages" with need-based ranges grouped by conversation turn. Shows ALL ranges with gap detection.

### Compression Philosophy (5 bullets)

Need-based guidance replacing size-based recommendations:
1. All compression serves the primary task, but be frugal
2. Context capacity is precious — compress consumed outputs, don't avoid tools
3. Compress by need, not by percentage
4. Work from summaries — compress ALL listed ranges
5. Curate with KEEP/REF markers for critical content

### Other Fixes

- Remove `toolOutputReminder` (bypassed adaptive threshold)
- `acp_status` default = compressible ranges view
- Debug nudge (`config.debug` → terminal output)
- `baselineCorrected` persistence fix
- Bug 14 cap (detailed notification: 10K chars)
- System prompt 5 fixes
- Multi-block notification empty summary fix
- Oracle reviewed: all findings addressed

## Files Changed

- `lib/compress/keep-markers.ts` — NEW: marker resolution
- `lib/messages/inject/inject.ts` — compressBaselineSet lock + philosophy + ranges
- `lib/messages/inject/utils.ts` — buildCompressibleRanges + gap detection
- `lib/compress/status.ts` — acp_status ranges view
- `lib/prompts/compression-rules.ts` — COMPRESS_PHILOSOPHY
- `lib/prompts/system.ts` — 5 system prompt fixes
- `lib/state/` — compressBaselineSet flag (types, state, persistence, utils)
- `lib/ui/notification.ts` — Bug 14 cap + multi-block fix
- `lib/hooks.ts` — debug nudge callback
- `lib/compress/range.ts` — resolveKeepMarkers call
- `lib/config.ts` + `lib/config-validation.ts` — keepEmbedMaxChars
- `lib/prompts/compress-range.ts` — KEEP/REF docs
- `tests/` — 4 files updated (inject, keep-markers, acp-status, nudge-text)

## Verification

- `npm run typecheck`: 0 errors
- `npm run test`: 630 tests pass, 0 failures
- Oracle reviewed: core fix correct, all findings addressed
- Deployed and tested in live session

Issue: dog/opencode-acp#23