### PR TITLE
release: v1.12.3 — regex tag fragment leak fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.12.3 — Regex Tag Fragment Leak Fix (PR #130)
+
+**Problem**: Three regexes in `lib/messages/utils.ts` had missing opening-tag `<` and tag-name matchers, causing ACP internal XML tag fragments and stale message IDs to leak into user-visible chat after multiple compression rounds (issue #123).
+
+**Fix**: (1) `DCP_PAIRED_TAG_REGEX` (line 14): `]*>` matched any `>` char → fixed to `<(?:dcp|acp)[^>]*>`. (2) `DCP_BLOCK_ID_TAG_REGEX` (line 11): `(])` required literal `]` → `replaceBlockIdsWithBlocked` was a complete no-op → fixed to `(<(?:dcp|acp)-message-id[^>]*>)`. (3) `DCP_MESSAGE_REF_TAG_REGEX` (line 13): matched only `m\d+</closing>` → left `<dcp-message-id ...>` opening tag fragments → fixed to include opening tag. Supersedes PR #124.
+
+Files: `lib/messages/utils.ts`. Tests: `tests/regex-tag-leak.test.ts` (NEW, 23 tests). 666 tests pass.
+
 ### v1.12.2 — Compress Failure Rollback + Sync Carve-out Removal (PR #126)
 
 **Problem**: Two bugs in post-compression-failure handling (issue #125). (1) The compress tool mutated in-memory state incrementally with no try/catch — if anything threw between the first `applyCompressionState` and `finalizeSession`, "ghost blocks" (active blocks never persisted) hid messages on subsequent transforms. (2) `syncCompressionBlocks` had a carve-out that kept blocks active when the anchor was missing from messages but tracked in `byMessageId`. This carve-out was intended for ACP-hidden anchors, but sync runs on the raw message list (before filtering), so it only triggered for externally-deleted anchors → messages hidden without recap injection → empty LLM requests.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -395,6 +395,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.12.3 — 正则标签碎片泄漏修复（PR #130）
+
+**问题**：`lib/messages/utils.ts` 中三个正则表达式缺少开标签 `<` 和标签名匹配，导致 ACP 内部 XML 标签碎片和过期消息 ID 在多轮压缩后泄漏到用户可见的对话框中（issue #123）。
+
+**修复**：（1）`DCP_PAIRED_TAG_REGEX`（第 14 行）：`]*>` 匹配任意 `>` 字符 → 修正为 `<(?:dcp|acp)[^>]*>`。（2）`DCP_BLOCK_ID_TAG_REGEX`（第 11 行）：`(])` 要求字面量 `]` → `replaceBlockIdsWithBlocked` 完全失效 → 修正为 `(<(?:dcp|acp)-message-id[^>]*>)`。（3）`DCP_MESSAGE_REF_TAG_REGEX`（第 13 行）：只匹配 `m\d+</closing>` → 残留 `<dcp-message-id ...>` 开标签碎片 → 补上开标签匹配。取代 PR #124。
+
+文件：`lib/messages/utils.ts`。测试：`tests/regex-tag-leak.test.ts`（新增，23 个测试）。666 个测试通过。
+
 ### v1.12.2 — 压缩失败回滚 + Sync carve-out 移除（PR #126）
 
 **问题**：压缩失败后的处理存在两个 bug（issue #125）。（1）compress 工具在内存中增量修改状态，没有 try/catch——如果在 `applyCompressionState` 和 `finalizeSession` 之间抛出异常，"幽灵块"（未持久化的活跃块）会在后续 transform 中隐藏消息。（2）`syncCompressionBlocks` 有一个 carve-out：当块的锚点从消息中缺失但在 `byMessageId` 中有记录时，块保持活跃。这个 carve-out 本意是保护 ACP 隐藏的锚点，但 sync 运行在原始消息列表上（在过滤之前），所以它只在外部删除的锚点场景触发 → 块保持活跃但无法注入摘要 → 隐藏消息无替换 → **LLM 请求为空**。

--- a/devlog/2026-07-14_release-v1.12.3/REQ.md
+++ b/devlog/2026-07-14_release-v1.12.3/REQ.md
@@ -1,0 +1,19 @@
+# REQ: Release v1.12.3
+
+## Problem Statement
+
+PR #130 (regex tag fragment leak fix for issue #123) has been merged to master. A release is needed to publish the fix to npm.
+
+## Changes in v1.12.3
+
+Three regex fixes in `lib/messages/utils.ts`:
+- `DCP_PAIRED_TAG_REGEX` (line 14): `]*>` matched any `>` — tag fragments leaked into chat
+- `DCP_BLOCK_ID_TAG_REGEX` (line 11): `(])` required literal `]` — `replaceBlockIdsWithBlocked` was a no-op
+- `DCP_MESSAGE_REF_TAG_REGEX` (line 13): Missing opening tag — fragments in compression summaries
+
+## Acceptance Criteria
+
+- [x] Version bumped to 1.12.3 in `package.json`
+- [x] Changelog updated in `README.md` and `README.zh-CN.md`
+- [x] Devlog entry created
+- [ ] PR merged → auto-publish via `release.yml`

--- a/devlog/2026-07-14_release-v1.12.3/WORKLOG.md
+++ b/devlog/2026-07-14_release-v1.12.3/WORKLOG.md
@@ -1,0 +1,31 @@
+# WORKLOG: Release v1.12.3
+
+## Commits
+
+| Commit | Description |
+|--------|-------------|
+| `2026-07-14` | release: v1.12.3 — regex tag fragment leak fix (PR #130) |
+
+## Changes
+
+### Version Bump
+- `package.json`: 1.12.2 → 1.12.3
+
+### Changelog
+- `README.md`: Added v1.12.3 entry
+- `README.zh-CN.md`: Added v1.12.3 entry
+
+### Devlog
+- `devlog/2026-07-14_release-v1.12.3/` (REQ.md + WORKLOG.md)
+
+## Release Contents (from PR #130, issue #123)
+
+Three regex fixes in `lib/messages/utils.ts`:
+1. `DCP_PAIRED_TAG_REGEX` (line 14): `]*>` → `<(?:dcp|acp)[^>]*>` (PR #124's fix, extended)
+2. `DCP_BLOCK_ID_TAG_REGEX` (line 11): `(])` → `(<(?:dcp|acp)-message-id[^>]*>)` (was complete no-op)
+3. `DCP_MESSAGE_REF_TAG_REGEX` (line 13): added opening tag match (was leaving fragments)
+
+Tests: `tests/regex-tag-leak.test.ts` (NEW, 23 tests). Total: 666 pass.
+
+## Post-Merge
+- `release.yml` will auto-tag `v1.12.3`, build, test, publish to npm, create GitHub Release

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.12.2",
+    "version": "1.12.3",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Release v1.12.3 (patch)

Version bump for the regex tag fragment leak fix (PR #130, issue #123).

## Changes

- **Version**: 1.12.2 → 1.12.3
- **Changelog**: Added v1.12.3 entries to `README.md` and `README.zh-CN.md`
- **Devlog**: `devlog/2026-07-14_release-v1.12.3/` (REQ.md + WORKLOG.md)

## Release Contents

Three regex fixes in `lib/messages/utils.ts`:
1. `DCP_PAIRED_TAG_REGEX` — `]*>` matched any `>` char (tag fragments leaked into chat)
2. `DCP_BLOCK_ID_TAG_REGEX` — `(])` required literal `]` (function was a no-op)
3. `DCP_MESSAGE_REF_TAG_REGEX` — Missing opening tag (fragments in summaries)

## Verification

- ✅ CI check: All passed
- ✅ Tests: 666 pass, 0 fail

## Post-Merge

`release.yml` auto-tags `v1.12.3`, builds, tests, publishes to npm.