### PR TITLE
fix: getCurrentTokenUsage underestimation when output=0

### DIFF
--- a/devlog/2026-07-14_token-usage-fix/REQ.md
+++ b/devlog/2026-07-14_token-usage-fix/REQ.md
@@ -1,0 +1,48 @@
+# REQ - Fix getCurrentTokenUsage underestimation when output=0
+
+- Task ID: `2026-07-14_token-usage-fix`
+- Home Repo: `opencode-acp`
+- Created: 2026-07-14
+- Status: Done
+- Priority: P0
+- Owner: awork
+- References: Gitea issue dog/opencode-acp#20
+
+## 1. Background & Problem Statement
+
+- **Context**: Session `ses_0a3be0cdeffezb9pLzfifH7lzK` hit 1.03M tokens (context full) with 16x API 400 errors, but ACP never triggered compression nudges or GC.
+- **Current behavior (symptom)**: `getCurrentTokenUsage()` in `lib/token-utils.ts` skips assistant messages with `output <= 0` (line 17). When recent assistant messages have `output=0` (aborted/hidden agent requests, finish_reason=other), the function falls through to content estimation that only counts text parts. If most content was compressed away, the estimate is ~10% of actual → ACP thinks context is at 10% when it's at 100%+.
+- **Expected behavior**: `getCurrentTokenUsage` should use token data from assistant messages that have `input > 0` even when `output = 0`, since `input + cacheRead + cacheWrite` still represents the prompt size sent to the model.
+- **Impact**: Context overflow with no compression trigger. Model gets API 400 errors, session becomes unusable.
+
+## 2. Reproduction
+
+- **Environment**: GLM-5.2 model, 1M context limit, long sessions with aborted agent requests.
+- **Minimal reproduction steps**:
+  1. Have a session where recent assistant messages have `output=0` (from hidden agent requests/aborts)
+  2. Context grows past the configured limit
+  3. ACP never fires nudges because it underestimates usage by 10x
+- **Relevant configuration**: `minContextLimit: "20%"`, `maxContextLimit: "20%"` on 1M model.
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**: Backward compatible — existing tests must still pass. No change to the token formula (`input + cacheRead + cacheWrite + output + reasoning`).
+- **Non-Goals**: Not changing the GC system (deprecated). Not changing config defaults.
+
+## 4. Acceptance Criteria
+
+- **Correctness**:
+  - [x] Assistant messages with `output=0, input>0` are used (not skipped)
+  - [x] Assistant messages with `output=0, input=0` are still skipped (truly empty)
+  - [x] Compaction check still works (stale messages return 0)
+  - [x] Fallback estimation includes tool outputs, not just text
+- **Regression**:
+  - [x] All 669 tests pass (4 existing + 3 new)
+
+## 5. Proposed Approach
+
+- **Affected modules**: `lib/token-utils.ts`, `tests/token-usage.test.ts`
+- **Changes**:
+  1. Change skip condition from `output <= 0` to `input <= 0 && output <= 0`
+  2. Change fallback from text-only to `countAllMessageTokens` (text + tool outputs)
+- **Risks**: Minimal — the token formula is unchanged, only the message selection condition widened.

--- a/devlog/2026-07-14_token-usage-fix/WORKLOG.md
+++ b/devlog/2026-07-14_token-usage-fix/WORKLOG.md
@@ -1,0 +1,34 @@
+# WORKLOG - token-usage-fix
+
+## Commits
+
+1. `fix: getCurrentTokenUsage uses input-only token data (output=0 fix)` — `lib/token-utils.ts` + `tests/token-usage.test.ts`
+
+## Key Changes
+
+### `lib/token-utils.ts`
+- **Skip condition** (line 28): Changed from `(output || 0) <= 0` to `input <= 0 && output <= 0`. Assistant messages with `output=0` but `input>0` (aborted/hidden requests) are now used instead of skipped.
+- **Fallback estimation** (line 51): Changed from text-only loop to `countAllMessageTokens(m)` which includes tool outputs. Tool-heavy conversations are no longer undercounted in the fallback path.
+- Token formula unchanged: `input + cacheRead + cacheWrite + output + reasoning`.
+
+### `tests/token-usage.test.ts`
+- 3 new tests:
+  1. `getCurrentTokenUsage uses assistant message with output=0 but input>0` — verifies the core fix
+  2. `getCurrentTokenUsage skips assistant message with both input=0 and output=0` — verifies truly empty messages are still skipped
+  3. `getCurrentTokenUsage fallback counts tool outputs not just text` — verifies improved fallback
+
+## Test Results
+
+- TypeScript: 0 errors
+- Build: success (383.73 KB)
+- Tests: 669/669 pass (was 666 + 3 new)
+
+## Root Cause Analysis
+
+Session `ses_0a3be0cdeffezb9pLzfifH7lzK` (1M context, GLM-5.2):
+- 6 recent assistant messages had `output=0` (finish=other, hidden agent requests/aborts)
+- `getCurrentTokenUsage` skipped all 6, fell through to text-only estimation
+- Most content was compressed away → estimate ≈ 100K (10% of 1M)
+- 10% < 20% minContextLimit → no nudge fired
+- 10% < 100% majorGcThreshold → no emergency GC
+- Model kept going until API 400 errors (16x)

--- a/lib/token-utils.ts
+++ b/lib/token-utils.ts
@@ -14,7 +14,18 @@ export function getCurrentTokenUsage(state: SessionState, messages: WithParts[])
         }
 
         const assistantInfo = msg.info as AssistantMessage
-        if ((assistantInfo.tokens?.output || 0) <= 0) {
+        const input = assistantInfo.tokens?.input || 0
+        const output = assistantInfo.tokens?.output || 0
+        const reasoning = assistantInfo.tokens?.reasoning || 0
+        const cacheRead = assistantInfo.tokens?.cache?.read || 0
+        const cacheWrite = assistantInfo.tokens?.cache?.write || 0
+
+        // [FIX output=0 underestimation] Accept input-only token data (output=0
+        // from aborted/hidden requests). input + cacheRead + cacheWrite still
+        // represents the prompt size sent to the model. Previously required
+        // output > 0, which skipped these and fell through to text-only
+        // estimation → massive undercount → no nudge fired → context overflow.
+        if (input <= 0 && output <= 0) {
             continue
         }
 
@@ -26,12 +37,6 @@ export function getCurrentTokenUsage(state: SessionState, messages: WithParts[])
             return 0
         }
 
-        const input = assistantInfo.tokens?.input || 0
-        const output = assistantInfo.tokens?.output || 0
-        const reasoning = assistantInfo.tokens?.reasoning || 0
-        const cacheRead = assistantInfo.tokens?.cache?.read || 0
-        const cacheWrite = assistantInfo.tokens?.cache?.write || 0
-
         // [FIX Bug 17] Universal token estimation
         // opencode session.ts: adjustedInputTokens = inputTokens - cacheRead - cacheWrite
         // So: input + cacheRead + cacheWrite = prompt_tokens (total input)
@@ -39,16 +44,11 @@ export function getCurrentTokenUsage(state: SessionState, messages: WithParts[])
         return input + cacheRead + cacheWrite + output + reasoning
     }
 
-    // [FIX Bug 5] fallback: estimate tokens from message content when no assistant
-    // message has output tokens (first turn or after full compaction)
+    // [FIX Bug 5] fallback: estimate from all content (text + tool outputs)
+    // when no assistant message has token data (first turn or full compaction).
     let estimated = 0
     for (const m of messages) {
-        const parts = Array.isArray(m.parts) ? m.parts : []
-        for (const part of parts) {
-            if (part.type === "text" && typeof part.text === "string") {
-                estimated += countTokens(part.text)
-            }
-        }
+        estimated += countAllMessageTokens(m)
     }
     return estimated
 }

--- a/tests/token-usage.test.ts
+++ b/tests/token-usage.test.ts
@@ -298,3 +298,125 @@ test("isContextOverLimits does not extend the max threshold when summaryBuffer i
 
     assert.equal(overLimit.overMaxLimit, true)
 })
+
+function buildOutputZeroAssistantMessage(): WithParts {
+    const sessionID = "ses_compaction_token_usage"
+
+    return {
+        info: {
+            id: "msg-assistant-output-zero",
+            role: "assistant",
+            sessionID,
+            agent: "assistant",
+            time: { created: 5 },
+            tokens: {
+                input: 50000,
+                output: 0,
+                reasoning: 0,
+                cache: {
+                    read: 10000,
+                    write: 0,
+                },
+            },
+        } as WithParts["info"],
+        parts: [
+            textPart(
+                "msg-assistant-output-zero",
+                sessionID,
+                "msg-assistant-output-zero-part",
+                "",
+            ),
+        ],
+    }
+}
+
+test("getCurrentTokenUsage uses assistant message with output=0 but input>0", () => {
+    const messages = buildCompactedMessages()
+    messages.push(buildPostCompactionAssistantMessage())
+    messages.push(buildOutputZeroAssistantMessage())
+
+    const state = createSessionState()
+
+    // The output=0 message has input=50000, cache.read=10000
+    // Total = input + cacheRead + cacheWrite + output + reasoning
+    //       = 50000 + 10000 + 0 + 0 + 0 = 60000
+    assert.equal(getCurrentTokenUsage(state, messages), 60000)
+})
+
+test("getCurrentTokenUsage skips assistant message with both input=0 and output=0", () => {
+    const messages = buildCompactedMessages()
+    messages.push(buildPostCompactionAssistantMessage())
+
+    // Add a truly empty assistant message (no token data at all)
+    messages.push({
+        info: {
+            id: "msg-assistant-empty",
+            role: "assistant",
+            sessionID: "ses_compaction_token_usage",
+            agent: "assistant",
+            time: { created: 5 },
+            tokens: {
+                input: 0,
+                output: 0,
+                reasoning: 0,
+                cache: { read: 0, write: 0 },
+            },
+        } as WithParts["info"],
+        parts: [],
+    })
+
+    const state = createSessionState()
+
+    // Should skip the empty message and use the post-compaction one
+    const freshReportedTotal = 2400 + 600 + 150 + 300
+    assert.equal(getCurrentTokenUsage(state, messages), freshReportedTotal)
+})
+
+test("getCurrentTokenUsage fallback counts tool outputs not just text", () => {
+    const sessionID = "ses_tool_fallback"
+    const messages: WithParts[] = [
+        {
+            info: {
+                id: "msg-user-1",
+                role: "user",
+                sessionID,
+                agent: "assistant",
+                time: { created: 1 },
+            } as WithParts["info"],
+            parts: [
+                textPart("msg-user-1", sessionID, "prt-u1", "Short text"),
+                {
+                    id: "prt-tool-1",
+                    messageID: "msg-user-1",
+                    sessionID,
+                    type: "tool" as const,
+                    callID: "call-1",
+                    tool: "bash",
+                    state: {
+                        status: "completed" as const,
+                        input: { command: "ls -la" },
+                        output: "total 100\ndrwxr-xr-x  2 root root 4096 Jan  1 00:00 .",
+                        title: "ls",
+                        metadata: {},
+                        time: { start: 1, end: 2 },
+                    },
+                },
+            ],
+        },
+    ]
+
+    const state = createSessionState()
+
+    // No assistant messages → falls back to content estimation
+    // Should count BOTH the text part AND the tool output
+    const usage = getCurrentTokenUsage(state, messages)
+    assert.ok(usage > 0, "fallback should return non-zero for tool-heavy messages")
+
+    // Tool output "total 100\ndrwxr-xr-x ..." adds significant tokens
+    // that the old text-only fallback would have missed entirely
+    const textOnlyTokens = Math.ceil("Short text".length / 4)
+    assert.ok(
+        usage > textOnlyTokens,
+        "fallback should count tool outputs, not just text parts",
+    )
+})


### PR DESCRIPTION
## Summary

**Problem**: `getCurrentTokenUsage()` in `lib/token-utils.ts` skipped assistant messages with `output=0` (from aborted/hidden agent requests). When all recent assistant messages had `output=0`, the function fell through to text-only content estimation. If most content was compressed away, the estimate was ~10% of actual → ACP thought context was at 10% when it was at 100%+ → no nudge/GC fired → context overflow with API 400 errors.

**Fix**: 
1. Changed skip condition from `output <= 0` to `input <= 0 && output <= 0` — accepts messages with input-only token data (output=0 but input>0 is valid; input represents the prompt size sent to the model)
2. Improved fallback estimation from text-only to `countAllMessageTokens` (includes tool outputs)

**Root cause session**: `ses_0a3be0cdeffezb9pLzfifH7lzK` (1M context, GLM-5.2) — 6 recent assistant messages had `output=0` from hidden agent requests. Estimated usage was 100K (10%) instead of actual 1.03M (103%). 16x API 400 errors before user noticed.

Files: `lib/token-utils.ts`. Tests: `tests/token-usage.test.ts` (3 new).

## Verification

- TypeScript: 0 errors
- Build: success (383.73 KB)
- Tests: 669/669 pass (4 existing + 3 new)