### PR TITLE
release: v1.12.2 — compress failure rollback + sync carve-out removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.12.2 — Compress Failure Rollback + Sync Carve-out Removal (PR #126)
+
+**Problem**: Two bugs in post-compression-failure handling (issue #125). (1) The compress tool mutated in-memory state incrementally with no try/catch — if anything threw between the first `applyCompressionState` and `finalizeSession`, "ghost blocks" (active blocks never persisted) hid messages on subsequent transforms. (2) `syncCompressionBlocks` had a carve-out that kept blocks active when the anchor was missing from messages but tracked in `byMessageId`. This carve-out was intended for ACP-hidden anchors, but sync runs on the raw message list (before filtering), so it only triggered for externally-deleted anchors → messages hidden without recap injection → empty LLM requests.
+
+**Fix**: (1) Added `snapshotCompressionState()` / `restoreCompressionState()` to `lib/compress/pipeline.ts` using `structuredClone`. Wrapped the mutation phase in try/catch in both `lib/compress/range.ts` and `lib/compress/message.ts`. On failure, state (including `manualMode`) is restored to the pre-mutation snapshot — no ghost blocks. (2) Removed the carve-out in `lib/messages/sync.ts`. When anchor is gone from messages, always deactivate the block. Oracle-reviewed.
+
+Files: `lib/messages/sync.ts`, `lib/compress/pipeline.ts`, `lib/compress/range.ts`, `lib/compress/message.ts`. Tests: `tests/sync.test.ts` (updated), `tests/compress-rollback.test.ts` (NEW, 4 tests). 643 tests pass.
+
 ### v1.12.1 — Compression Recap Injection Fix + Stale Compress Stripping (PR #119)
 
 **Problem**: `acp_context_recap` was used to create synthetic tool-result recap messages but was NOT registered as a real tool — providers could strip/convert unregistered tool-results, causing the model to see compression summaries as plain text or user messages (echo/drift bugs). Additionally, compress tool-call inputs duplicated block recap content in context.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -395,6 +395,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.12.2 — 压缩失败回滚 + Sync carve-out 移除（PR #126）
+
+**问题**：压缩失败后的处理存在两个 bug（issue #125）。（1）compress 工具在内存中增量修改状态，没有 try/catch——如果在 `applyCompressionState` 和 `finalizeSession` 之间抛出异常，"幽灵块"（未持久化的活跃块）会在后续 transform 中隐藏消息。（2）`syncCompressionBlocks` 有一个 carve-out：当块的锚点从消息中缺失但在 `byMessageId` 中有记录时，块保持活跃。这个 carve-out 本意是保护 ACP 隐藏的锚点，但 sync 运行在原始消息列表上（在过滤之前），所以它只在外部删除的锚点场景触发 → 块保持活跃但无法注入摘要 → 隐藏消息无替换 → **LLM 请求为空**。
+
+**修复**：（1）在 `lib/compress/pipeline.ts` 中新增 `snapshotCompressionState()` / `restoreCompressionState()`（使用 `structuredClone`）。在 `lib/compress/range.ts` 和 `lib/compress/message.ts` 中用 try/catch 包裹变更阶段。失败时，状态（包括 `manualMode`）恢复到变更前的快照——不会有幽灵块。（2）移除 `lib/messages/sync.ts` 中的 carve-out。锚点从消息中缺失时，总是停用块。经 Oracle 审查。
+
+文件：`lib/messages/sync.ts`、`lib/compress/pipeline.ts`、`lib/compress/range.ts`、`lib/compress/message.ts`。测试：`tests/sync.test.ts`（更新）、`tests/compress-rollback.test.ts`（新增，4 个测试）。643 个测试通过。
+
 ### v1.12.1 — 压缩摘要注入修复 + 历史压缩调用剥离（PR #119）
 
 **问题**：`acp_context_recap` 用于创建合成的 tool-result 摘要消息，但未注册为真实工具——provider 可能剥离/转换未注册的 tool-result，导致模型将压缩摘要视为纯文本或用户消息（回声/漂移 bug）。此外，compress 工具调用的输入与 block recap 内容重复占用上下文。

--- a/devlog/2026-07-14_release-v1.12.2/REQ.md
+++ b/devlog/2026-07-14_release-v1.12.2/REQ.md
@@ -1,0 +1,24 @@
+# REQ: Release v1.12.2
+
+## Problem Statement
+
+PR #126 (compress failure rollback + sync carve-out removal) has been merged to master. A release is needed to publish the fix to npm.
+
+## Changes in v1.12.2
+
+- **Bug 2 (sync.ts carve-out removal)**: Fix for issue #125 — externally-deleted anchors kept blocks active, hiding messages without recap injection → empty LLM requests.
+- **Bug 1 (compress snapshot/rollback)**: Defensive fix — compress tool mutations are now wrapped in try/catch with state snapshot/rollback via `structuredClone`. On failure, state (including `manualMode`) is restored — no ghost blocks.
+
+## Acceptance Criteria
+
+- [x] Version bumped to 1.12.2 in `package.json`
+- [x] Changelog updated in `README.md` and `README.zh-CN.md`
+- [x] Devlog entry created
+- [x] CI checks pass (`pr-checks.yml` + `ci.yml`)
+- [ ] PR merged → auto-publish via `release.yml`
+
+## Constraints
+
+- Branch name MUST follow `YYYY-MM-DD_release-v{VERSION}` for auto-tagging
+- All tests must pass
+- `npm run check:package` must pass

--- a/devlog/2026-07-14_release-v1.12.2/WORKLOG.md
+++ b/devlog/2026-07-14_release-v1.12.2/WORKLOG.md
@@ -1,0 +1,39 @@
+# WORKLOG: Release v1.12.2
+
+## Commits
+
+| Commit | Description |
+|--------|-------------|
+| `2026-07-14` | release: v1.12.2 — bump version, changelog, devlog |
+
+## Changes
+
+### Version Bump
+- `package.json`: 1.12.1 → 1.12.2
+
+### Changelog
+- `README.md`: Added v1.12.2 entry under "## Changelog"
+- `README.zh-CN.md`: Added v1.12.2 entry under "## 更新日志"
+
+### Devlog
+- `devlog/2026-07-14_release-v1.12.2/REQ.md` — release requirements
+- `devlog/2026-07-14_release-v1.12.2/WORKLOG.md` — this file
+
+## Release Contents (from PR #126)
+
+### Bug 2: sync.ts carve-out removal (issue #125 primary fix)
+- Removed `lib/messages/sync.ts:54-66` carve-out that kept blocks active when anchor was externally deleted
+- Root cause: `syncCompressionBlocks` runs on raw messages (hooks.ts:250) before `filterCompressedRanges` (hooks.ts:262), so ACP-hidden anchors are still present — carve-out only triggered for externally-deleted anchors → empty LLM requests
+
+### Bug 1: Compress snapshot/rollback (defensive)
+- Added `snapshotCompressionState()` / `restoreCompressionState()` to `lib/compress/pipeline.ts`
+- Wrapped mutation phase in try/catch in `lib/compress/range.ts` and `lib/compress/message.ts`
+- Captures `prune.messages`, `stats`, and `manualMode` via `structuredClone`
+
+## Test Results
+- TypeScript: ✅ pass
+- Tests: ✅ 643 pass, 0 fail
+- Build: ✅ success
+
+## Post-Merge
+- `release.yml` will auto-tag `v1.12.2`, build, test, publish to npm, create GitHub Release

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.12.1",
+    "version": "1.12.2",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Release v1.12.2

Version bump for the compress failure rollback + sync carve-out fix (PR #126, issue #125).

## Changes

- **Version**: 1.12.1 → 1.12.2
- **Changelog**: Added v1.12.2 entries to `README.md` and `README.zh-CN.md`
- **Devlog**: `devlog/2026-07-14_release-v1.12.2/` (REQ.md + WORKLOG.md)

## Release Contents

### Bug 2: sync.ts carve-out removal (issue #125 primary fix)
Removed carve-out in `lib/messages/sync.ts` that kept blocks active when anchor was externally deleted → empty LLM requests.

### Bug 1: Compress snapshot/rollback (defensive)
Added `snapshotCompressionState()` / `restoreCompressionState()` to `lib/compress/pipeline.ts`. Compress tool mutations wrapped in try/catch with state rollback (including `manualMode`).

## Verification

- ✅ TypeScript: pass
- ✅ Tests: 643 pass, 0 fail
- ✅ CI check (`check-pr.sh`): All checks passed
- ✅ Build: success

## Post-Merge

`release.yml` will auto-tag `v1.12.2`, build, test, publish to npm, create GitHub Release.