### PR TITLE
release: v1.12.1 — compression recap injection fix + stale compress stripping

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.12.1 — Compression Recap Injection Fix + Stale Compress Stripping (PR #119)
+
+**Problem**: `acp_context_recap` was used to create synthetic tool-result recap messages but was NOT registered as a real tool — providers could strip/convert unregistered tool-results, causing the model to see compression summaries as plain text or user messages (echo/drift bugs). Additionally, compress tool-call inputs duplicated block recap content in context.
+
+**Fix**: Register `acp_context_recap` as a real tool (`lib/compress/recap.ts`) so providers properly serialize tool-results. Add `stripStaleCompressCalls` (`lib/messages/prune.ts`) to remove compress tool-call parts from previous turns. Also fixes: KEEP/REF regex normalization (`m150` → `m00150`), `resolveKeepMarkers` in message mode, toast notification `replace()` failure, notification range display (`→ Range: b20: m00150–m00155`), proportional baseline adjustment after compress, and reverts the problematic `postCompressRangesShown` feature.
+
+Files: `lib/compress/recap.ts` (NEW), `lib/messages/prune.ts`, `lib/compress/keep-markers.ts`, `lib/compress/message.ts`, `lib/messages/inject/inject.ts`, `lib/ui/notification.ts`. Tests: `tests/strip-stale-compress.test.ts` (NEW, 7 tests). Oracle-reviewed.
+
 ### v1.12.0 — Baseline Leak Fix + KEEP/REF Markers + Compressible Ranges (PR #115)
 
 Comprehensive fix for issue #23 (context memory leak). 7 commits, 22 files, 851 insertions, 327 deletions.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -395,6 +395,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.12.1 — 压缩摘要注入修复 + 历史压缩调用剥离（PR #119）
+
+**问题**：`acp_context_recap` 用于创建合成的 tool-result 摘要消息，但未注册为真实工具——provider 可能剥离/转换未注册的 tool-result，导致模型将压缩摘要视为纯文本或用户消息（回声/漂移 bug）。此外，compress 工具调用的输入与 block recap 内容重复占用上下文。
+
+**修复**：将 `acp_context_recap` 注册为真实工具（`lib/compress/recap.ts`），使 provider 正确序列化 tool-result。新增 `stripStaleCompressCalls`（`lib/messages/prune.ts`），剥离历史轮次的 compress 工具调用部分。同时修复：KEEP/REF 正则归一化（`m150` → `m00150`）、message 模式下 `resolveKeepMarkers` 调用、toast 通知 `replace()` 失败、通知范围显示（`→ Range: b20: m00150–m00155`）、压缩后比例基线调整，并回退了有问题的 `postCompressRangesShown` 功能。
+
+文件：`lib/compress/recap.ts`（新增）、`lib/messages/prune.ts`、`lib/compress/keep-markers.ts`、`lib/compress/message.ts`、`lib/messages/inject/inject.ts`、`lib/ui/notification.ts`。测试：`tests/strip-stale-compress.test.ts`（新增，7 个测试）。经 Oracle 审查。
+
 ### v1.12.0 — 基线泄露修复 + KEEP/REF 标记 + 可压缩范围（PR #115）
 
 Issue #23（上下文内存泄露）的综合修复。7 个 commit，22 个文件，851 行新增，327 行删除。

--- a/devlog/2026-07-12_release-v1.12.1/REQ.md
+++ b/devlog/2026-07-12_release-v1.12.1/REQ.md
@@ -1,0 +1,22 @@
+# REQ: Release v1.12.1
+
+## Version
+1.12.0 → 1.12.1
+
+## Source
+PR #119 (branch `2026-07-12_post-compress-ranges`) — merged to master.
+
+## Changes
+- CRITICAL: Register `acp_context_recap` as real tool — fixes compression recap injection
+- `stripStaleCompressCalls` — removes compress tool-call parts from previous turns
+- KEEP/REF regex normalization (`m150` → `m00150`)
+- `resolveKeepMarkers` in message mode
+- Toast notification `replace()` fix
+- Notification range display (`→ Range: b20: m00150–m00155`)
+- Proportional baseline adjustment after compress
+- Revert `postCompressRangesShown` (caused over-compression chains)
+- Oracle review: 0 CRITICAL, 2 WARN addressed (test coverage + stale TODOs)
+
+## Verification
+- 638 tests pass, typecheck OK
+- Runtime verified: 37 recaps all `type: tool`, 0 compress calls in API context

--- a/devlog/2026-07-12_release-v1.12.1/WORKLOG.md
+++ b/devlog/2026-07-12_release-v1.12.1/WORKLOG.md
@@ -1,0 +1,14 @@
+# WORKLOG
+
+## Branch: `2026-07-12_release-v1.12.1`
+## Base: `master` (commit `1d0f236` — PR #119 merge)
+
+### Steps
+1. Created branch `2026-07-12_release-v1.12.1` from master
+2. Bumped `package.json`: 1.12.0 → 1.12.1
+3. Added changelog entry to `README.md`
+4. Added changelog entry to `README.zh-CN.md`
+5. Created devlog `devlog/2026-07-12_release-v1.12.1/`
+
+### CI
+On merge → `release.yml` detects `YYYY-MM-DD_release-v*` branch → auto-tags `v1.12.1` → builds → tests → publishes to npm → creates GitHub Release.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.12.0",
+    "version": "1.12.1",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Release v1.12.1 — bundle of PR #119 (compression recap injection fix + stale compress stripping + KEEP/REF fixes + baseline + notification).

### Changes (from PR #119)
- **CRITICAL**: Register `acp_context_recap` as real tool — fixes compression recap injection
- `stripStaleCompressCalls` — removes compress tool-call parts from previous turns
- KEEP/REF regex normalization (`m150` → `m00150`)
- `resolveKeepMarkers` in message mode
- Toast notification `replace()` fix + notification range display
- Proportional baseline adjustment after compress
- Revert `postCompressRangesShown`
- Oracle-reviewed (0 CRITICAL, 2 WARN addressed)
- 638 tests pass, 7 new

### Merge → Auto-publish
Merging this PR triggers `release.yml`: auto-tags `v1.12.1`, builds, tests, publishes to npm, creates GitHub Release.

Issue: dog/opencode-acp#23