### PR TITLE
feat: batch compress interface (multi-topic) + cooldown rate-limit

### DIFF
--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -289,6 +289,12 @@
                 "toolOutputNudgeThreshold": {
                     "type": "number",
                     "description": "Tool-output token growth required before the tool-output accumulation reminder fires (absolute, not percentage). If unset, default follows nudgeGrowthTokens (adaptive: 5% of modelContextLimit, clamped to [6000, 50000]). Was hardcoded to 5000 — fired ~10x too often on large-context models (issue #18)."
+                },
+                "cooldownOutputs": {
+                    "type": "number",
+                    "minimum": 0,
+                    "default": 2,
+                    "description": "Minimum number of new assistant outputs required between successive compress calls. Blocks 'frequent compression' thrash (e.g. repeated tiny batches in the same turn). 0 or unset disables the cooldown. Exempt: first compress in a session, manual /acp compress, and compress when context is already over maxContextLimit (overflow priority)."
                 }
             },
             "default": {

--- a/devlog/2026-07-13_batch-compress/DESIGN.md
+++ b/devlog/2026-07-13_batch-compress/DESIGN.md
@@ -1,0 +1,113 @@
+# DESIGN - Batch Compress Interface (Multi-Topic)
+
+## 1. Schema (range mode)
+
+New canonical shape:
+```jsonc
+{
+  "topics": [
+    { "topic": "Auth Exploration", "content": [ { "startId": "m00001", "endId": "m00012", "summary": "..." } ] },
+    { "topic": "Build Fix",         "content": [ { "startId": "m00020", "endId": "m00035", "summary": "..." } ] }
+  ],
+  "summaryMaxChars": 6000  // optional, per-summary override
+}
+```
+
+Legacy shape (backward compat, wrapped internally to `[{topic, content}]`):
+```jsonc
+{ "topic": "Auth Exploration", "content": [ { "startId": "...", "endId": "...", "summary": "..." } ] }
+```
+
+### Tool schema (buildSchema)
+All fields optional at the schema layer so the SDK accepts both forms; structural enforcement moves to `normalizeTopics`/`validateArgs`:
+- `topics?`: array of `{ topic: string, content: array<{startId,endId,summary}> }`
+- `topic?`, `content?`: legacy single-topic fields
+- `summaryMaxChars?`: number
+
+`normalizeTopics(input) -> CompressBatchTopic[]`:
+- if `topics` is a non-empty array → use it
+- else if `topic` (string) + `content` (array) → `[{topic, content}]`
+- else → throw "Provide `topics` ..."
+
+### Type additions (lib/compress/types.ts)
+```ts
+export interface CompressBatchTopic { topic: string; content: CompressRangeEntry[] }
+```
+`ResolvedRangeCompression` gains `topic: string` (set during resolution from the owning topic).
+
+## 2. range.ts execute flow (revised)
+
+```
+normalizeTopics(input) -> topics[]
+for each topic: validateArgs({topic, content})   // reuse existing per-entry validation
+summary length check per entry (maxLen)
+prepareSession -> rawMessages, searchContext
+checkCompressCooldown(ctx, rawMessages)          // NEW
+resolvedPlans: for each topic -> resolveRanges({topic,content}, ...).map(p => ({...p, topic}))
+validateNonOverlapping(allResolvedPlans)         // GLOBAL across topics (unchanged fn)
+filterProtectedToolMessages per plan; drop empties
+minCompressRange total-chars check across all
+preparedPlans loop (parseBlockPlaceholders ... appendMissingBlockSummaries) — unchanged, per plan
+runId = allocateRunId ONCE
+for each preparedPlan:
+    blockId = allocateBlockId
+    applyCompressionState({ topic: plan.topic, batchTopic: plan.topic, ... })   // topic per plan
+recordCompressSuccess(ctx, rawMessages)          // NEW — before finalize so it persists
+finalizeSession(ctx, toolCtx, rawMessages, notifications, topics.length===1 ? topics[0].topic : undefined)
+```
+
+### Why range-utils barely changes
+`validateArgs` and `resolveRanges` already take the flat `{topic, content}`. We call them once per topic with that topic's flat shape, then tag each resolved plan with its topic. `validateNonOverlapping` already operates globally on a plan list — we feed it the concatenated list, so ranges from different topics are also overlap-checked. Only addition: `resolveRanges` populates `plan.topic = args.topic`.
+
+## 3. Cooldown design
+
+### State (lib/state/types.ts Nudges)
+```ts
+lastCompressAssistantCount?: number  // undefined = no prior compress this session
+```
+Persisted in `PersistedNudges`; `?? undefined` on load (old files → undefined → first compress allowed).
+
+### Config (lib/config.ts CompressConfig)
+```ts
+cooldownOutputs?: number  // default 2; undefined/0 disables
+```
+DEFAULT_CONFIG.compress.cooldownOutputs = 2; mergeCompress: `override.cooldownOutputs ?? base.cooldownOutputs`.
+
+### Helper (lib/compress/pipeline.ts)
+```ts
+checkCompressCooldown(ctx, rawMessages):
+  cooldown = ctx.config.compress.cooldownOutputs
+  if (cooldown === undefined || cooldown <= 0) return        // disabled
+  if (ctx.state.manualMode === "compress-pending") return    // manual /acp compress exempt
+  last = ctx.state.nudges.lastCompressAssistantCount
+  if (last === undefined) return                             // first compress
+  if (isOverMaxContextLimit(ctx, rawMessages)) return        // overflow priority
+  current = countAssistantOutputs(rawMessages)
+  if (current - last < cooldown) throw "Frequent compression blocked: ..."
+
+recordCompressSuccess(ctx, rawMessages):
+  ctx.state.nudges.lastCompressAssistantCount = countAssistantOutputs(rawMessages)
+```
+- `countAssistantOutputs`: `messages.filter(m => m.info.role === "assistant" && m.info.summary !== true).length` (exclude synthetic recap pseudo-messages).
+- `isOverMaxContextLimit`: mirrors inject/utils.ts — resolves `maxContextLimit` (% of modelContextLimit or absolute number) vs `getCurrentTokenUsage(state, rawMessages)`.
+
+### Placement
+Called in range.ts and message.ts execute **after prepareSession, before any state mutation**. `recordCompressSuccess` called **immediately before finalizeSession** (so it persists; all throwing checks precede it).
+
+### Why count assistant messages
+Same-turn double-compress sees the same rawMessages → delta 0 → blocked. After 1 new assistant output → delta 1 → blocked (cooldown 2). After 2 → allowed. Robust to message-transform vs tool-call timing because it measures persisted assistant message count, not turn number.
+
+## 4. message.ts
+No schema change (already per-entry topic + batch). Only adds `checkCompressCooldown` after prepareSession and `recordCompressSuccess` before finalize.
+
+## 5. Prompts
+- `compress-range.ts` BATCHING → rewritten for `topics` (group independent ranges under separate topics in ONE call).
+- `extensions/tool.ts` RANGE_FORMAT_EXTENSION → shows `topics` JSON.
+- `context-limit-nudge.ts` / `turn-nudge.ts` / `iteration-nudge.ts` → multi-topic JSON example + "compress everything in one call".
+- `messages/inject/inject.ts:295` one-call hint expanded to mention `topics`.
+
+## 6. Backward compatibility
+- Persisted state: `lastCompressAssistantCount` optional; old files load (undefined → first compress allowed).
+- Tool args: legacy `{topic, content}` accepted via shim.
+- Config: `cooldownOutputs` optional; old configs get default 2 via merge.
+- Internal `dcp` tags/naming untouched.

--- a/devlog/2026-07-13_batch-compress/REQ.md
+++ b/devlog/2026-07-13_batch-compress/REQ.md
@@ -1,0 +1,46 @@
+# REQ - Batch Compress Interface (Multi-Topic)
+
+- Task ID: `2026-07-13_batch-compress`
+- Home Repo: `opencode-acp`
+- Created: 2026-07-13
+- Status: InProgress
+- Priority: P1
+- Owner: sisyphus
+- References: dog/opencode-acp#26
+
+## 1. Background & Problem Statement
+
+- **Context**: The `compress` tool (range mode) accepts a single `topic` + a `content` array of ranges per call. When the model needs to compress several unrelated conversation phases in one go, it must either (a) issue multiple compress calls (wasteful, and each call re-runs prepare/finalize), or (b) force everything under one inaccurate topic label.
+- **Current behavior (symptom)**: One call = one topic (with N ranges). No rate-limit against the model calling compress repeatedly with tiny batches ("frequent compression" thrash).
+- **Expected behavior**:
+  1. One call = multiple topics, each topic grouping its own ranges: `{ topics: [{ topic, content: [{startId,endId,summary}] }, ...] }`.
+  2. A cooldown rate-limits successive compress calls: block if called again before `cooldownOutputs` (default 2) new assistant outputs have appeared. Exemptions: first compress, manual `/acp compress`, and overMaxLimit (overflow priority).
+  3. Tool description, system prompt format extension, and the per-5%-injection nudges all updated to teach the new multi-topic format and to emphasize "compress everything in one call".
+  4. Backward compatibility: legacy single-topic `{topic, content}` still accepted (wrapped internally).
+- **Impact**: Fewer compress round-trips, more accurate per-topic summaries, less model thrash from repeated compress calls.
+
+## 2. Constraints & Non-Goals
+
+- **Constraints**:
+  - Backward compatibility: persisted state format additions must be optional (old state files load cleanly). Legacy `{topic, content}` tool args still accepted. Internal `dcp` tags/naming unchanged.
+  - No new dependencies. TypeScript strict, no `as any`/`@ts-ignore`.
+  - Per-summary char cap stays at `maxSummaryLengthHard` (default 10000); batch multiplies total budget naturally (N summaries × cap). GC old-gen truncation (>3000) unchanged.
+  - Message mode already supports per-entry topic — NOT changed structurally (only gets the cooldown).
+- **Non-Goals**: Changing block allocation (one range → one block, shared runId per call), GC, prune, recap injection, decompress.
+
+## 3. Acceptance Criteria (must be testable)
+
+- [ ] `compress({topics:[{topic,content:[...]},{topic,content:[...]}]})` creates blocks, each tagged with its own topic, sharing one runId.
+- [ ] Legacy `compress({topic,content:[...]})` still works (wrapped to single-topic batch).
+- [ ] Ranges from different topics are globally overlap-checked (no double-compressing same messages).
+- [ ] Cooldown blocks a second compress when fewer than `cooldownOutputs` new assistant messages exist; allows after threshold met; first compress / manual / overMaxLimit are exempt.
+- [ ] `cooldownOutputs` persisted across restart (backward-compat: old files without it load fine).
+- [ ] Tool description + format extension + 3 nudges show the `topics` format and one-call guidance.
+- [ ] `npm run typecheck`, `npm test`, `npm run build` all pass.
+- [ ] New `tests/compress-batch.test.ts` covers multi-topic, legacy shim, overlap across topics, and cooldown.
+
+## 4. Proposed Approach
+
+- **Affected modules**: `lib/compress/{types,range,range-utils,pipeline,message}.ts`, `lib/config.ts`, `lib/config-validation.ts`, `dcp.schema.json`, `lib/state/{types,state,persistence}.ts`, `lib/prompts/{compress-range,extensions/tool,context-limit-nudge,turn-nudge,iteration-nudge}.ts`, `lib/messages/inject/inject.ts`. See DESIGN.md.
+- **Risks**: Schema validation coupling (mitigated: schema accepts both forms); cooldown breaking multi-compress tests (mitigated: cooldown optional + undefined-disables).
+- **Rollback strategy**: Revert the branch; no persisted-state destructive migration (additive only).

--- a/devlog/2026-07-13_batch-compress/WORKLOG.md
+++ b/devlog/2026-07-13_batch-compress/WORKLOG.md
@@ -1,0 +1,57 @@
+# WORKLOG - Batch Compress Interface (Multi-Topic)
+
+- Task ID: `2026-07-13_batch-compress`
+- References: dog/opencode-acp#26
+- Status: Implemented — typecheck, 646 tests, build all pass.
+
+## Summary
+
+Added a batch interface to the `compress` tool: one call now accepts multiple topics, each grouping its own ranges. Introduced a `cooldownOutputs` rate-limit that blocks repeated compress calls until enough new assistant outputs appear. Updated the tool description, system-prompt format extension, and the three injection nudges to teach the `topics` format and emphasize compressing everything in one call. Legacy single-topic `{topic, content}` args remain accepted via an internal backward-compat shim.
+
+## Changes by Layer
+
+### State (`lib/state/`)
+
+- `types.ts`: `Nudges` gained `lastCompressAssistantCount: number | undefined` — records the assistant-output count at the last successful compress; used by the cooldown check.
+- `state.ts`: `createInitialState`, `resetSessionState`, and the persisted-state restore path all initialize/carry the new field.
+- `utils.ts`: `resetOnCompaction` (third `Nudges` construction site) initializes it too — typecheck caught this.
+- `persistence.ts`: `PersistedNudges` gained the optional field; `saveSessionState` writes it. Old state files without the field load cleanly (`undefined` → cooldown disabled until first success).
+
+### Config (`lib/config.ts`, `lib/config-validation.ts`, `dcp.schema.json`)
+
+- `CompressConfig.cooldownOutputs?: number` (optional; default `2` in `DEFAULT_CONFIG`).
+- `mergeCompress` propagates the override-or-base value.
+- `config-validation.ts`: `compress.cooldownOutputs` added to `VALID_CONFIG_KEYS` with a `typeof === "number" && >= 0` check.
+- `dcp.schema.json`: `cooldownOutputs` property (number, min 0, default 2) added to `compress`.
+
+### Compress subsystem (`lib/compress/`)
+
+- `types.ts`: new `CompressBatchTopic { topic: string; content: CompressRangeEntry[] }`; `ResolvedRangeCompression` gained `topic: string`.
+- `range-utils.ts`: `resolveRanges` stamps `plan.topic = args.topic`; `validateNonOverlapping` error now names the offending topics. The existing "Overlapping ranges cannot be compressed in the same batch" phrase is retained so existing tests still match.
+- `pipeline.ts`: four new helpers — `countAssistantOutputs`, `isOverMaxContextLimit` (mirrors `inject/utils` logic, returns `false` when `modelContextLimit` is unset to avoid a compress→inject reverse dependency), `checkCompressCooldown` (early-returns on disabled/manual/first-call/over-limit; else throws a "Frequent compression blocked" error), `recordCompressSuccess` (writes the assistant-output count on success).
+- `range.ts`: `buildSchema` rewritten — `topics` is the new primary input (array of `{topic, content}`); legacy `topic`/`content` still accepted; `summaryMaxChars` retained. `normalizeTopics()` wraps a legacy single-topic call into a one-element `topics` array, or throws guidance if neither shape is present. `execute` flow: normalize → per-topic `validateArgs` → summary-length loop → `prepareSession` → `checkCompressCooldown` → `flatMap` resolve all topics → global `validateNonOverlapping` → (unchanged filter/min-range/prepare loop) → single `allocateRunId` → per-plan `applyCompressionState` (carrying `topic` + `batchTopic`) → `recordCompressSuccess` → `finalizeSession`. All blocks in one call share one `runId`.
+- `message.ts`: added `checkCompressCooldown` after `prepareSession` and `recordCompressSuccess` before `finalizeSession`. Schema unchanged (message mode already had per-entry topic).
+
+### Prompts (`lib/prompts/`)
+
+- `compress-range.ts`: "BATCHING" section rewritten to "BATCHING — MULTIPLE TOPICS IN ONE CALL" with a `topics` JSON example and the rules (one topic per concern, all ready ranges in one call, don't split, global overlap, legacy accepted).
+- `extensions/tool.ts`: `RANGE_FORMAT_EXTENSION` now shows the `topics` array JSON.
+- `context-limit-nudge.ts`, `turn-nudge.ts`, `iteration-nudge.ts`: JSON examples switched to `topics`; "add more `topics` entries" guidance.
+- `messages/inject/inject.ts`: the one-call hint at the injection site mentions `topics`.
+
+### Tests
+
+- `tests/compress-batch.test.ts` (new, 8 tests): multi-topic (2 blocks, own topics, shared runId), legacy shim, cross-topic overlap rejected, cooldown blocks, cooldown allows, manual bypass, cooldown disabled, missing-fields guidance.
+- `tests/prompts.test.ts`: one assertion updated (`content` array → `topics`).
+
+## Verification
+
+- `npm run typecheck` — clean.
+- `npm test` — 646 pass / 0 fail (638 existing + 8 new).
+- `npm run build` — succeeds (`dist/index.js` 389 KB).
+
+## Notes / Gotchas
+
+- Existing test `buildConfig()` factories omit `cooldownOutputs`, so at runtime it is `undefined` and the cooldown helper early-returns — this is why no existing multi-compress test needed changes.
+- In the new cooldown tests, `state.sessionId` is pinned to the test session ID before calling `execute`, so `ensureSessionInitialized` (which resets state on a sessionId mismatch) becomes a no-op and the manually-set `nudges`/`manualMode` fields survive.
+- Backticks inside the nudge template literals had to be escaped (`\``) — an unescaped backtick trips TS1005.

--- a/lib/compress/message.ts
+++ b/lib/compress/message.ts
@@ -3,7 +3,13 @@ import type { ToolContext } from "./types"
 import { countMessageCharacters, countTokens } from "../token-utils"
 import { MESSAGE_FORMAT_EXTENSION } from "../prompts/extensions/tool"
 import { formatIssues, formatResult, resolveMessages, validateArgs } from "./message-utils"
-import { finalizeSession, prepareSession, type NotificationEntry } from "./pipeline"
+import {
+    checkCompressCooldown,
+    finalizeSession,
+    prepareSession,
+    recordCompressSuccess,
+    type NotificationEntry,
+} from "./pipeline"
 import { appendProtectedPromptInfo, appendProtectedTools } from "./protected-content"
 import {
     allocateBlockId,
@@ -75,6 +81,7 @@ export function createCompressMessageTool(ctx: ToolContext): ReturnType<typeof t
                 toolCtx,
                 `Compress Message: ${input.topic}`,
             )
+            checkCompressCooldown(ctx, rawMessages)
             const { plans, skippedIssues, skippedCount } = resolveMessages(
                 input,
                 searchContext,
@@ -186,6 +193,7 @@ export function createCompressMessageTool(ctx: ToolContext): ReturnType<typeof t
                 })
             }
 
+            recordCompressSuccess(ctx, rawMessages)
             await finalizeSession(ctx, toolCtx, rawMessages, notifications, input.topic)
 
             // Compress input cleanup: handled by stripStaleCompressCalls in

--- a/lib/compress/pipeline.ts
+++ b/lib/compress/pipeline.ts
@@ -108,3 +108,47 @@ export async function finalizeSession(
         contextTokensBefore,
     )
 }
+
+function countAssistantOutputs(messages: WithParts[]): number {
+    return messages.filter((m) => m.info.role === "assistant" && m.info.summary !== true).length
+}
+
+function isOverMaxContextLimit(ctx: ToolContext, rawMessages: WithParts[]): boolean {
+    const limit = ctx.config.compress.maxContextLimit
+    const modelLimit = ctx.state.modelContextLimit
+    if (modelLimit === undefined || modelLimit <= 0) return false
+
+    let maxLimit: number
+    if (typeof limit === "number") {
+        maxLimit = limit
+    } else if (typeof limit === "string" && limit.endsWith("%")) {
+        const pct = Math.max(0, Math.min(100, Number.parseFloat(limit)))
+        if (!Number.isFinite(pct)) return false
+        maxLimit = Math.round((pct / 100) * modelLimit)
+    } else {
+        return false
+    }
+
+    return getCurrentTokenUsage(ctx.state, rawMessages) > maxLimit
+}
+
+export function checkCompressCooldown(ctx: ToolContext, rawMessages: WithParts[]): void {
+    const cooldown = ctx.config.compress.cooldownOutputs
+    if (cooldown === undefined || cooldown <= 0) return
+    if (ctx.state.manualMode === "compress-pending") return
+
+    const last = ctx.state.nudges.lastCompressAssistantCount
+    if (last === undefined) return
+    if (isOverMaxContextLimit(ctx, rawMessages)) return
+
+    const current = countAssistantOutputs(rawMessages)
+    if (current - last < cooldown) {
+        throw new Error(
+            `Frequent compression blocked: only ${current - last} new assistant output(s) since your last compress (cooldownOutputs=${cooldown}). Combine everything into a single compress call with multiple \`topics\` instead of many small calls. If context is genuinely full, finish the current step and compress the largest consumed ranges together.`,
+        )
+    }
+}
+
+export function recordCompressSuccess(ctx: ToolContext, rawMessages: WithParts[]): void {
+    ctx.state.nudges.lastCompressAssistantCount = countAssistantOutputs(rawMessages)
+}

--- a/lib/compress/range-utils.ts
+++ b/lib/compress/range-utils.ts
@@ -61,6 +61,7 @@ export function resolveRanges(
 
         return {
             index,
+            topic: args.topic,
             entry: normalizedEntry,
             selection,
             anchorMessageId: resolveAnchorMessageId(startReference),
@@ -90,7 +91,7 @@ export function validateNonOverlapping(plans: ResolvedRangeCompression[]): void 
         }
 
         issues.push(
-            `content[${previous.index}] (${previous.entry.startId}..${previous.entry.endId}) overlaps content[${current.index}] (${current.entry.startId}..${current.entry.endId}). Overlapping ranges cannot be compressed in the same batch.`,
+            `topic "${previous.topic}" content[${previous.index}] (${previous.entry.startId}..${previous.entry.endId}) overlaps topic "${current.topic}" content[${current.index}] (${current.entry.startId}..${current.entry.endId}). Overlapping ranges cannot be compressed in the same batch.`,
         )
     }
 

--- a/lib/compress/range.ts
+++ b/lib/compress/range.ts
@@ -2,7 +2,13 @@ import { tool } from "@opencode-ai/plugin"
 import type { ToolContext } from "./types"
 import { countMessageCharacters, countTokens } from "../token-utils"
 import { RANGE_FORMAT_EXTENSION } from "../prompts/extensions/tool"
-import { finalizeSession, prepareSession, type NotificationEntry } from "./pipeline"
+import {
+    checkCompressCooldown,
+    finalizeSession,
+    prepareSession,
+    recordCompressSuccess,
+    type NotificationEntry,
+} from "./pipeline"
 import {
     appendProtectedPromptInfo,
     appendProtectedTools,
@@ -25,40 +31,80 @@ import {
     applyCompressionState,
     wrapCompressedSummary,
 } from "./state"
-import type { CompressRangeToolArgs } from "./types"
+import type { CompressBatchTopic, CompressRangeEntry } from "./types"
 import { resolveKeepMarkers } from "./keep-markers"
+
+function rangeEntrySchema() {
+    return tool.schema.object({
+        startId: tool.schema
+            .string()
+            .describe(
+                "Message or block ID marking the beginning of range (e.g. m00001, b2)",
+            ),
+        endId: tool.schema
+            .string()
+            .describe("Message or block ID marking the end of range (e.g. m00012, b5)"),
+        summary: tool.schema
+            .string()
+            .describe(
+                "Complete technical summary replacing all content in range. Keep only essential details (conclusions, file paths, decisions, exact values, etc.).",
+            ),
+    })
+}
 
 function buildSchema(maxSummaryLengthHard: number) {
     return {
-        topic: tool.schema
-            .string()
-            .describe("Short label (3-5 words) for display - e.g., 'Auth System Exploration'"),
-        content: tool.schema
+        topics: tool.schema
             .array(
                 tool.schema.object({
-                    startId: tool.schema
+                    topic: tool.schema
                         .string()
                         .describe(
-                            "Message or block ID marking the beginning of range (e.g. m00001, b2)",
+                            "Short label (3-5 words) for this group - e.g., 'Auth System Exploration'",
                         ),
-                    endId: tool.schema
-                        .string()
-                        .describe("Message or block ID marking the end of range (e.g. m00012, b5)"),
-                    summary: tool.schema
-                        .string()
-                        .describe(
-                            "Complete technical summary replacing all content in range. Keep only essential details (conclusions, file paths, decisions, exact values, etc.).",
-                        ),
+                    content: tool.schema
+                        .array(rangeEntrySchema())
+                        .describe("One or more ranges to compress under this topic"),
                 }),
             )
+            .optional()
             .describe(
-                "One or more ranges to compress, each with start/end boundaries and a summary",
+                "One or more topics, each grouping multiple ranges. Compress everything that is ready in a SINGLE call — do not split into multiple compress calls. Each topic becomes its own labeled block.",
+            ),
+        topic: tool.schema
+            .string()
+            .optional()
+            .describe(
+                "[Legacy] Single-topic label. Prefer `topics`. Accepted for backward compatibility.",
+            ),
+        content: tool.schema
+            .array(rangeEntrySchema())
+            .optional()
+            .describe(
+                "[Legacy] Ranges for a single topic. Prefer `topics`. Accepted for backward compatibility.",
             ),
         summaryMaxChars: tool.schema
             .number()
             .optional()
             .describe(`Override max summary length (default max: ${maxSummaryLengthHard} chars). Use when content is important and needs more detail — don't lose critical info just to fit the limit.`),
     }
+}
+
+function normalizeTopics(input: {
+    topics?: unknown
+    topic?: unknown
+    content?: unknown
+}): CompressBatchTopic[] {
+    const topicsField = input.topics
+    if (Array.isArray(topicsField) && topicsField.length > 0) {
+        return topicsField as CompressBatchTopic[]
+    }
+    if (typeof input.topic === "string" && Array.isArray(input.content)) {
+        return [{ topic: input.topic, content: input.content as CompressRangeEntry[] }]
+    }
+    throw new Error(
+        "Provide `topics` (an array of { topic, content: [{ startId, endId, summary }] }) so all ready ranges compress in one call. The legacy single-topic { topic, content } shape is also accepted.",
+    )
 }
 
 export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof tool> {
@@ -69,15 +115,22 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
         description: runtimePrompts.compressRange + RANGE_FORMAT_EXTENSION,
         args: buildSchema(ctx.config.compress.maxSummaryLengthHard),
         async execute(args, toolCtx) {
-            const input = args as CompressRangeToolArgs
-            validateArgs(input)
+            const topics = normalizeTopics(args as Parameters<typeof normalizeTopics>[0])
 
-            const maxLen = (args as { summaryMaxChars?: number }).summaryMaxChars ?? ctx.config.compress.maxSummaryLengthHard
-            for (const entry of input.content) {
-                if (entry.summary.length > maxLen) {
-                    throw new Error(
-                        `Summary too long (${entry.summary.length} chars, max ${maxLen}).\n1. If this summary is nearly the same size as the original content, it may not be worth compressing — skip it.\n2. Strip noise (failed attempts, verbose outputs) but keep project-critical details (file paths, decisions, exact values).\n3. For important content needing detail, pass summaryMaxChars to increase the limit — don't lose critical info just to fit. Example: add "summaryMaxChars": 6000 to the tool call args.`,
-                    )
+            for (const topic of topics) {
+                validateArgs(topic)
+            }
+
+            const maxLen =
+                (args as { summaryMaxChars?: number }).summaryMaxChars ??
+                ctx.config.compress.maxSummaryLengthHard
+            for (const topic of topics) {
+                for (const entry of topic.content) {
+                    if (entry.summary.length > maxLen) {
+                        throw new Error(
+                            `Summary too long (${entry.summary.length} chars, max ${maxLen}).\n1. If this summary is nearly the same size as the original content, it may not be worth compressing — skip it.\n2. Strip noise (failed attempts, verbose outputs) but keep project-critical details (file paths, decisions, exact values).\n3. For important content needing detail, pass summaryMaxChars to increase the limit — don't lose critical info just to fit. Example: add "summaryMaxChars": 6000 to the tool call args.`,
+                        )
+                    }
                 }
             }
 
@@ -89,9 +142,13 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
             const { rawMessages, searchContext } = await prepareSession(
                 ctx,
                 toolCtx,
-                `Compress Range: ${input.topic}`,
+                `Compress Range: ${topics.map((t) => t.topic).join(" + ")}`,
             )
-            const resolvedPlans = resolveRanges(input, searchContext, ctx.state)
+            checkCompressCooldown(ctx, rawMessages)
+
+            const resolvedPlans = topics.flatMap((topic) =>
+                resolveRanges(topic, searchContext, ctx.state),
+            )
             validateNonOverlapping(resolvedPlans)
 
             const filteredPlans = resolvedPlans
@@ -138,6 +195,7 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
 
             const notifications: NotificationEntry[] = []
             const preparedPlans: Array<{
+                topic: string
                 entry: (typeof filteredPlans)[number]["entry"]
                 selection: (typeof filteredPlans)[number]["selection"]
                 anchorMessageId: string
@@ -217,6 +275,7 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
                 })
 
                 preparedPlans.push({
+                    topic: plan.topic,
                     entry: plan.entry,
                     selection: plan.selection,
                     anchorMessageId: plan.anchorMessageId,
@@ -242,8 +301,8 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
                 const applied = applyCompressionState(
                     ctx.state,
                     {
-                        topic: input.topic,
-                        batchTopic: input.topic,
+                        topic: preparedPlan.topic,
+                        batchTopic: preparedPlan.topic,
                         startId: preparedPlan.entry.startId,
                         endId: preparedPlan.entry.endId,
                         mode: "range",
@@ -270,7 +329,14 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
                 })
             }
 
-            await finalizeSession(ctx, toolCtx, rawMessages, notifications, input.topic)
+            recordCompressSuccess(ctx, rawMessages)
+            await finalizeSession(
+                ctx,
+                toolCtx,
+                rawMessages,
+                notifications,
+                topics.length === 1 ? topics[0]!.topic : undefined,
+            )
 
             // Compress input cleanup: handled by stripStaleCompressCalls in
             // lib/messages/prune.ts, called from hooks.ts during message transform.

--- a/lib/compress/types.ts
+++ b/lib/compress/types.ts
@@ -22,6 +22,10 @@ export interface CompressRangeToolArgs {
     content: CompressRangeEntry[]
 }
 
+export interface CompressBatchTopic {
+    topic: string
+    content: CompressRangeEntry[]
+}
 export interface CompressMessageEntry {
     messageId: string
     topic: string
@@ -65,6 +69,7 @@ export interface ResolvedMessageCompression {
 
 export interface ResolvedRangeCompression {
     index: number
+    topic: string
     entry: CompressRangeEntry
     selection: SelectionResolution
     anchorMessageId: string

--- a/lib/config-validation.ts
+++ b/lib/config-validation.ts
@@ -46,6 +46,7 @@ export const VALID_CONFIG_KEYS = new Set([
     "compress.minCompressRange",
     "compress.maxVisibleSegments",
     "compress.keepEmbedMaxChars",
+    "compress.cooldownOutputs",
     "gc",
     "gc.algorithm",
     "gc.promotionThreshold",
@@ -458,6 +459,28 @@ export function validateConfigTypes(config: Record<string, any>): ValidationErro
                     key: "compress.keepEmbedMaxChars",
                     expected: "positive number (>= 100)",
                     actual: `${compress.keepEmbedMaxChars}`,
+                })
+            }
+
+            if (
+                compress.cooldownOutputs !== undefined &&
+                typeof compress.cooldownOutputs !== "number"
+            ) {
+                errors.push({
+                    key: "compress.cooldownOutputs",
+                    expected: "number",
+                    actual: typeof compress.cooldownOutputs,
+                })
+            }
+
+            if (
+                typeof compress.cooldownOutputs === "number" &&
+                compress.cooldownOutputs < 0
+            ) {
+                errors.push({
+                    key: "compress.cooldownOutputs",
+                    expected: "non-negative number (>= 0)",
+                    actual: `${compress.cooldownOutputs}`,
                 })
             }
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -36,6 +36,7 @@ export interface CompressConfig {
     minCompressRange: number
     maxVisibleSegments: number
     keepEmbedMaxChars: number
+    cooldownOutputs?: number
 }
 
 export interface Commands {
@@ -204,6 +205,7 @@ const defaultConfig: PluginConfig = {
         minCompressRange: 2000,
         maxVisibleSegments: 50,
         keepEmbedMaxChars: 2000,
+        cooldownOutputs: 2,
     },
     strategies: {
         deduplication: {
@@ -417,6 +419,7 @@ function mergeCompress(
         minCompressRange: override.minCompressRange ?? base.minCompressRange,
         maxVisibleSegments: override.maxVisibleSegments ?? base.maxVisibleSegments,
         keepEmbedMaxChars: override.keepEmbedMaxChars ?? base.keepEmbedMaxChars,
+        cooldownOutputs: override.cooldownOutputs ?? base.cooldownOutputs,
     }
 }
 

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -292,7 +292,7 @@ export const injectCompressNudges = (
             const ranges = buildCompressibleRanges(messages, state)
             if (ranges.length > 0) {
                 breakdown += `\n\n${formatCompressibleRanges(ranges)}`
-                breakdown += `\n💡 Compress all ranges in one call (pass multiple content entries: \`content: [{...}, {...}]\`).`
+                breakdown += `\n💡 Compress ALL ranges in one call via \`topics\` (\`topics: [{ topic, content: [{ startId, endId, summary }] }, ...]\`); don't split into multiple calls.`
             }
             breakdown += `\nUse \`acp_status({scope:"uncompressed"})\` to re-fetch compressible ranges after compressing, or \`acp_status\` for compressed block details.`
 

--- a/lib/prompts/compress-range.ts
+++ b/lib/prompts/compress-range.ts
@@ -32,8 +32,23 @@ Rules:
 - Do not invent IDs. Use only IDs that are present in context.
 - NEVER use IDs from compressed block summaries, previous nudges, or your own memory — only IDs currently visible as XML metadata tags in the conversation.
 
-BATCHING
-When multiple independent ranges are ready and their boundaries do not overlap, include all of them as separate entries in the \`content\` array of a single tool call. Each entry should have its own \`startId\`, \`endId\`, and \`summary\`.
+BATCHING — MULTIPLE TOPICS IN ONE CALL
+Compress everything that is ready in a SINGLE tool call. Group independent ranges under separate \`topics\`. Each topic is a labeled group of one or more ranges; ranges that belong to the same phase or theme share a topic.
+
+\`\`\`
+{
+  "topics": [
+    { "topic": "Auth System Exploration", "content": [ { "startId": "m00005", "endId": "m00020", "summary": "..." } ] },
+    { "topic": "Build Fix", "content": [ { "startId": "m00030", "endId": "m00045", "summary": "..." } ] }
+  ]
+}
+\`\`\`
+
+Rules:
+- One topic per distinct concern. Give each a short label (3-5 words).
+- Put every ready range into this one call. Do NOT issue a second compress call immediately after — repeated tiny calls are rate-limited ("frequent compression blocked").
+- Ranges across all topics must not overlap (the system checks this globally).
+- The legacy single-topic \`{ "topic": "...", "content": [...] }\` shape is still accepted, but prefer \`topics\` so all ready ranges go in one call.
 
 KEEP AND REF MARKERS
 When writing a summary, you may embed markers that reference specific messages in the compressed range. The system resolves them automatically:

--- a/lib/prompts/context-limit-nudge.ts
+++ b/lib/prompts/context-limit-nudge.ts
@@ -8,15 +8,21 @@ If mid-atomic-operation, finish that step first, then compress.
 
 HOW TO CALL COMPRESS:
 {
-  "topic": "Short Label",
-  "content": [
+  "topics": [
     {
-      "startId": "<ID from early in this conversation>",
-      "endId": "<ID from later in this conversation>",
-      "summary": "Complete technical summary of everything in the range"
+      "topic": "Short Label",
+      "content": [
+        {
+          "startId": "<ID from early in this conversation>",
+          "endId": "<ID from later in this conversation>",
+          "summary": "Complete technical summary of everything in the range"
+        }
+      ]
     }
   ]
 }
+
+Put EVERY ready range into this single call (add more \`topics\` entries as needed). Do NOT make a second compress call right after — it will be rate-limited.
 
 ⚠️ ID RULES — MOST COMMON CAUSE OF ERRORS:
 - ONLY use IDs you can see in  tags in the messages ABOVE.

--- a/lib/prompts/extensions/tool.ts
+++ b/lib/prompts/extensions/tool.ts
@@ -5,18 +5,26 @@
 export const RANGE_FORMAT_EXTENSION = `
 THE FORMAT OF COMPRESS
 
+Compress everything ready in ONE call. Pass \`topics\` — an array where each entry groups one or more ranges under a short topic label.
+
 \`\`\`
 {
-  topic: string,           // Short label (3-5 words) - e.g., "Auth System Exploration"
-  content: [               // One or more ranges to compress
+  topics: [               // One or more topics — compress all ready ranges together
     {
-      startId: string,     // Boundary ID at range start: mNNNNN or bN
-      endId: string,       // Boundary ID at range end: mNNNNN or bN
-      summary: string      // Complete technical summary replacing all content in range
+      topic: string,      // Short label (3-5 words) for this group - e.g., "Auth System Exploration"
+      content: [          // One or more ranges to compress under this topic
+        {
+          startId: string, // Boundary ID at range start: mNNNNN or bN
+          endId: string,   // Boundary ID at range end: mNNNNN or bN
+          summary: string  // Complete technical summary replacing all content in range
+        }
+      ]
     }
   ]
 }
-\`\`\``
+\`\`\`
+
+Legacy single-topic \`{ topic, content: [...] }\` is also accepted. Do NOT split into multiple compress calls.`
 
 export const MESSAGE_FORMAT_EXTENSION = `
 THE FORMAT OF COMPRESS

--- a/lib/prompts/iteration-nudge.ts
+++ b/lib/prompts/iteration-nudge.ts
@@ -5,9 +5,12 @@ export const ITERATION_NUDGE = `
 You've been iterating for a while. If any earlier work is closed and unlikely to be referenced, compress it now.
 
 {
-  "topic": "Short Label",
-  "content": [{ "startId": "<visible message ID>", "endId": "<visible message ID>", "summary": "..." }]
+  "topics": [
+    { "topic": "Short Label", "content": [{ "startId": "<visible message ID>", "endId": "<visible message ID>", "summary": "..." }] }
+  ]
 }
+
+Compress everything ready in one call (add more \`topics\` entries). Do NOT split into multiple compress calls.
 
 ⚠️ ONLY use IDs from <dcp-message-id> tags visible above. Do NOT invent or copy example IDs.
 

--- a/lib/prompts/turn-nudge.ts
+++ b/lib/prompts/turn-nudge.ts
@@ -5,9 +5,12 @@ export const TURN_NUDGE = `
 Context is getting full. If you've finished reading tool outputs or exploration results, compress them — you can decompress later if needed. This keeps your focus on the current task and improves accuracy.
 
 {
-  "topic": "Short Label",
-  "content": [{ "startId": "<visible message ID>", "endId": "<visible message ID>", "summary": "..." }]
+  "topics": [
+    { "topic": "Short Label", "content": [{ "startId": "<visible message ID>", "endId": "<visible message ID>", "summary": "..." }] }
+  ]
 }
+
+Compress everything ready in one call (add more \`topics\` entries). Do NOT split into multiple compress calls.
 
 ⚠️ ONLY use IDs from  tags visible above. Do NOT invent or copy example IDs.
 

--- a/lib/state/persistence.ts
+++ b/lib/state/persistence.ts
@@ -48,6 +48,7 @@ export interface PersistedNudges {
     lastNudgeShownTokens?: number
     lastToolOutputNudgeTokens?: number
     compressBaselineSet?: boolean
+    lastCompressAssistantCount?: number
 }
 
 export interface PersistedMessageIds {
@@ -151,6 +152,7 @@ export async function saveSessionState(
             lastNudgeShownTokens: sessionState.nudges.lastNudgeShownTokens,
             lastToolOutputNudgeTokens: sessionState.nudges.lastToolOutputNudgeTokens,
             compressBaselineSet: sessionState.nudges.compressBaselineSet,
+            lastCompressAssistantCount: sessionState.nudges.lastCompressAssistantCount,
         },
         stats: sessionState.stats,
         lastUpdated: new Date().toISOString(),

--- a/lib/state/state.ts
+++ b/lib/state/state.ts
@@ -88,6 +88,7 @@ export function createSessionState(): SessionState {
             lastToolOutputNudgeTokens: undefined,
             shouldInjectThisTurn: undefined,
             compressBaselineSet: false,
+            lastCompressAssistantCount: undefined,
         },
         stats: {
             pruneTokenCounter: 0,
@@ -132,6 +133,7 @@ export function resetSessionState(state: SessionState): void {
         lastToolOutputNudgeTokens: undefined,
         shouldInjectThisTurn: undefined,
         compressBaselineSet: false,
+        lastCompressAssistantCount: undefined,
     }
     state.stats = {
         pruneTokenCounter: 0,
@@ -204,6 +206,7 @@ export async function ensureSessionInitialized(
     state.nudges.lastNudgeShownTokens = persisted.nudges.lastNudgeShownTokens
     state.nudges.lastToolOutputNudgeTokens = persisted.nudges.lastToolOutputNudgeTokens
     state.nudges.compressBaselineSet = persisted.nudges.compressBaselineSet ?? false
+    state.nudges.lastCompressAssistantCount = persisted.nudges.lastCompressAssistantCount
     state.stats = {
         pruneTokenCounter: persisted.stats?.pruneTokenCounter || 0,
         totalPruneTokens: persisted.stats?.totalPruneTokens || 0,

--- a/lib/state/types.ts
+++ b/lib/state/types.ts
@@ -108,6 +108,8 @@ export interface Nudges {
      * Reset to false when compress is NOT in the current turn.
      */
     compressBaselineSet: boolean
+    /** Assistant-output count at last successful compress. Undefined = no prior compress (first call allowed). Drives the compress cooldown rate-limiter. */
+    lastCompressAssistantCount: number | undefined
 }
 
 export interface SessionState {

--- a/lib/state/utils.ts
+++ b/lib/state/utils.ts
@@ -363,6 +363,7 @@ export function resetOnCompaction(state: SessionState): void {
         lastToolOutputNudgeTokens: undefined,
         shouldInjectThisTurn: undefined,
         compressBaselineSet: false,
+        lastCompressAssistantCount: undefined,
     }
     // [FIX] Reset message IDs on compaction — old mappings are stale after
     // compaction replaces messages with a summary. Keeping them causes

--- a/tests/compress-batch.test.ts
+++ b/tests/compress-batch.test.ts
@@ -1,0 +1,313 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { mkdirSync } from "node:fs"
+import { createCompressRangeTool } from "../lib/compress/range"
+import { createSessionState, type WithParts } from "../lib/state"
+import type { PluginConfig } from "../lib/config"
+import { Logger } from "../lib/logger"
+
+const testDataHome = join(tmpdir(), `opencode-acp-batch-${process.pid}`)
+const testConfigHome = join(tmpdir(), `opencode-acp-batch-config-${process.pid}`)
+
+process.env.XDG_DATA_HOME = testDataHome
+process.env.XDG_CONFIG_HOME = testConfigHome
+
+mkdirSync(testDataHome, { recursive: true })
+mkdirSync(testConfigHome, { recursive: true })
+
+function buildConfig(cooldownOutputs?: number): PluginConfig {
+    return {
+        enabled: true,
+        debug: false,
+        pruneNotification: "off",
+        pruneNotificationType: "chat",
+        commands: { enabled: true, protectedTools: [] },
+        manualMode: { enabled: false, automaticStrategies: true },
+        turnProtection: { enabled: false, turns: 4 },
+        experimental: { allowSubAgents: false, customPrompts: false },
+        protectedFilePatterns: [],
+        compress: {
+            mode: "range",
+            permission: "allow",
+            showCompression: false,
+            maxContextLimit: 150000,
+            minContextLimit: 50000,
+            nudgeFrequency: 5,
+            iterationNudgeThreshold: 15,
+            nudgeForce: "soft",
+            protectedTools: [],
+            protectTags: false,
+            protectUserMessages: false,
+            cooldownOutputs,
+        },
+        strategies: {
+            deduplication: { enabled: true, protectedTools: [] },
+            purgeErrors: { enabled: true, turns: 4, protectedTools: [] },
+        },
+        gc: {
+            algorithm: "truncate",
+            promotionThreshold: 5,
+            maxBlockAge: 15,
+            maxOldGenSummaryLength: 3000,
+            majorGcThresholdPercent: "100%",
+            batchCleanup: { lowThreshold: "60%", highThreshold: "75%", forceThreshold: "90%" },
+        },
+    }
+}
+
+function textPart(messageID: string, sessionID: string, id: string, text: string) {
+    return { id, messageID, sessionID, type: "text" as const, text }
+}
+
+function buildMessages(sessionID: string): WithParts[] {
+    const roles: Array<{ id: string; role: "user" | "assistant"; text: string }> = [
+        { id: "msg-user-1", role: "user", text: "Investigate the auth flow" },
+        { id: "msg-assistant-1", role: "assistant", text: "Mapped the login code path" },
+        { id: "msg-user-2", role: "user", text: "Now fix the build error" },
+        { id: "msg-assistant-2", role: "assistant", text: "Fixed the broken import" },
+        { id: "msg-user-3", role: "user", text: "Ship it" },
+        { id: "msg-assistant-3", role: "assistant", text: "Committed and pushed" },
+    ]
+    return roles.map((r, i) => ({
+        info: {
+            id: r.id,
+            role: r.role,
+            sessionID,
+            agent: "assistant",
+            ...(r.role === "user"
+                ? {
+                      model: { providerID: "anthropic", modelID: "claude-test" },
+                  }
+                : {}),
+            time: { created: i + 1 },
+        } as WithParts["info"],
+        parts: [textPart(r.id, sessionID, `part-${i + 1}`, r.text)],
+    }))
+}
+
+function makeToolCtx(sessionID: string, messageID: string) {
+    return {
+        ask: async () => {},
+        metadata: () => {},
+        sessionID,
+        messageID,
+    }
+}
+
+function makeTool(state: ReturnType<typeof createSessionState>, config: PluginConfig, rawMessages: WithParts[]) {
+    return createCompressRangeTool({
+        client: {
+            session: {
+                messages: async () => ({ data: rawMessages }),
+                get: async () => ({ data: { parentID: null } }),
+            },
+        },
+        state,
+        logger: new Logger(false),
+        config,
+        prompts: {
+            reload() {},
+            getRuntimePrompts() {
+                return { compressRange: "", compressMessage: "" }
+            },
+        },
+    } as any)
+}
+
+test("multi-topic batch creates one block per range, each tagged with its own topic, sharing a runId", async () => {
+    const sessionID = `ses_batch_multi_${Date.now()}`
+    const rawMessages = buildMessages(sessionID)
+    const state = createSessionState()
+    const tool = makeTool(state, buildConfig(2), rawMessages)
+
+    await tool.execute(
+        {
+            topics: [
+                {
+                    topic: "Auth Exploration",
+                    content: [{ startId: "m00001", endId: "m00002", summary: "Auth flow mapped." }],
+                },
+                {
+                    topic: "Build Fix",
+                    content: [{ startId: "m00003", endId: "m00004", summary: "Broken import fixed." }],
+                },
+            ],
+        },
+        makeToolCtx(sessionID, "msg-compress-multi"),
+    )
+
+    const blocks = Array.from(state.prune.messages.blocksById.values()).sort(
+        (a, b) => a.blockId - b.blockId,
+    )
+    assert.equal(blocks.length, 2)
+    assert.equal(blocks[0]?.topic, "Auth Exploration")
+    assert.equal(blocks[1]?.topic, "Build Fix")
+    assert.equal(blocks[0]?.runId, blocks[1]?.runId)
+    assert.equal(blocks[0]?.batchTopic, "Auth Exploration")
+    assert.equal(blocks[1]?.batchTopic, "Build Fix")
+})
+
+test("legacy single-topic { topic, content } shape is accepted via backward-compat shim", async () => {
+    const sessionID = `ses_batch_legacy_${Date.now()}`
+    const rawMessages = buildMessages(sessionID)
+    const state = createSessionState()
+    const tool = makeTool(state, buildConfig(2), rawMessages)
+
+    await tool.execute(
+        {
+            topic: "Legacy Single Topic",
+            content: [{ startId: "m00001", endId: "m00002", summary: "Legacy shape worked." }],
+        },
+        makeToolCtx(sessionID, "msg-compress-legacy"),
+    )
+
+    const blocks = Array.from(state.prune.messages.blocksById.values())
+    assert.equal(blocks.length, 1)
+    assert.equal(blocks[0]?.topic, "Legacy Single Topic")
+    assert.equal(blocks[0]?.batchTopic, "Legacy Single Topic")
+})
+
+test("ranges overlapping across different topics are rejected globally", async () => {
+    const sessionID = `ses_batch_overlap_${Date.now()}`
+    const rawMessages = buildMessages(sessionID)
+    const state = createSessionState()
+    const tool = makeTool(state, buildConfig(2), rawMessages)
+
+    await assert.rejects(
+        tool.execute(
+            {
+                topics: [
+                    {
+                        topic: "Topic A",
+                        content: [{ startId: "m00001", endId: "m00003", summary: "Spans A." }],
+                    },
+                    {
+                        topic: "Topic B",
+                        content: [{ startId: "m00002", endId: "m00004", summary: "Spans B." }],
+                    },
+                ],
+            },
+            makeToolCtx(sessionID, "msg-compress-overlap"),
+        ),
+        /Overlapping ranges cannot be compressed in the same batch/,
+    )
+
+    assert.equal(state.prune.messages.blocksById.size, 0)
+})
+
+test("cooldown blocks a second compress when too few new assistant outputs exist", async () => {
+    const sessionID = `ses_batch_cooldown_block_${Date.now()}`
+    const rawMessages = buildMessages(sessionID)
+    const state = createSessionState()
+    // Pin sessionId so prepareSession's ensureSessionInitialized is a no-op and doesn't reset state.
+    state.sessionId = sessionID
+    // Simulate a prior compress that happened at the current assistant-output count (delta would be 0).
+    state.nudges.lastCompressAssistantCount = 3
+    const tool = makeTool(state, buildConfig(2), rawMessages)
+
+    await assert.rejects(
+        tool.execute(
+            {
+                topics: [
+                    {
+                        topic: "Should Be Blocked",
+                        content: [{ startId: "m00005", endId: "m00006", summary: "Blocked by cooldown." }],
+                    },
+                ],
+            },
+            makeToolCtx(sessionID, "msg-compress-blocked"),
+        ),
+        /Frequent compression blocked/,
+    )
+
+    assert.equal(state.prune.messages.blocksById.size, 0)
+})
+
+test("cooldown allows compress when enough new assistant outputs have appeared", async () => {
+    const sessionID = `ses_batch_cooldown_allow_${Date.now()}`
+    const rawMessages = buildMessages(sessionID)
+    const state = createSessionState()
+    // Pin sessionId so prepareSession's ensureSessionInitialized is a no-op and doesn't reset state.
+    state.sessionId = sessionID
+    // Prior compress was 2 assistant outputs ago (3 now - 1 then = delta 2 >= cooldown 2).
+    state.nudges.lastCompressAssistantCount = 1
+    const tool = makeTool(state, buildConfig(2), rawMessages)
+
+    await tool.execute(
+        {
+            topics: [
+                {
+                    topic: "Allowed After Threshold",
+                    content: [{ startId: "m00001", endId: "m00002", summary: "Passed cooldown." }],
+                },
+            ],
+        },
+        makeToolCtx(sessionID, "msg-compress-allowed"),
+    )
+
+    assert.equal(state.prune.messages.blocksById.size, 1)
+    assert.equal(state.nudges.lastCompressAssistantCount, 3)
+})
+
+test("manual mode (compress-pending) bypasses the cooldown", async () => {
+    const sessionID = `ses_batch_cooldown_manual_${Date.now()}`
+    const rawMessages = buildMessages(sessionID)
+    const state = createSessionState()
+    // Pin sessionId so prepareSession's ensureSessionInitialized is a no-op and doesn't reset state.
+    state.sessionId = sessionID
+    state.nudges.lastCompressAssistantCount = 3
+    state.manualMode = "compress-pending"
+    const tool = makeTool(state, buildConfig(2), rawMessages)
+
+    await tool.execute(
+        {
+            topics: [
+                {
+                    topic: "Manual Bypass",
+                    content: [{ startId: "m00001", endId: "m00002", summary: "Manual trigger." }],
+                },
+            ],
+        },
+        makeToolCtx(sessionID, "msg-compress-manual"),
+    )
+
+    assert.equal(state.prune.messages.blocksById.size, 1)
+})
+
+test("cooldown disabled when cooldownOutputs is 0", async () => {
+    const sessionID = `ses_batch_cooldown_disabled_${Date.now()}`
+    const rawMessages = buildMessages(sessionID)
+    const state = createSessionState()
+    state.nudges.lastCompressAssistantCount = 3
+    const tool = makeTool(state, buildConfig(0), rawMessages)
+
+    await tool.execute(
+        {
+            topics: [
+                {
+                    topic: "Cooldown Off",
+                    content: [{ startId: "m00001", endId: "m00002", summary: "No rate limit." }],
+                },
+            ],
+        },
+        makeToolCtx(sessionID, "msg-compress-disabled"),
+    )
+
+    assert.equal(state.prune.messages.blocksById.size, 1)
+})
+
+test("missing both topics and legacy fields throws a clear guidance error", async () => {
+    const sessionID = `ses_batch_missing_${Date.now()}`
+    const rawMessages = buildMessages(sessionID)
+    const state = createSessionState()
+    const tool = makeTool(state, buildConfig(2), rawMessages)
+
+    await assert.rejects(
+        tool.execute({ summaryMaxChars: 5000 } as any, makeToolCtx(sessionID, "msg-compress-missing")),
+        /Provide `topics`/,
+    )
+
+    assert.equal(state.prune.messages.blocksById.size, 0)
+})

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -156,7 +156,7 @@ test("prompt store exposes bundled range-mode compress prompt", () => {
         assert.match(runtimePrompts.compressRange, /Collapse a range in the conversation/i)
         assert.match(runtimePrompts.compressRange, /COMPRESSED BLOCK PLACEHOLDERS/)
         assert.match(runtimePrompts.compressRange, /BATCHING/)
-        assert.match(runtimePrompts.compressRange, /content` array/)
+        assert.match(runtimePrompts.compressRange, /topics/)
     } finally {
         fixture.cleanup()
     }


### PR DESCRIPTION
## Summary

Adds a **batch interface** to the `compress` tool so one call can compress multiple unrelated conversation phases, each under its own topic. Also adds a **cooldown rate-limit** to stop repeated small compress calls.

Closes dog/opencode-acp#26.

## What changed

**Batch interface (range mode)**
- New schema: `{ topics: [{ topic, content: [{startId,endId,summary}] }, ...], summaryMaxChars? }`.
- Legacy `{ topic, content }` still accepted — wrapped internally via a backward-compat shim.
- Each topic's ranges become blocks tagged with that topic; all blocks in one call share one `runId`.
- Ranges are globally overlap-checked across topics (no double-compressing the same messages).

**Cooldown rate-limit**
- New `compress.cooldownOutputs` config (default `2`). A second compress is blocked until at least that many new assistant outputs have appeared.
- Exemptions: first compress (no prior count), manual `/acp compress`, and over-max-context-limit (overflow priority).
- Error message guides the model to combine everything into one `topics` call.

**Prompt updates**
- Tool description gains a `BATCHING` section; the range format extension shows the `topics` JSON.
- The three injection nudges (context-limit / turn / iteration) now show the `topics` array and emphasize one-call batching.
- Message mode is structurally unchanged (already had per-entry topic) — it just gets the cooldown.

**Per-summary cap** stays at `maxSummaryLengthHard` (10000); batch multiplies total budget naturally (N × cap). GC old-gen truncation (>3000) unchanged.

## Verification

- `npm run typecheck` — clean
- `npm test` — 646 pass / 0 fail (638 existing + 8 new in `tests/compress-batch.test.ts`)
- `npm run build` — succeeds

## Test coverage (`tests/compress-batch.test.ts`)

1. Multi-topic batch → 2 blocks, each tagged with own topic, shared runId
2. Legacy single-topic `{topic, content}` accepted
3. Cross-topic overlap rejected globally
4. Cooldown blocks when too few new assistant outputs
5. Cooldown allows after threshold met
6. Manual mode bypasses cooldown
7. Cooldown disabled when `cooldownOutputs: 0`
8. Missing `topics`/legacy fields → clear guidance error

## Backward compatibility

- Persisted state: `lastCompressAssistantCount` is optional; old state files load clean (cooldown stays disabled until first success).
- Tool args: legacy `{topic, content}` accepted and wrapped.
- Internal `dcp` tags/naming unchanged.

## Commits

8 atomic commits by layer: state → config → compress-foundation → compress-wiring(+tests) → prompts-tool(+test) → prompts-nudges → inject → devlog.

Devlog: `devlog/2026-07-13_batch-compress/` (REQ.md, DESIGN.md, WORKLOG.md).

---

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)