### PR TITLE
release: v1.12.0 — baseline leak fix + KEEP/REF + compressible ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,24 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.12.0 — Baseline Leak Fix + KEEP/REF Markers + Compressible Ranges (PR #115)
+
+Comprehensive fix for issue #23 (context memory leak). 7 commits, 22 files, 851 insertions, 327 deletions.
+
+**Baseline Leak Fix**: After compress, the model continues working in the same turn, inflating context from ~78K to ~150K. Each transform re-established the nudge baseline to the inflated value, leaking 72K of headroom. Fix: `compressBaselineSet` lock flag sets baseline only on the first post-compress transform; turn-wide compress scan (`messages.slice(currentTurnStart).some(...)`) replaces last-message-only check.
+
+**KEEP/REF Markers**: Models over-summarize because they can't precisely retype large content. `[[KEEP:mNNNNN]]` auto-expands original message content inline (truncated to 2000 chars). `[[REF:mNNNNN|desc]]` creates compact links. Resolution runs after summary finalization, before wrapping.
+
+**Compressible Ranges**: Replaces size-based "Largest code/text messages" listing with need-based ranges grouped by conversation turn. Shows ALL ranges with gap detection (no ranges spanning compressed holes). The nudge now says "compress ALL listed ranges" instead of recommending specific large items.
+
+**Compression Philosophy (5 bullets)**: Need-based guidance replacing size-based recommendations — compress by need not by percentage, work from summaries not raw outputs, curate with KEEP/REF for critical content.
+
+**Other fixes**: Removed `toolOutputReminder` (bypassed adaptive threshold, caused over-compression); `acp_status` default = compressible ranges view; debug nudge (`config.debug` → terminal output); `baselineCorrected` persistence fix; Bug 14 cap (detailed notification: 10K chars); system prompt 5 fixes; multi-block notification empty summary fix. Oracle reviewed.
+
+Files: `lib/messages/inject/inject.ts`, `lib/compress/keep-markers.ts`, `lib/messages/inject/utils.ts`, `lib/compress/status.ts`, `lib/prompts/compression-rules.ts`, `lib/prompts/system.ts`, `lib/state/`, `lib/ui/notification.ts`, `lib/hooks.ts`. Tests: 630 pass.
+
+---
+
 ### v1.11.4 — Baseline Persistence Fix + Unified Release Workflow (PR #112, #113)
 
 **Bug fix (PR #112)**: After compress sets `lastPerMessageNudgeTokens = undefined`, the next transform re-establishes the baseline in memory but never persists it to disk (save condition was false). After restart, nudges break again. Fix: added `baselineReEstablished` flag to save condition. Also fixed async save race condition in `writePersistedSessionState` (file path resolved after `await`).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -395,6 +395,24 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.12.0 — 基线泄露修复 + KEEP/REF 标记 + 可压缩范围（PR #115）
+
+Issue #23（上下文内存泄露）的综合修复。7 个 commit，22 个文件，851 行新增，327 行删除。
+
+**基线泄露修复**：压缩后模型在同一轮继续工作，上下文从 ~78K 膨胀到 ~150K。每次 transform 重新建立 nudge 基线到膨胀后的值，泄露 72K 余量。修复：`compressBaselineSet` 锁标志只在首次 post-compress transform 设基线；全轮扫描（`messages.slice(currentTurnStart).some(...)`）替换仅检查最后一条 assistant 消息。
+
+**KEEP/REF 标记**：模型过度摘要因为无法精确重打大段内容。`[[KEEP:mNNNNN]]` 自动展开原始消息内容（截断到 2000 字符）。`[[REF:mNNNNN|描述]]` 生成紧凑链接。解析在摘要定稿后、包装前执行。
+
+**可压缩范围**：用按需分组范围替换基于大小的"最大代码/文本消息"列表。显示所有范围，带间隔检测（不会跨越压缩洞）。nudge 现在说"压缩所有列出的范围"而不是推荐特定大项。
+
+**压缩哲学（5 条）**：基于需要的指导替换基于大小的推荐——按需压缩而非按百分比，基于摘要工作而非原始输出，用 KEEP/REF 策展关键内容。
+
+**其他修复**：移除 `toolOutputReminder`（绕过自适应阈值，导致过度压缩）；`acp_status` 默认 = 可压缩范围视图；调试 nudge（`config.debug` → 终端输出）；`baselineCorrected` 持久化修复；Bug 14 截断（detailed 通知：10K 字符）；系统提示 5 处修复；多块通知空摘要修复。经 Oracle 审查。
+
+文件：`lib/messages/inject/inject.ts`、`lib/compress/keep-markers.ts`、`lib/messages/inject/utils.ts`、`lib/compress/status.ts`、`lib/prompts/compression-rules.ts`、`lib/prompts/system.ts`、`lib/state/`、`lib/ui/notification.ts`、`lib/hooks.ts`。测试：630 通过。
+
+---
+
 ### v1.11.4 — 基线持久化修复 + 统一发布工作流（PR #112, #113）
 
 **Bug 修复（PR #112）**：压缩后 baseline 设为 `undefined`，下一轮重建为真实值但**不写盘**（save 条件为 false）。重启后 nudge 失效。修复：新增 `baselineReEstablished` flag 加入 save 条件。同时修复 `writePersistedSessionState` 异步竞态（文件路径在 `await` 之后解析）。

--- a/devlog/2026-07-12_release-v1.12.0/REQ.md
+++ b/devlog/2026-07-12_release-v1.12.0/REQ.md
@@ -1,0 +1,24 @@
+# REQ: Release v1.12.0
+
+## What
+
+Release v1.12.0 — bundles all issue #23 fixes from branch `2026-07-11_compress-keep-ranges`.
+
+## Changes in this release
+
+- Baseline leak fix (`compressBaselineSet` lock + turn-wide compress scan)
+- KEEP/REF markers
+- Compressible ranges listing (replaces size-based recommendations)
+- Compression Philosophy (5 bullets)
+- `toolOutputReminder` removal
+- `acp_status` default = ranges view
+- Debug nudge feature
+- `baselineCorrected` persistence fix
+- Bug 14 cap (detailed notification: 10K)
+- System prompt 5 fixes
+- Multi-block notification empty summary fix
+- Oracle reviewed
+
+## Source
+
+Branch `2026-07-11_compress-keep-ranges`, PR #115.

--- a/devlog/2026-07-12_release-v1.12.0/WORKLOG.md
+++ b/devlog/2026-07-12_release-v1.12.0/WORKLOG.md
@@ -1,0 +1,28 @@
+# WORKLOG
+
+## Branch: `2026-07-12_release-v1.12.0`
+
+### Steps
+
+1. Created release branch from `2026-07-11_compress-keep-ranges` (includes all PR #115 changes)
+2. Bumped `package.json` version: 1.11.4 → 1.12.0
+3. Added changelog entries to `README.md` and `README.zh-CN.md`
+4. Created devlog entry
+5. Committed, pushed, created PR
+
+### Contents
+
+All 7 commits from `2026-07-11_compress-keep-ranges`:
+- `1e4a92d` feat: KEEP/REF markers + compressible ranges listing
+- `5bca817` fix: add KEEP anti-pattern guidance to compress prompt
+- `3d9c801` fix: move KEEP anti-pattern guidance to HOW TO COMPRESS rules
+- `169e720` fix: compress detection overwrites disk baseline on restart
+- `3a4ed2c` fix: notification summary empty for multi-block compressions
+- `3f5bfbe` feat: inject nudge text to terminal when debug mode is on
+- `3d3def4` fix: baseline leak after compress + Oracle review fixes
+
+### Verification
+
+- 630 tests pass
+- typecheck OK
+- Oracle reviewed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.11.4",
+    "version": "1.12.0",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Release v1.12.0 — bundles all issue #23 fixes.

### What's included (7 commits from `2026-07-11_compress-keep-ranges` + release bump)

- **Baseline leak fix** (`compressBaselineSet` lock + turn-wide compress scan)
- **KEEP/REF markers** (`[[KEEP:mNNNNN]]` auto-expand, `[[REF:mNNNNN|desc]]` compact link)
- **Compressible ranges** (replaces size-based recommendations)
- **Compression Philosophy** (5 bullets, need-based)
- **`toolOutputReminder` removal** (bypassed adaptive threshold)
- **`acp_status` ranges view** (default = ranges, `view:"messages"` for old)
- **Debug nudge** (`config.debug` → terminal output)
- **Notification fixes** (Bug 14 cap, multi-block empty summary)
- **System prompt 5 fixes**
- **Oracle reviewed**

### Version bump
- `package.json`: 1.11.4 → 1.12.0
- `README.md` + `README.zh-CN.md`: changelog entries

### Verification
- 630 tests pass
- typecheck OK
- CI will auto-tag `v1.12.0` and publish to npm on merge

Closes issue #23 content from PR #115.

Issue: dog/opencode-acp#23