### PR TITLE
fix: compress failure rollback & sync carve-out removal (issue #125)

### DIFF
--- a/devlog/2026-07-13_compress-failure-rollback/REQ.md
+++ b/devlog/2026-07-13_compress-failure-rollback/REQ.md
@@ -1,0 +1,76 @@
+# REQ: Compress Failure Rollback & Sync Carve-out Fix
+
+## Problem
+
+Two bugs in ACP's post-compression-failure handling (upstream issue #125):
+
+### Bug 1: No state rollback on compress tool failure
+
+`lib/compress/range.ts` and `lib/compress/message.ts` mutate in-memory state
+incrementally via `applyCompressionState()` in a loop. There is no try/catch,
+no snapshot/rollback. If anything throws between the first `applyCompressionState`
+and `finalizeSession()` (which persists state), the in-memory state is left with
+"ghost blocks" — active blocks that were never persisted.
+
+Ghost blocks affect subsequent message-transform runs: they hide messages and
+inject recaps despite the failure. On session restart, ghost blocks disappear
+(persisted state doesn't have them), creating memory/disk inconsistency.
+
+### Bug 2: sync.ts L60 carve-out causes message loss (issue #125 root cause)
+
+`lib/messages/sync.ts:54-66` had a carve-out: when a block's anchor message is
+missing from the current message list, the block is kept active if the anchor
+is tracked in `byMessageId`. The intent was to handle anchors hidden by ACP
+compression.
+
+However, `syncCompressionBlocks` runs on the **RAW message list** (before
+`filterCompressedRanges`), so ACP-hidden anchors are still present in the list.
+The carve-out only triggered for **externally-deleted** anchors (OpenCode
+compaction or manual message deletion).
+
+When the carve-out keeps a block active but the anchor is gone,
+`filterCompressedRanges` hides the block's messages (via `byMessageId`
+`activeBlockIds`) but cannot inject the recap (no anchor in message list) →
+**empty LLM request**. This is the exact symptom from issue #125.
+
+## Solution
+
+### Fix 1: State snapshot/rollback
+
+Add `snapshotCompressionState()` and `restoreCompressionState()` to
+`lib/compress/pipeline.ts`. Wrap the mutation phase (from `allocateRunId` to
+`finalizeSession`) in both `range.ts` and `message.ts` with try/catch. On
+failure, restore the snapshot and re-throw.
+
+Snapshot covers `state.prune.messages` (deep clone via `structuredClone`) and
+`state.stats` (shallow copy — only two number fields).
+
+### Fix 2: Remove sync.ts carve-out
+
+Replace the nested if/continue at sync.ts:54-66 with a simple deactivation
+when the anchor is missing. This is correct because:
+
+1. `syncCompressionBlocks` runs on the raw message list → ACP-hidden anchors
+   are still present → carve-out never triggers for them
+2. After OpenCode compaction, anchors are gone → blocks deactivated →
+   `byMessageId` `activeBlockIds` cleared → surviving messages unhidden →
+   clean state
+3. Without the anchor, `filterCompressedRanges` cannot inject recaps anyway
+
+## Files Changed
+
+- `lib/messages/sync.ts` — removed carve-out (Bug 2)
+- `lib/compress/pipeline.ts` — added snapshot/restore helpers (Bug 1)
+- `lib/compress/range.ts` — try/catch with rollback (Bug 1)
+- `lib/compress/message.ts` — try/catch with rollback (Bug 1)
+- `tests/sync.test.ts` — updated carve-out test, added issue #125 test
+- `tests/compress-rollback.test.ts` — new: snapshot/restore tests
+
+## Acceptance Criteria
+
+- [x] All 643 tests pass
+- [x] TypeScript type check passes
+- [x] Build succeeds
+- [x] sync.ts deactivates blocks when anchor is externally deleted (even if in byMessageId)
+- [x] compress tool restores state on failure (no ghost blocks)
+- [x] No backward compatibility issues (persisted state format unchanged)

--- a/devlog/2026-07-13_compress-failure-rollback/WORKLOG.md
+++ b/devlog/2026-07-13_compress-failure-rollback/WORKLOG.md
@@ -1,0 +1,63 @@
+# WORKLOG: Compress Failure Rollback & Sync Carve-out Fix
+
+## Iteration 1 — Investigation & Implementation
+
+### Investigation
+
+Read all relevant source files:
+- `lib/messages/sync.ts` — syncCompressionBlocks with L60 carve-out
+- `lib/messages/prune.ts` — filterCompressedRanges (actual filtering logic)
+- `lib/compress/range.ts` — range-mode compress tool (no try/catch)
+- `lib/compress/message.ts` — message-mode compress tool (no try/catch)
+- `lib/compress/state.ts` — applyCompressionState (heavy state mutation)
+- `lib/compress/pipeline.ts` — prepareSession/finalizeSession
+- `lib/state/types.ts` — PruneMessagesState, CompressionBlock types
+- `lib/state/utils.ts` — resetOnCompaction, serialize/deserialize helpers
+- `lib/state/persistence.ts` — saveSessionState/loadSessionState
+- `lib/strategies/deduplication.ts`, `lib/strategies/purge-errors.ts`
+
+### Key Finding
+
+Issue #125's described mechanism (`effectiveMessageIds - directMessageIds` filter)
+does NOT exist in the source code. The actual filtering uses `byMessageId` with
+`activeBlockIds`. However, the symptom (empty LLM request) is real, caused by
+the sync.ts L60 carve-out keeping blocks active when their anchors are externally
+deleted.
+
+### Implementation
+
+**Bug 2 fix** (`lib/messages/sync.ts`):
+- Removed the nested `if (!messagesState.byMessageId.has(block.anchorMessageId))`
+  check at L59-65
+- Replaced with unconditional deactivation when anchor is missing
+- Added detailed comment explaining why the carve-out was wrong
+
+**Bug 1 fix** (`lib/compress/pipeline.ts`, `range.ts`, `message.ts`):
+- Added `CompressionSnapshot` interface, `snapshotCompressionState()`, and
+  `restoreCompressionState()` to pipeline.ts
+- Snapshot uses `structuredClone` for `prune.messages` (deep clone, independent
+  Maps/Sets), shallow copy for `stats`
+- Restore also uses `structuredClone` to ensure snapshot stays pristine
+- Wrapped mutation phase in try/catch in both range.ts and message.ts
+- On catch: restore state, re-throw error
+
+### Test Changes
+
+- Updated `tests/sync.test.ts`:
+  - Changed "keeps block active when anchor is in byMessageId" → "deactivates
+    block when anchor is gone even if tracked in byMessageId"
+  - Added "issue #125: external anchor deletion deactivates block and clears
+    byMessageId activeBlockIds"
+
+- Created `tests/compress-rollback.test.ts`:
+  - snapshotCompressionState captures prune.messages and stats
+  - restoreCompressionState fully restores state after mutations
+  - snapshot is independent from state mutations
+  - restore creates independent Maps/Sets (no shared references)
+
+### Verification
+
+- TypeScript: pass
+- Tests: 643 pass, 0 fail
+- Build: success
+- Format: changed files formatted

--- a/lib/compress/message.ts
+++ b/lib/compress/message.ts
@@ -3,7 +3,13 @@ import type { ToolContext } from "./types"
 import { countMessageCharacters, countTokens } from "../token-utils"
 import { MESSAGE_FORMAT_EXTENSION } from "../prompts/extensions/tool"
 import { formatIssues, formatResult, resolveMessages, validateArgs } from "./message-utils"
-import { finalizeSession, prepareSession, type NotificationEntry } from "./pipeline"
+import {
+    finalizeSession,
+    prepareSession,
+    snapshotCompressionState,
+    restoreCompressionState,
+    type NotificationEntry,
+} from "./pipeline"
 import { appendProtectedPromptInfo, appendProtectedTools } from "./protected-content"
 import {
     allocateBlockId,
@@ -41,7 +47,9 @@ function buildSchema(maxSummaryLengthHard: number) {
         summaryMaxChars: tool.schema
             .number()
             .optional()
-            .describe(`Override max summary length (default max: ${maxSummaryLengthHard} chars). Use when content is important and needs more detail — don't lose critical info just to fit the limit.`),
+            .describe(
+                `Override max summary length (default max: ${maxSummaryLengthHard} chars). Use when content is important and needs more detail — don't lose critical info just to fit the limit.`,
+            ),
     }
 }
 
@@ -56,7 +64,9 @@ export function createCompressMessageTool(ctx: ToolContext): ReturnType<typeof t
             const input = args as CompressMessageToolArgs
             validateArgs(input)
 
-            const maxLen = (args as { summaryMaxChars?: number }).summaryMaxChars ?? ctx.config.compress.maxSummaryLengthHard
+            const maxLen =
+                (args as { summaryMaxChars?: number }).summaryMaxChars ??
+                ctx.config.compress.maxSummaryLengthHard
             for (const entry of input.content) {
                 if (entry.summary.length > maxLen) {
                     throw new Error(
@@ -143,50 +153,56 @@ export function createCompressMessageTool(ctx: ToolContext): ReturnType<typeof t
                 })
             }
 
+            const snapshot = snapshotCompressionState(ctx.state)
             const runId = allocateRunId(ctx.state)
 
-            for (const { plan, summaryWithTools } of preparedPlans) {
-                const blockId = allocateBlockId(ctx.state)
-                const keepResult = resolveKeepMarkers(
-                    summaryWithTools,
-                    rawMessages,
-                    ctx.state,
-                    ctx.config,
-                )
-                const resolvedSummary = keepResult.summary
-                const storedSummary = wrapCompressedSummary(blockId, resolvedSummary)
-                const summaryTokens = countTokens(storedSummary)
+            try {
+                for (const { plan, summaryWithTools } of preparedPlans) {
+                    const blockId = allocateBlockId(ctx.state)
+                    const keepResult = resolveKeepMarkers(
+                        summaryWithTools,
+                        rawMessages,
+                        ctx.state,
+                        ctx.config,
+                    )
+                    const resolvedSummary = keepResult.summary
+                    const storedSummary = wrapCompressedSummary(blockId, resolvedSummary)
+                    const summaryTokens = countTokens(storedSummary)
 
-                applyCompressionState(
-                    ctx.state,
-                    {
-                        topic: plan.entry.topic,
-                        batchTopic: input.topic,
-                        startId: plan.entry.messageId,
-                        endId: plan.entry.messageId,
-                        mode: "message",
+                    applyCompressionState(
+                        ctx.state,
+                        {
+                            topic: plan.entry.topic,
+                            batchTopic: input.topic,
+                            startId: plan.entry.messageId,
+                            endId: plan.entry.messageId,
+                            mode: "message",
+                            runId,
+                            compressMessageId: toolCtx.messageID,
+                            compressCallId: callId,
+                            summaryTokens,
+                        },
+                        plan.selection,
+                        plan.anchorMessageId,
+                        blockId,
+                        storedSummary,
+                        [],
+                        ctx.config.gc,
+                    )
+
+                    notifications.push({
+                        blockId,
                         runId,
-                        compressMessageId: toolCtx.messageID,
-                        compressCallId: callId,
+                        summary: resolvedSummary,
                         summaryTokens,
-                    },
-                    plan.selection,
-                    plan.anchorMessageId,
-                    blockId,
-                    storedSummary,
-                    [],
-                    ctx.config.gc,
-                )
+                    })
+                }
 
-                notifications.push({
-                    blockId,
-                    runId,
-                    summary: resolvedSummary,
-                    summaryTokens,
-                })
+                await finalizeSession(ctx, toolCtx, rawMessages, notifications, input.topic)
+            } catch (error) {
+                restoreCompressionState(ctx.state, snapshot)
+                throw error
             }
-
-            await finalizeSession(ctx, toolCtx, rawMessages, notifications, input.topic)
 
             // Compress input cleanup: handled by stripStaleCompressCalls in
             // lib/messages/prune.ts, called from hooks.ts during message transform.

--- a/lib/compress/pipeline.ts
+++ b/lib/compress/pipeline.ts
@@ -1,4 +1,4 @@
-import type { WithParts } from "../state"
+import type { PruneMessagesState, SessionState, SessionStats, WithParts } from "../state"
 import { ensureSessionInitialized } from "../state"
 import { saveSessionState } from "../state/persistence"
 import { assignMessageRefs } from "../message-ids"
@@ -10,6 +10,23 @@ import type { ToolContext } from "./types"
 import { buildSearchContext, fetchSessionMessages } from "./search"
 import type { SearchContext } from "./types"
 import { applyPendingCompressionDurations } from "./timing"
+
+export interface CompressionSnapshot {
+    messages: PruneMessagesState
+    stats: SessionStats
+}
+
+export function snapshotCompressionState(state: SessionState): CompressionSnapshot {
+    return {
+        messages: structuredClone(state.prune.messages),
+        stats: { ...state.stats },
+    }
+}
+
+export function restoreCompressionState(state: SessionState, snapshot: CompressionSnapshot): void {
+    state.prune.messages = structuredClone(snapshot.messages)
+    state.stats = { ...snapshot.stats }
+}
 
 interface RunContext {
     ask(input: {

--- a/lib/compress/pipeline.ts
+++ b/lib/compress/pipeline.ts
@@ -14,18 +14,24 @@ import { applyPendingCompressionDurations } from "./timing"
 export interface CompressionSnapshot {
     messages: PruneMessagesState
     stats: SessionStats
+    manualMode: SessionState["manualMode"]
 }
 
 export function snapshotCompressionState(state: SessionState): CompressionSnapshot {
     return {
         messages: structuredClone(state.prune.messages),
         stats: { ...state.stats },
+        manualMode: state.manualMode,
     }
 }
 
-export function restoreCompressionState(state: SessionState, snapshot: CompressionSnapshot): void {
+export function restoreCompressionState(
+    state: SessionState,
+    snapshot: CompressionSnapshot,
+): void {
     state.prune.messages = structuredClone(snapshot.messages)
     state.stats = { ...snapshot.stats }
+    state.manualMode = snapshot.manualMode
 }
 
 interface RunContext {

--- a/lib/compress/range.ts
+++ b/lib/compress/range.ts
@@ -2,7 +2,13 @@ import { tool } from "@opencode-ai/plugin"
 import type { ToolContext } from "./types"
 import { countMessageCharacters, countTokens } from "../token-utils"
 import { RANGE_FORMAT_EXTENSION } from "../prompts/extensions/tool"
-import { finalizeSession, prepareSession, type NotificationEntry } from "./pipeline"
+import {
+    finalizeSession,
+    prepareSession,
+    snapshotCompressionState,
+    restoreCompressionState,
+    type NotificationEntry,
+} from "./pipeline"
 import {
     appendProtectedPromptInfo,
     appendProtectedTools,
@@ -57,7 +63,9 @@ function buildSchema(maxSummaryLengthHard: number) {
         summaryMaxChars: tool.schema
             .number()
             .optional()
-            .describe(`Override max summary length (default max: ${maxSummaryLengthHard} chars). Use when content is important and needs more detail — don't lose critical info just to fit the limit.`),
+            .describe(
+                `Override max summary length (default max: ${maxSummaryLengthHard} chars). Use when content is important and needs more detail — don't lose critical info just to fit the limit.`,
+            ),
     }
 }
 
@@ -72,7 +80,9 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
             const input = args as CompressRangeToolArgs
             validateArgs(input)
 
-            const maxLen = (args as { summaryMaxChars?: number }).summaryMaxChars ?? ctx.config.compress.maxSummaryLengthHard
+            const maxLen =
+                (args as { summaryMaxChars?: number }).summaryMaxChars ??
+                ctx.config.compress.maxSummaryLengthHard
             for (const entry of input.content) {
                 if (entry.summary.length > maxLen) {
                     throw new Error(
@@ -225,52 +235,58 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
                 })
             }
 
+            const snapshot = snapshotCompressionState(ctx.state)
             const runId = allocateRunId(ctx.state)
 
-            for (const preparedPlan of preparedPlans) {
-                const blockId = allocateBlockId(ctx.state)
-                const keepResult = resolveKeepMarkers(
-                    preparedPlan.finalSummary,
-                    rawMessages,
-                    ctx.state,
-                    ctx.config,
-                )
-                preparedPlan.finalSummary = keepResult.summary
-                const storedSummary = wrapCompressedSummary(blockId, preparedPlan.finalSummary)
-                const summaryTokens = countTokens(storedSummary)
+            try {
+                for (const preparedPlan of preparedPlans) {
+                    const blockId = allocateBlockId(ctx.state)
+                    const keepResult = resolveKeepMarkers(
+                        preparedPlan.finalSummary,
+                        rawMessages,
+                        ctx.state,
+                        ctx.config,
+                    )
+                    preparedPlan.finalSummary = keepResult.summary
+                    const storedSummary = wrapCompressedSummary(blockId, preparedPlan.finalSummary)
+                    const summaryTokens = countTokens(storedSummary)
 
-                const applied = applyCompressionState(
-                    ctx.state,
-                    {
-                        topic: input.topic,
-                        batchTopic: input.topic,
-                        startId: preparedPlan.entry.startId,
-                        endId: preparedPlan.entry.endId,
-                        mode: "range",
+                    const applied = applyCompressionState(
+                        ctx.state,
+                        {
+                            topic: input.topic,
+                            batchTopic: input.topic,
+                            startId: preparedPlan.entry.startId,
+                            endId: preparedPlan.entry.endId,
+                            mode: "range",
+                            runId,
+                            compressMessageId: toolCtx.messageID,
+                            compressCallId: callId,
+                            summaryTokens,
+                        },
+                        preparedPlan.selection,
+                        preparedPlan.anchorMessageId,
+                        blockId,
+                        storedSummary,
+                        preparedPlan.consumedBlockIds,
+                        ctx.config.gc,
+                    )
+
+                    totalCompressedMessages += applied.messageIds.length
+
+                    notifications.push({
+                        blockId,
                         runId,
-                        compressMessageId: toolCtx.messageID,
-                        compressCallId: callId,
+                        summary: preparedPlan.finalSummary,
                         summaryTokens,
-                    },
-                    preparedPlan.selection,
-                    preparedPlan.anchorMessageId,
-                    blockId,
-                    storedSummary,
-                    preparedPlan.consumedBlockIds,
-                    ctx.config.gc,
-                )
+                    })
+                }
 
-                totalCompressedMessages += applied.messageIds.length
-
-                notifications.push({
-                    blockId,
-                    runId,
-                    summary: preparedPlan.finalSummary,
-                    summaryTokens,
-                })
+                await finalizeSession(ctx, toolCtx, rawMessages, notifications, input.topic)
+            } catch (error) {
+                restoreCompressionState(ctx.state, snapshot)
+                throw error
             }
-
-            await finalizeSession(ctx, toolCtx, rawMessages, notifications, input.topic)
 
             // Compress input cleanup: handled by stripStaleCompressCalls in
             // lib/messages/prune.ts, called from hooks.ts during message transform.
@@ -289,7 +305,11 @@ function extractBoundaryConsumedBlocks(
     const consumed: number[] = []
     const seen = new Set<number>()
     for (const ref of [startReference, endReference]) {
-        if (ref.kind === "compressed-block" && ref.blockId !== undefined && !seen.has(ref.blockId)) {
+        if (
+            ref.kind === "compressed-block" &&
+            ref.blockId !== undefined &&
+            !seen.has(ref.blockId)
+        ) {
             seen.add(ref.blockId)
             consumed.push(ref.blockId)
         }

--- a/lib/messages/sync.ts
+++ b/lib/messages/sync.ts
@@ -50,19 +50,28 @@ export const syncCompressionBlocks = (
             continue
         }
 
-        // Only deactivate if anchor message is completely gone from both current messages AND DCP tracked messages
+        // Deactivate block when its anchor message is gone from the current
+        // message list. This handles both OpenCode compaction (which removes old
+        // messages) and external message deletion. Without the anchor,
+        // filterCompressedRanges cannot inject the block's recap — keeping the
+        // block active would hide messages with no summary replacement.
+        //
+        // [FIX issue #125] Previous code had a carve-out that kept blocks active
+        // when the anchor was tracked in byMessageId. This was intended to handle
+        // anchors hidden by ACP compression, but syncCompressionBlocks runs on
+        // the RAW message list (before filterCompressedRanges), so ACP-hidden
+        // anchors are still present and never reach this branch. The carve-out
+        // only triggered for externally-deleted anchors, causing messages to be
+        // hidden without recap injection → empty LLM requests.
         if (
             typeof block.anchorMessageId === "string" &&
             block.anchorMessageId.length > 0 &&
             !messageIds.has(block.anchorMessageId)
         ) {
-            // If anchor exists in DCP's byMessageId (persisted), keep block active
-            if (!messagesState.byMessageId.has(block.anchorMessageId)) {
-                block.active = false
-                block.deactivatedAt = now
-                block.deactivatedByBlockId = undefined
-                continue
-            }
+            block.active = false
+            block.deactivatedAt = now
+            block.deactivatedByBlockId = undefined
+            continue
         }
 
         for (const consumedBlockId of block.consumedBlockIds) {

--- a/tests/compress-rollback.test.ts
+++ b/tests/compress-rollback.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { createSessionState } from "../lib/state"
+import { snapshotCompressionState, restoreCompressionState } from "../lib/compress/pipeline"
+import { applyCompressionState, allocateRunId, allocateBlockId } from "../lib/compress/state"
+import type { SelectionResolution, CompressionStateInput } from "../lib/compress/types"
+import type { GCConfig } from "../lib/config"
+
+const defaultGcConfig: GCConfig = {
+    algorithm: "truncate",
+    promotionThreshold: 5,
+    maxBlockAge: 15,
+    maxOldGenSummaryLength: 3000,
+    majorGcThresholdPercent: "100%",
+}
+
+function makeSelection(messageIds: string[], toolIds: string[] = []): SelectionResolution {
+    const messageTokenById = new Map<string, number>()
+    for (const id of messageIds) {
+        messageTokenById.set(id, 100)
+    }
+    return {
+        messageIds,
+        toolIds,
+        messageTokenById,
+        requiredBlockIds: [],
+        startReference: { kind: "message", rawIndex: 0 },
+        endReference: { kind: "message", rawIndex: 0 },
+    }
+}
+
+function makeCompressionInput(runId: number, blockId: number): CompressionStateInput {
+    return {
+        topic: "test",
+        batchTopic: "test",
+        startId: "m001",
+        endId: "m005",
+        mode: "range" as const,
+        runId,
+        compressMessageId: "compress-msg-1",
+        compressCallId: undefined,
+        summaryTokens: 50,
+    }
+}
+
+test("snapshotCompressionState captures prune.messages and stats", () => {
+    const state = createSessionState()
+    state.prune.messages.nextBlockId = 5
+    state.prune.messages.nextRunId = 3
+    state.stats.pruneTokenCounter = 42
+    state.stats.totalPruneTokens = 500
+
+    const snapshot = snapshotCompressionState(state)
+
+    state.prune.messages.nextBlockId = 99
+    state.stats.totalPruneTokens = 999
+
+    assert.equal(snapshot.messages.nextBlockId, 5, "snapshot preserves original value")
+    assert.equal(snapshot.messages.nextRunId, 3)
+    assert.equal(snapshot.stats.pruneTokenCounter, 42)
+    assert.equal(snapshot.stats.totalPruneTokens, 500)
+})
+
+test("restoreCompressionState fully restores state after mutations", () => {
+    const state = createSessionState()
+    state.stats.totalPruneTokens = 100
+
+    const selection = makeSelection(["msg-1", "msg-2", "msg-3"])
+    const snapshot = snapshotCompressionState(state)
+
+    const runId = allocateRunId(state)
+    const blockId = allocateBlockId(state)
+    applyCompressionState(
+        state,
+        makeCompressionInput(runId, blockId),
+        selection,
+        "anchor-1",
+        blockId,
+        "[Compressed conversation section]\ntest summary\n\n<b1>",
+        [],
+        defaultGcConfig,
+    )
+
+    assert.ok(state.prune.messages.blocksById.has(blockId), "block created after apply")
+    assert.ok(state.prune.messages.byMessageId.has("msg-1"), "byMessageId populated")
+    assert.notEqual(
+        state.prune.messages.nextBlockId,
+        snapshot.messages.nextBlockId,
+        "nextBlockId mutated",
+    )
+
+    restoreCompressionState(state, snapshot)
+
+    assert.equal(state.prune.messages.blocksById.size, 0, "blocksById cleared after restore")
+    assert.equal(state.prune.messages.byMessageId.size, 0, "byMessageId cleared after restore")
+    assert.equal(
+        state.prune.messages.activeBlockIds.size,
+        0,
+        "activeBlockIds cleared after restore",
+    )
+    assert.equal(state.prune.messages.nextBlockId, 1, "nextBlockId restored to initial")
+    assert.equal(state.prune.messages.nextRunId, 1, "nextRunId restored to initial")
+    assert.equal(state.stats.totalPruneTokens, 100, "stats restored")
+})
+
+test("snapshot is independent — mutating original does not affect snapshot", () => {
+    const state = createSessionState()
+    const snapshot = snapshotCompressionState(state)
+
+    state.prune.messages.byMessageId.set("test-id", {
+        tokenCount: 999,
+        allBlockIds: [42],
+        activeBlockIds: [42],
+    })
+    state.prune.messages.blocksById.set(42, {} as any)
+    state.prune.messages.activeBlockIds.add(42)
+
+    assert.equal(snapshot.messages.byMessageId.size, 0, "snapshot byMessageId unaffected")
+    assert.equal(snapshot.messages.blocksById.size, 0, "snapshot blocksById unaffected")
+    assert.equal(snapshot.messages.activeBlockIds.size, 0, "snapshot activeBlockIds unaffected")
+})
+
+test("restoreCompressionState creates independent Maps/Sets (no shared references)", () => {
+    const state = createSessionState()
+    state.prune.messages.byMessageId.set("msg-1", {
+        tokenCount: 100,
+        allBlockIds: [1],
+        activeBlockIds: [1],
+    })
+
+    const snapshot = snapshotCompressionState(state)
+    restoreCompressionState(state, snapshot)
+
+    state.prune.messages.byMessageId.set("msg-2", {
+        tokenCount: 200,
+        allBlockIds: [2],
+        activeBlockIds: [2],
+    })
+
+    assert.equal(
+        snapshot.messages.byMessageId.size,
+        1,
+        "snapshot unaffected by post-restore mutation",
+    )
+    assert.ok(!snapshot.messages.byMessageId.has("msg-2"), "snapshot has no msg-2")
+})

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -36,7 +36,13 @@ function makeBlock(overrides: Partial<CompressionBlock> & { blockId: number }): 
 
 function userMsg(id: string): WithParts {
     return {
-        info: { id, role: "user", sessionID: SID, agent: "a", time: { created: 1 } } as WithParts["info"],
+        info: {
+            id,
+            role: "user",
+            sessionID: SID,
+            agent: "a",
+            time: { created: 1 },
+        } as WithParts["info"],
         parts: [],
     }
 }
@@ -68,18 +74,31 @@ test("syncCompressionBlocks deactivates block when anchor message is deleted", (
     assert.ok(block.deactivatedAt !== undefined)
 })
 
-test("syncCompressionBlocks keeps block active when anchor is in byMessageId but not in messages", () => {
+test("syncCompressionBlocks deactivates block when anchor is gone even if tracked in byMessageId", () => {
     const state = createSessionState()
     state.prune.messages.blocksById.set(1, makeBlock({ blockId: 1, anchorMessageId: "m1" }))
-    state.prune.messages.byMessageId.set("m1", { tokenCount: 100, allBlockIds: [1], activeBlockIds: [1] })
+    state.prune.messages.byMessageId.set("m1", {
+        tokenCount: 100,
+        allBlockIds: [1],
+        activeBlockIds: [1],
+    })
     const messages = [userMsg("m2")]
     syncCompressionBlocks(state, logger, messages)
-    assert.ok(state.prune.messages.activeBlockIds.has(1), "block should stay active when anchor tracked in byMessageId")
+    const block = state.prune.messages.blocksById.get(1)!
+    assert.equal(
+        block.active,
+        false,
+        "block should be deactivated — anchor gone means recap cannot be injected",
+    )
+    assert.ok(!state.prune.messages.activeBlockIds.has(1))
 })
 
 test("syncCompressionBlocks deactivates user-deactivated blocks", () => {
     const state = createSessionState()
-    state.prune.messages.blocksById.set(1, makeBlock({ blockId: 1, anchorMessageId: "m1", deactivatedByUser: true }))
+    state.prune.messages.blocksById.set(
+        1,
+        makeBlock({ blockId: 1, anchorMessageId: "m1", deactivatedByUser: true }),
+    )
     const messages = [userMsg("m1")]
     syncCompressionBlocks(state, logger, messages)
     const block = state.prune.messages.blocksById.get(1)!
@@ -89,8 +108,14 @@ test("syncCompressionBlocks deactivates user-deactivated blocks", () => {
 
 test("syncCompressionBlocks deactivates consumed blocks when parent is active", () => {
     const state = createSessionState()
-    state.prune.messages.blocksById.set(1, makeBlock({ blockId: 1, anchorMessageId: "m1", createdAt: 1 }))
-    state.prune.messages.blocksById.set(2, makeBlock({ blockId: 2, anchorMessageId: "m3", consumedBlockIds: [1], createdAt: 2 }))
+    state.prune.messages.blocksById.set(
+        1,
+        makeBlock({ blockId: 1, anchorMessageId: "m1", createdAt: 1 }),
+    )
+    state.prune.messages.blocksById.set(
+        2,
+        makeBlock({ blockId: 2, anchorMessageId: "m3", consumedBlockIds: [1], createdAt: 2 }),
+    )
     state.prune.messages.activeBlockIds.add(1)
     const messages = [userMsg("m1"), userMsg("m3")]
     syncCompressionBlocks(state, logger, messages)
@@ -104,19 +129,67 @@ test("syncCompressionBlocks deactivates consumed blocks when parent is active", 
 test("syncCompressionBlocks updates byMessageId activeBlockIds after sync", () => {
     const state = createSessionState()
     state.prune.messages.blocksById.set(1, makeBlock({ blockId: 1, anchorMessageId: "m1" }))
-    state.prune.messages.byMessageId.set("m2", { tokenCount: 200, allBlockIds: [1], activeBlockIds: [1] })
+    state.prune.messages.byMessageId.set("m2", {
+        tokenCount: 200,
+        allBlockIds: [1],
+        activeBlockIds: [1],
+    })
     const messages = [userMsg("m2")]
     syncCompressionBlocks(state, logger, messages)
     const entry2 = state.prune.messages.byMessageId.get("m2")!
-    assert.equal(entry2.activeBlockIds.length, 0, "m2 activeBlockIds should be empty after block deactivated (anchor m1 gone)")
+    assert.equal(
+        entry2.activeBlockIds.length,
+        0,
+        "m2 activeBlockIds should be empty after block deactivated (anchor m1 gone)",
+    )
 })
 
 test("syncCompressionBlocks processes blocks in creation order", () => {
     const state = createSessionState()
-    state.prune.messages.blocksById.set(2, makeBlock({ blockId: 2, anchorMessageId: "m3", createdAt: 200 }))
-    state.prune.messages.blocksById.set(1, makeBlock({ blockId: 1, anchorMessageId: "m1", createdAt: 100 }))
+    state.prune.messages.blocksById.set(
+        2,
+        makeBlock({ blockId: 2, anchorMessageId: "m3", createdAt: 200 }),
+    )
+    state.prune.messages.blocksById.set(
+        1,
+        makeBlock({ blockId: 1, anchorMessageId: "m1", createdAt: 100 }),
+    )
     const messages = [userMsg("m1"), userMsg("m3")]
     syncCompressionBlocks(state, logger, messages)
     assert.ok(state.prune.messages.activeBlockIds.has(1))
     assert.ok(state.prune.messages.activeBlockIds.has(2))
+})
+
+test("issue #125: external anchor deletion deactivates block and clears byMessageId activeBlockIds", () => {
+    const state = createSessionState()
+    state.prune.messages.blocksById.set(1, makeBlock({ blockId: 1, anchorMessageId: "anchor-1" }))
+    state.prune.messages.activeBlockIds.add(1)
+    state.prune.messages.activeByAnchorMessageId.set("anchor-1", 1)
+    state.prune.messages.byMessageId.set("anchor-1", {
+        tokenCount: 100,
+        allBlockIds: [1],
+        activeBlockIds: [1],
+    })
+    state.prune.messages.byMessageId.set("surviving-msg", {
+        tokenCount: 200,
+        allBlockIds: [1],
+        activeBlockIds: [1],
+    })
+
+    const messages = [userMsg("surviving-msg")]
+
+    syncCompressionBlocks(state, logger, messages)
+
+    const block = state.prune.messages.blocksById.get(1)!
+    assert.equal(block.active, false, "block deactivated when anchor externally deleted")
+
+    const anchorEntry = state.prune.messages.byMessageId.get("anchor-1")!
+    assert.equal(anchorEntry.activeBlockIds.length, 0, "anchor activeBlockIds cleared")
+
+    const survivingEntry = state.prune.messages.byMessageId.get("surviving-msg")!
+    assert.equal(
+        survivingEntry.activeBlockIds.length,
+        0,
+        "surviving message activeBlockIds cleared — not hidden",
+    )
 })


### PR DESCRIPTION
## Summary

Fixes two bugs in ACP's post-compression-failure handling (#125):

### Bug 1: Compress tool state rollback

The compress tool mutated in-memory state incrementally via `applyCompressionState()` with no try/catch. If anything threw between the first mutation and `finalizeSession()` (which persists state), the in-memory state was left with "ghost blocks" — active blocks never persisted to disk.

**Fix**: Added `snapshotCompressionState()` / `restoreCompressionState()` to `lib/compress/pipeline.ts`. Wrapped the mutation phase in try/catch in both `range.ts` and `message.ts`. On failure, state is restored to the pre-mutation snapshot (deep clone via `structuredClone`).

### Bug 2: sync.ts L60 carve-out (issue #125 root cause)

`lib/messages/sync.ts:54-66` kept blocks active when the anchor was missing from messages but tracked in `byMessageId`. This was intended for anchors hidden by ACP compression, but `syncCompressionBlocks` runs on the **raw message list** (before `filterCompressedRanges`), so ACP-hidden anchors are still present in the list. The carve-out only triggered for **externally-deleted** anchors → messages hidden without recap injection → **empty LLM requests**.

**Fix**: Removed the carve-out. When anchor is gone from messages, always deactivate the block. `filterCompressedRanges` cannot inject recaps without an anchor anyway.

## Files Changed

| File | Change |
|------|--------|
| `lib/messages/sync.ts` | Removed carve-out — always deactivate when anchor missing (Bug 2) |
| `lib/compress/pipeline.ts` | Added `CompressionSnapshot`, `snapshotCompressionState()`, `restoreCompressionState()` (Bug 1) |
| `lib/compress/range.ts` | Wrapped mutation phase in try/catch with rollback (Bug 1) |
| `lib/compress/message.ts` | Wrapped mutation phase in try/catch with rollback (Bug 1) |
| `tests/sync.test.ts` | Updated carve-out test to assert deactivation; added issue #125 regression test |
| `tests/compress-rollback.test.ts` | New: 4 tests for snapshot/restore independence and correctness |

## Test Results

- TypeScript: ✅ pass
- Tests: ✅ 643 pass, 0 fail
- Build: ✅ success

## Devlog

`devlog/2026-07-13_compress-failure-rollback/` — REQ.md + WORKLOG.md