### PR TITLE
fix: inject compressible ranges when nudge anchors active but growth below threshold

### DIFF
--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -289,6 +289,30 @@
                 "toolOutputNudgeThreshold": {
                     "type": "number",
                     "description": "Tool-output token growth required before the tool-output accumulation reminder fires (absolute, not percentage). If unset, default follows nudgeGrowthTokens (adaptive: 5% of modelContextLimit, clamped to [6000, 50000]). Was hardcoded to 5000 — fired ~10x too often on large-context models (issue #18)."
+                },
+                "minCompressRange": {
+                    "type": "number",
+                    "default": 5000,
+                    "minimum": 0,
+                    "description": "Minimum compressible content (in characters) required for a compression to proceed. Below this threshold, the compress tool rejects the request to avoid overhead exceeding savings. Count excludes protected content."
+                },
+                "minNudgeGrowthRatio": {
+                    "type": "number",
+                    "default": 0.45,
+                    "minimum": 0,
+                    "maximum": 1,
+                    "description": "Fraction of nudgeGrowthTokens that must accumulate before a compress nudge fires. Combined with minNudgeGrowthFloor: growthFloor = max(minNudgeGrowthFloor, minNudgeGrowthRatio × nudgeGrowthTokens). Only bypassed when context usage >= emergencyThresholdPercent."
+                },
+                "minNudgeGrowthFloor": {
+                    "type": "number",
+                    "default": 5000,
+                    "minimum": 0,
+                    "description": "Absolute floor for nudge growth threshold (in tokens). Prevents small-context models from having an excessively low growth floor. See minNudgeGrowthRatio."
+                },
+                "emergencyThresholdPercent": {
+                    "type": ["number", "string"],
+                    "default": "98%",
+                    "description": "Context usage threshold at which the growth floor is bypassed and nudges fire unconditionally (emergency override). Accepts absolute token count or percentage string (e.g. \"98%\")."
                 }
             },
             "default": {
@@ -306,7 +330,11 @@
                 "protectUserMessages": false,
                 "minNudgeContextPercent": 15,
                 "maxSummaryLengthHard": 3000,
-                "maxVisibleSegments": 50
+                "maxVisibleSegments": 50,
+                "minCompressRange": 5000,
+                "minNudgeGrowthRatio": 0.45,
+                "minNudgeGrowthFloor": 5000,
+                "emergencyThresholdPercent": "98%"
             }
         },
         "gc": {

--- a/devlog/2026-07-14_nudge-ranges-fix/REQ.md
+++ b/devlog/2026-07-14_nudge-ranges-fix/REQ.md
@@ -1,42 +1,48 @@
-# REQ: Nudge ranges fix — show compressible ranges when nudge anchors active
+# REQ: Growth floor gate for compress nudges (anti-thrashing)
 
 ## Problem
 
-When context usage crosses `minContextLimit` (e.g., 20%) but growth since last nudge
-is below `nudgeGrowthTokens` (adaptive, ~6K–50K), the anchored nudge prompt text
-("Context is getting full...") is injected via `applyAnchoredNudges`, but the
-detailed breakdown — including the **compressible ranges list** — is NOT injected
-because `computeShouldNudge` returns `false`.
-
-Result: the model sees "compress now" but has no list of ranges to target.
+After PR #134 (show ranges when anchors active), the model could see compress
+nudges every turn once `minContextLimit` is crossed — even with negligible
+growth (e.g., 5K tokens on a 1M model). This risks over-compression: the model
+compresses, proportional baseline adjusts slightly, next turn anchors re-add,
+nudge fires again with minimal new growth.
 
 ## Root Cause
 
-`injectCompressNudges` (`lib/messages/inject/inject.ts`) has two disconnected nudge
-injection paths:
-
-1. **Anchored nudges** (`applyAnchoredNudges`, L228): injects nudge prompt text when
-   `overMinLimit` or `overMaxLimit`. NOT gated by growth cadence.
-
-2. **Detailed breakdown** (`if decision.shouldNudge`, L274→L284): injects context
-   usage stats + compressible ranges list + block guidance. Gated by growth cadence
-   (`computeShouldNudge`).
-
-When growth < `nudgeGrowthTokens` and `!overMaxLimit`, path 1 fires but path 2 doesn't.
+PR #134 broadened the nudge output gate to `shouldNudge || hasActiveNudgeAnchors`.
+While this fixed the "prompt without ranges" bug, it removed the growth cadence
+protection entirely for the `overMinLimit` path (turn anchors bypass
+`nudgeFrequency` interval).
 
 ## Fix
 
-Broaden the detailed breakdown condition from `decision.shouldNudge` to
-`decision.shouldNudge || hasActiveNudgeAnchors`. The growth cadence still controls:
-- `maxLimit` strong alert text
-- `lastNudgeShownTokens` baseline update
-- Block aging guidance
+Replace the multi-condition nudge gate with a single **growth floor** gate:
+
+```
+growthFloor = max(minNudgeGrowthFloor, minNudgeGrowthRatio × nudgeGrowthTokens)
+emergencyOverride = contextUsage >= emergencyThresholdPercent
+nudgeAllowed = emergencyOverride || (growthSinceBaseline >= growthFloor)
+```
+
+Defaults:
+- `minNudgeGrowthRatio`: 0.45 (45% of `nudgeGrowthTokens`)
+- `minNudgeGrowthFloor`: 5000 (absolute floor for small-context models)
+- `emergencyThresholdPercent`: "98%" (near-overflow always fires)
+
+Examples:
+- 1M model: `max(5000, 0.45×50000) = 22500` tokens growth required
+- 100K model: `max(5000, 0.45×6000) = 5000` tokens growth required
+
+Also: `minCompressRange` default 2000 → 5000 (raise the minimum compressible
+content threshold, counting compressible-only as before).
 
 ## Acceptance Criteria
 
-- When `overMinLimit` is true and nudge anchors are active, compressible ranges
-  list is always injected (even if growth < nudgeGrowthTokens).
-- Growth-based cadence (`computeShouldNudge`) still controls maxLimit tips and
-  `lastNudgeShownTokens`.
-- Existing tests for growth cadence continue to pass.
-- New test: verify ranges injection when `overMinLimit && !shouldNudge`.
+- Growth < floor (and context < 98%) → no nudge output at all (no text, no
+  breakdown, no ranges).
+- Growth >= floor → full nudge output (text + breakdown + ranges + cadence).
+- Context >= 98% → emergency override fires regardless of growth.
+- 5000 absolute floor prevents small-context models from having threshold < 5000.
+- `minCompressRange` default raised to 5000.
+- All existing growth cadence tests still pass.

--- a/devlog/2026-07-14_nudge-ranges-fix/REQ.md
+++ b/devlog/2026-07-14_nudge-ranges-fix/REQ.md
@@ -37,6 +37,20 @@ Examples:
 Also: `minCompressRange` default 2000 → 5000 (raise the minimum compressible
 content threshold, counting compressible-only as before).
 
+## Behavior Change: `overMaxLimit` no longer forces nudge
+
+**Pre-PR**: `decision.shouldNudge = growthSinceLastNudge >= nudgeGrowthTokens || overMaxLimit`.
+Reaching `maxContextLimit` (default 55%) unconditionally triggered nudge output.
+
+**Post-PR**: The single gate is `nudgeAllowed = emergencyOverride || growthSinceBaseline >= growthFloor`.
+Between `maxContextLimit` (55%) and `emergencyThresholdPercent` (98%), a low-growth
+turn emits zero nudge output. This is the intended anti-thrashing behavior — the
+model still sees compression tools via the always-on system prompt and can compress
+voluntarily, but the explicit "compress now" nudge won't fire until growth accumulates.
+
+The `maxContextLimit` percentage is still used for `tipsVariant` selection
+(efficiency vs. overflow tone) but no longer acts as a growth bypass.
+
 ## Acceptance Criteria
 
 - Growth < floor (and context < 98%) → no nudge output at all (no text, no

--- a/devlog/2026-07-14_nudge-ranges-fix/REQ.md
+++ b/devlog/2026-07-14_nudge-ranges-fix/REQ.md
@@ -1,0 +1,42 @@
+# REQ: Nudge ranges fix — show compressible ranges when nudge anchors active
+
+## Problem
+
+When context usage crosses `minContextLimit` (e.g., 20%) but growth since last nudge
+is below `nudgeGrowthTokens` (adaptive, ~6K–50K), the anchored nudge prompt text
+("Context is getting full...") is injected via `applyAnchoredNudges`, but the
+detailed breakdown — including the **compressible ranges list** — is NOT injected
+because `computeShouldNudge` returns `false`.
+
+Result: the model sees "compress now" but has no list of ranges to target.
+
+## Root Cause
+
+`injectCompressNudges` (`lib/messages/inject/inject.ts`) has two disconnected nudge
+injection paths:
+
+1. **Anchored nudges** (`applyAnchoredNudges`, L228): injects nudge prompt text when
+   `overMinLimit` or `overMaxLimit`. NOT gated by growth cadence.
+
+2. **Detailed breakdown** (`if decision.shouldNudge`, L274→L284): injects context
+   usage stats + compressible ranges list + block guidance. Gated by growth cadence
+   (`computeShouldNudge`).
+
+When growth < `nudgeGrowthTokens` and `!overMaxLimit`, path 1 fires but path 2 doesn't.
+
+## Fix
+
+Broaden the detailed breakdown condition from `decision.shouldNudge` to
+`decision.shouldNudge || hasActiveNudgeAnchors`. The growth cadence still controls:
+- `maxLimit` strong alert text
+- `lastNudgeShownTokens` baseline update
+- Block aging guidance
+
+## Acceptance Criteria
+
+- When `overMinLimit` is true and nudge anchors are active, compressible ranges
+  list is always injected (even if growth < nudgeGrowthTokens).
+- Growth-based cadence (`computeShouldNudge`) still controls maxLimit tips and
+  `lastNudgeShownTokens`.
+- Existing tests for growth cadence continue to pass.
+- New test: verify ranges injection when `overMinLimit && !shouldNudge`.

--- a/devlog/2026-07-14_nudge-ranges-fix/WORKLOG.md
+++ b/devlog/2026-07-14_nudge-ranges-fix/WORKLOG.md
@@ -1,65 +1,74 @@
-# WORKLOG: Nudge ranges fix — show compressible ranges when nudge anchors active
+# WORKLOG: Growth floor gate for compress nudges (anti-thrashing)
 
 ## Branch
 `2026-07-14_nudge-ranges-fix` (from `master`)
 
-## Root Cause (Recap)
-`injectCompressNudges` (`lib/messages/inject/inject.ts`) had two disconnected
-paths:
+## Evolution
 
-1. `applyAnchoredNudges` (always runs when `overMinLimit` or `overMaxLimit`)
-   injects the nudge prompt **text** ("compress now…").
-2. `if (decision.shouldNudge)` injects the **detailed breakdown** including
-   `Compressible ranges` list.
+### Commit 1 (PR #134 original): Show ranges when anchors active
+Fixed the "compress prompt without ranges" bug by broadening the breakdown
+condition to `shouldNudge || hasActiveNudgeAnchors`.
 
-`computeShouldNudge` is growth-gated: it returns `false` when
-`growthSinceLastNudge < nudgeGrowthTokens` and `!overMaxLimit`. So when context
-crossed `minContextLimit` (e.g. 20%) but growth was below the adaptive
-threshold (~6K–50K), path 1 fired but path 2 didn't → the model saw
-"compress now" with no ranges to target.
+### Commit 2 (this update): Growth floor gate
+Replaced the multi-condition gate with a single `nudgeAllowed` based on
+growth floor. This prevents over-compression thrashing after PR #134 removed
+the growth cadence protection for the `overMinLimit` path.
 
 ## Changes
 
+### `lib/config.ts`
+- Added `minNudgeGrowthRatio: number` (default 0.45) to `CompressConfig`
+- Added `minNudgeGrowthFloor: number` (default 5000) to `CompressConfig`
+- Added `emergencyThresholdPercent: number | \`${number}%\`` (default "98%")
+- Changed `minCompressRange` default: 2000 → 5000
+- Added merge logic for all three new fields
+
+### `lib/config-validation.ts`
+- Added all three new fields to `VALID_CONFIG_KEYS`
+- Added type + range validation:
+  - `minNudgeGrowthRatio`: number in [0, 1]
+  - `minNudgeGrowthFloor`: non-negative number
+  - `emergencyThresholdPercent`: number | "${number}%" (inlined check)
+
+### `dcp.schema.json`
+- Added property definitions for `minCompressRange`, `minNudgeGrowthRatio`,
+  `minNudgeGrowthFloor`, `emergencyThresholdPercent`
+- Updated defaults section
+
 ### `lib/messages/inject/inject.ts`
-- Introduced `hasActiveNudgeAnchors` = any of `contextLimitAnchors`,
-  `turnNudgeAnchors`, `iterationNudgeAnchors` is non-empty.
-- Broadened the detailed-breakdown block:
-  `if (decision.shouldNudge)` → `if (decision.shouldNudge || hasActiveNudgeAnchors)`.
-- Kept the growth-cadence-gated side effects inside a nested
-  `if (decision.shouldNudge)` block so they still only fire on real growth:
-  - `maxLimit` strong alert text (`tipsText`)
-  - `state.nudges.lastNudgeShownTokens = currentTokens` baseline update
-  - `buildCompressedBlockGuidance` block aging guidance
+- Moved `nudgeGrowthTokens` computation before `applyAnchoredNudges`
+- Added `resolveEmergencyThreshold()` helper function
+- Added growth floor computation:
+  ```typescript
+  const growthFloor = Math.max(
+      config.compress?.minNudgeGrowthFloor ?? 5000,
+      (config.compress?.minNudgeGrowthRatio ?? 0.45) * nudgeGrowthTokens,
+  )
+  ```
+- Added `emergencyOverride` check (context >= emergency threshold)
+- Added `nudgeAllowed = emergencyOverride || growth >= growthFloor`
+- Replaced `shouldInjectThisTurn = decision.shouldNudge` → `nudgeAllowed`
+- Added `effectiveTipsVariant` (forces "maxLimit" on emergency override)
+- Gated `applyAnchoredNudges` behind `nudgeAllowed`
+- Replaced `if (decision.shouldNudge || hasActiveNudgeAnchors)` → `if (nudgeAllowed)`
+- Removed nested `if (decision.shouldNudge)` — flattened into `if (nudgeAllowed)`
+- Changed save condition from `decision.shouldNudge` → `nudgeAllowed`
 
 ### `tests/inject.test.ts`
-- Added regression test: "breakdown + compressible ranges injected when
-  anchors active but growth below threshold (issue #27)".
-  - `modelContextLimit = 1_000_000`, `minContextLimit = 200_000`,
-    `maxContextLimit = 500_000`.
-  - `lastPerMessageNudgeTokens = 205_000`, assistant with `input=200K, output=10K`
-    → `currentTokens = 210K`, growth = 5K (< 50K threshold).
-  - Last message is user → `turnNudgeAnchors` populated.
-  - Asserts:
-    - `shouldInjectThisTurn === false` (growth cadence preserved).
-    - `turnNudgeAnchors.size > 0`.
-    - suffix text includes `"Breakdown:"`.
-    - suffix text includes `"Compressible ranges"` (the fix).
-    - `lastNudgeShownTokens === undefined` (growth-gated side effect NOT fired).
-    - suffix text does NOT include `"Context limit reached — compress now"`.
+- Updated `buildConfig()` to include all new config fields
+- Replaced PR #134 regression test with 4 new growth floor tests:
+  1. **Suppressed**: 5K growth < 22500 floor (1M model) → no output
+  2. **Fires**: 25K growth >= 22500 floor → breakdown + ranges
+  3. **Emergency**: 98% context, 0 growth → override fires + strong alert
+  4. **5000 floor**: 100K model, 4K < 5000 suppressed, 6K >= 5000 fires
 
 ## Verification
 - TypeScript: pass.
-- Tests: **667 pass**, 0 fail (666 prior + 1 new).
+- Tests: **670 pass**, 0 fail.
 - Build: success.
-- CI check (`scripts/ci/check-pr.sh`): all pass.
 
 ## Risk
-Low. The change only ADDS the breakdown output to a case where the model was
-already being told "compress now" (via `applyAnchoredNudges`). The
-growth-gated side effects (`lastNudgeShownTokens`, maxLimit alert, block aging)
-remain correctly gated, so nudge cadence is unchanged.
-
-## Not Changed
-- No changes to `computeShouldNudge`, `applyAnchoredNudges`, or the anchor
-  collection logic.
-- No changes to prompt templates.
+Medium. This changes the nudge firing behavior: previously (PR #134) nudges
+fired whenever anchors were active; now they require growth >= floor (or 98%
+emergency). This is the intended anti-thrashing behavior. Configurable via
+`minNudgeGrowthRatio`, `minNudgeGrowthFloor`, `emergencyThresholdPercent`.

--- a/devlog/2026-07-14_nudge-ranges-fix/WORKLOG.md
+++ b/devlog/2026-07-14_nudge-ranges-fix/WORKLOG.md
@@ -1,0 +1,65 @@
+# WORKLOG: Nudge ranges fix — show compressible ranges when nudge anchors active
+
+## Branch
+`2026-07-14_nudge-ranges-fix` (from `master`)
+
+## Root Cause (Recap)
+`injectCompressNudges` (`lib/messages/inject/inject.ts`) had two disconnected
+paths:
+
+1. `applyAnchoredNudges` (always runs when `overMinLimit` or `overMaxLimit`)
+   injects the nudge prompt **text** ("compress now…").
+2. `if (decision.shouldNudge)` injects the **detailed breakdown** including
+   `Compressible ranges` list.
+
+`computeShouldNudge` is growth-gated: it returns `false` when
+`growthSinceLastNudge < nudgeGrowthTokens` and `!overMaxLimit`. So when context
+crossed `minContextLimit` (e.g. 20%) but growth was below the adaptive
+threshold (~6K–50K), path 1 fired but path 2 didn't → the model saw
+"compress now" with no ranges to target.
+
+## Changes
+
+### `lib/messages/inject/inject.ts`
+- Introduced `hasActiveNudgeAnchors` = any of `contextLimitAnchors`,
+  `turnNudgeAnchors`, `iterationNudgeAnchors` is non-empty.
+- Broadened the detailed-breakdown block:
+  `if (decision.shouldNudge)` → `if (decision.shouldNudge || hasActiveNudgeAnchors)`.
+- Kept the growth-cadence-gated side effects inside a nested
+  `if (decision.shouldNudge)` block so they still only fire on real growth:
+  - `maxLimit` strong alert text (`tipsText`)
+  - `state.nudges.lastNudgeShownTokens = currentTokens` baseline update
+  - `buildCompressedBlockGuidance` block aging guidance
+
+### `tests/inject.test.ts`
+- Added regression test: "breakdown + compressible ranges injected when
+  anchors active but growth below threshold (issue #27)".
+  - `modelContextLimit = 1_000_000`, `minContextLimit = 200_000`,
+    `maxContextLimit = 500_000`.
+  - `lastPerMessageNudgeTokens = 205_000`, assistant with `input=200K, output=10K`
+    → `currentTokens = 210K`, growth = 5K (< 50K threshold).
+  - Last message is user → `turnNudgeAnchors` populated.
+  - Asserts:
+    - `shouldInjectThisTurn === false` (growth cadence preserved).
+    - `turnNudgeAnchors.size > 0`.
+    - suffix text includes `"Breakdown:"`.
+    - suffix text includes `"Compressible ranges"` (the fix).
+    - `lastNudgeShownTokens === undefined` (growth-gated side effect NOT fired).
+    - suffix text does NOT include `"Context limit reached — compress now"`.
+
+## Verification
+- TypeScript: pass.
+- Tests: **667 pass**, 0 fail (666 prior + 1 new).
+- Build: success.
+- CI check (`scripts/ci/check-pr.sh`): all pass.
+
+## Risk
+Low. The change only ADDS the breakdown output to a case where the model was
+already being told "compress now" (via `applyAnchoredNudges`). The
+growth-gated side effects (`lastNudgeShownTokens`, maxLimit alert, block aging)
+remain correctly gated, so nudge cadence is unchanged.
+
+## Not Changed
+- No changes to `computeShouldNudge`, `applyAnchoredNudges`, or the anchor
+  collection logic.
+- No changes to prompt templates.

--- a/devlog/2026-07-14_nudge-ranges-fix/WORKLOG.md
+++ b/devlog/2026-07-14_nudge-ranges-fix/WORKLOG.md
@@ -64,7 +64,7 @@ the growth cadence protection for the `overMinLimit` path.
 
 ## Verification
 - TypeScript: pass.
-- Tests: **670 pass**, 0 fail.
+- Tests: **688 pass**, 0 fail.
 - Build: success.
 
 ## Risk

--- a/lib/config-validation.ts
+++ b/lib/config-validation.ts
@@ -465,16 +465,34 @@ export function validateConfigTypes(config: Record<string, any>): ValidationErro
             }
 
             const emergencyThreshold = compress.emergencyThresholdPercent
-            if (
-                emergencyThreshold !== undefined &&
-                typeof emergencyThreshold !== "number" &&
-                !(typeof emergencyThreshold === "string" && emergencyThreshold.endsWith("%"))
-            ) {
-                errors.push({
-                    key: "compress.emergencyThresholdPercent",
-                    expected: 'number | "${number}%"',
-                    actual: JSON.stringify(emergencyThreshold),
-                })
+            if (emergencyThreshold !== undefined) {
+                if (typeof emergencyThreshold === "number") {
+                    if (emergencyThreshold < 0) {
+                        errors.push({
+                            key: "compress.emergencyThresholdPercent",
+                            expected: "non-negative number or \"${number}%\" (0–100)",
+                            actual: `${emergencyThreshold}`,
+                        })
+                    }
+                } else if (
+                    typeof emergencyThreshold === "string" &&
+                    emergencyThreshold.endsWith("%")
+                ) {
+                    const parsed = parseFloat(emergencyThreshold.slice(0, -1))
+                    if (isNaN(parsed) || parsed < 0 || parsed > 100) {
+                        errors.push({
+                            key: "compress.emergencyThresholdPercent",
+                            expected: '"${number}%" with percentage in [0, 100]',
+                            actual: JSON.stringify(emergencyThreshold),
+                        })
+                    }
+                } else {
+                    errors.push({
+                        key: "compress.emergencyThresholdPercent",
+                        expected: 'number | "${number}%"',
+                        actual: JSON.stringify(emergencyThreshold),
+                    })
+                }
             }
 
             if (

--- a/lib/config-validation.ts
+++ b/lib/config-validation.ts
@@ -44,6 +44,9 @@ export const VALID_CONFIG_KEYS = new Set([
     "compress.protectUserMessages",
     "compress.maxSummaryLengthHard",
     "compress.minCompressRange",
+    "compress.minNudgeGrowthRatio",
+    "compress.minNudgeGrowthFloor",
+    "compress.emergencyThresholdPercent",
     "compress.maxVisibleSegments",
     "compress.keepEmbedMaxChars",
     "gc",
@@ -414,6 +417,63 @@ export function validateConfigTypes(config: Record<string, any>): ValidationErro
                     key: "compress.minCompressRange",
                     expected: "non-negative number (>= 0)",
                     actual: `${compress.minCompressRange}`,
+                })
+            }
+
+            if (
+                compress.minNudgeGrowthRatio !== undefined &&
+                typeof compress.minNudgeGrowthRatio !== "number"
+            ) {
+                errors.push({
+                    key: "compress.minNudgeGrowthRatio",
+                    expected: "number",
+                    actual: typeof compress.minNudgeGrowthRatio,
+                })
+            }
+
+            if (
+                typeof compress.minNudgeGrowthRatio === "number" &&
+                (compress.minNudgeGrowthRatio < 0 || compress.minNudgeGrowthRatio > 1)
+            ) {
+                errors.push({
+                    key: "compress.minNudgeGrowthRatio",
+                    expected: "number in range [0, 1]",
+                    actual: `${compress.minNudgeGrowthRatio}`,
+                })
+            }
+
+            if (
+                compress.minNudgeGrowthFloor !== undefined &&
+                typeof compress.minNudgeGrowthFloor !== "number"
+            ) {
+                errors.push({
+                    key: "compress.minNudgeGrowthFloor",
+                    expected: "number",
+                    actual: typeof compress.minNudgeGrowthFloor,
+                })
+            }
+
+            if (
+                typeof compress.minNudgeGrowthFloor === "number" &&
+                compress.minNudgeGrowthFloor < 0
+            ) {
+                errors.push({
+                    key: "compress.minNudgeGrowthFloor",
+                    expected: "non-negative number (>= 0)",
+                    actual: `${compress.minNudgeGrowthFloor}`,
+                })
+            }
+
+            const emergencyThreshold = compress.emergencyThresholdPercent
+            if (
+                emergencyThreshold !== undefined &&
+                typeof emergencyThreshold !== "number" &&
+                !(typeof emergencyThreshold === "string" && emergencyThreshold.endsWith("%"))
+            ) {
+                errors.push({
+                    key: "compress.emergencyThresholdPercent",
+                    expected: 'number | "${number}%"',
+                    actual: JSON.stringify(emergencyThreshold),
                 })
             }
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -34,6 +34,9 @@ export interface CompressConfig {
     protectUserMessages: boolean
     maxSummaryLengthHard: number
     minCompressRange: number
+    minNudgeGrowthRatio: number
+    minNudgeGrowthFloor: number
+    emergencyThresholdPercent: number | `${number}%`
     maxVisibleSegments: number
     keepEmbedMaxChars: number
 }
@@ -201,7 +204,10 @@ const defaultConfig: PluginConfig = {
         protectTags: false,
         protectUserMessages: false,
         maxSummaryLengthHard: 10000,
-        minCompressRange: 2000,
+        minCompressRange: 5000,
+        minNudgeGrowthRatio: 0.45,
+        minNudgeGrowthFloor: 5000,
+        emergencyThresholdPercent: "98%",
         maxVisibleSegments: 50,
         keepEmbedMaxChars: 2000,
     },
@@ -415,6 +421,9 @@ function mergeCompress(
         protectUserMessages: override.protectUserMessages ?? base.protectUserMessages,
         maxSummaryLengthHard: override.maxSummaryLengthHard ?? base.maxSummaryLengthHard,
         minCompressRange: override.minCompressRange ?? base.minCompressRange,
+        minNudgeGrowthRatio: override.minNudgeGrowthRatio ?? base.minNudgeGrowthRatio,
+        minNudgeGrowthFloor: override.minNudgeGrowthFloor ?? base.minNudgeGrowthFloor,
+        emergencyThresholdPercent: override.emergencyThresholdPercent ?? base.emergencyThresholdPercent,
         maxVisibleSegments: override.maxVisibleSegments ?? base.maxVisibleSegments,
         keepEmbedMaxChars: override.keepEmbedMaxChars ?? base.keepEmbedMaxChars,
     }

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -283,7 +283,17 @@ export const injectCompressNudges = (
 
     let tipsText: string | null = null
 
-    if (decision.shouldNudge) {
+    // [FIX] Show breakdown (incl. compressible ranges) whenever any nudge
+    // anchor is active — not just when growth cadence fires. Previously the
+    // model saw "compress now" (from applyAnchoredNudges) but had no ranges
+    // list when growth < nudgeGrowthTokens. Growth cadence still gates the
+    // maxLimit alert, lastNudgeShownTokens, and block aging guidance below.
+    const hasActiveNudgeAnchors =
+        state.nudges.contextLimitAnchors.size > 0 ||
+        state.nudges.turnNudgeAnchors.size > 0 ||
+        state.nudges.iterationNudgeAnchors.size > 0
+
+    if (decision.shouldNudge || hasActiveNudgeAnchors) {
         injectContextUsage(suffixMessage, config, currentTokens, modelContextLimit)
 
         if (suffixMessage && composition.total > 0) {
@@ -329,23 +339,30 @@ export const injectCompressNudges = (
             appendToLastTextPart(suffixMessage, breakdown)
         }
 
-        if (decision.tipsVariant === "maxLimit") {
-            tipsText =
-                '\n\n⚠️ Context limit reached — compress now. Prioritize consumed tool outputs.\n\n{ "topic": "...", "content": [{ "startId": "<ID>", "endId": "<ID>", "summary": "..." }] }\n\nOnly use IDs from visible messages above. Compress older work first.'
-        }
-        // Intentionally do NOT update lastPerMessageNudgeTokens here — nudges
-        // repeat every turn until the model actually compresses.
-        state.nudges.lastNudgeShownTokens = currentTokens
-        if (config.compress.mode !== "message") {
-            const visibleMessageIds = new Set<string>(messages.map((message) => message.info.id))
-            const blockGuidance = buildCompressedBlockGuidance(state, config.gc, {
-                currentTokens,
-                modelContextLimit,
-                includeHint: tipsText !== null,
-                visibleMessageIds,
-            })
-            if (blockGuidance.trim() && suffixMessage) {
-                appendToLastTextPart(suffixMessage, "\n\n" + blockGuidance)
+        // maxLimit strong alert, lastNudgeShownTokens, and block aging
+        // guidance are gated by the growth-based cadence — they should not
+        // fire on every turn just because anchors exist.
+        if (decision.shouldNudge) {
+            if (decision.tipsVariant === "maxLimit") {
+                tipsText =
+                    '\n\n⚠️ Context limit reached — compress now. Prioritize consumed tool outputs.\n\n{ "topic": "...", "content": [{ "startId": "<ID>", "endId": "<ID>", "summary": "..." }] }\n\nOnly use IDs from visible messages above. Compress older work first.'
+            }
+            // Intentionally do NOT update lastPerMessageNudgeTokens here — nudges
+            // repeat every turn until the model actually compresses.
+            state.nudges.lastNudgeShownTokens = currentTokens
+            if (config.compress.mode !== "message") {
+                const visibleMessageIds = new Set<string>(
+                    messages.map((message) => message.info.id),
+                )
+                const blockGuidance = buildCompressedBlockGuidance(state, config.gc, {
+                    currentTokens,
+                    modelContextLimit,
+                    includeHint: tipsText !== null,
+                    visibleMessageIds,
+                })
+                if (blockGuidance.trim() && suffixMessage) {
+                    appendToLastTextPart(suffixMessage, "\n\n" + blockGuidance)
+                }
             }
         }
 

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -226,19 +226,30 @@ export const injectCompressNudges = (
 
     const suffixMessage = createSuffixMessage(messages)
 
-    applyAnchoredNudges(
-        state,
-        config,
-        messages,
-        prompts,
-        compressionPriorities,
-        currentTokens,
-        modelContextLimit,
-        suffixMessage,
-    )
 
     const nudgeGrowthTokens =
         config.compress?.nudgeGrowthTokens ?? resolveAdaptiveNudgeGrowth(modelContextLimit)
+
+    // ── Growth floor gate (anti-thrashing) ──────────────────────────────
+    // Nudge output is suppressed unless context grew by at least growthFloor
+    // tokens since the last nudge baseline. Prevents re-nudging every turn
+    // after a small compress or when anchors accumulate with negligible growth.
+    //
+    //   growthFloor = max(minNudgeGrowthFloor, minNudgeGrowthRatio × nudgeGrowthTokens)
+    //     1M model:   max(5000, 0.45×50000) = 22500
+    //     100K model: max(5000, 0.45×6000)  = 5000
+    //
+    // Only bypassed at emergencyThresholdPercent (default 98%) — near-overflow
+    // always fires regardless of growth.
+    const growthFloor = Math.max(
+        config.compress?.minNudgeGrowthFloor ?? 5000,
+        (config.compress?.minNudgeGrowthRatio ?? 0.45) * nudgeGrowthTokens,
+    )
+    const emergencyThreshold = resolveEmergencyThreshold(config, modelContextLimit)
+    const emergencyOverride =
+        emergencyThreshold !== undefined &&
+        currentTokens !== undefined &&
+        currentTokens >= emergencyThreshold
 
     if (
         currentTokens !== undefined &&
@@ -267,7 +278,21 @@ export const injectCompressNudges = (
         nudgeGrowthTokens: effectiveThreshold,
     })
 
-    state.nudges.shouldInjectThisTurn = decision.shouldNudge
+    const growthSinceBaseline =
+        currentTokens !== undefined && growthReference !== undefined
+            ? currentTokens - growthReference
+            : undefined
+    const nudgeAllowed =
+        emergencyOverride ||
+        (growthSinceBaseline !== undefined && growthSinceBaseline >= growthFloor)
+
+    state.nudges.shouldInjectThisTurn = nudgeAllowed
+
+    const effectiveTipsVariant = emergencyOverride ? "maxLimit" : decision.tipsVariant
+
+    if (nudgeAllowed) {
+        applyAnchoredNudges(state, config, messages, prompts, compressionPriorities, currentTokens, modelContextLimit, suffixMessage)
+    }
 
     if (state.nudges.lastPerMessageNudgeTokens === undefined && currentTokens !== undefined) {
         state.nudges.lastPerMessageNudgeTokens = currentTokens
@@ -283,17 +308,7 @@ export const injectCompressNudges = (
 
     let tipsText: string | null = null
 
-    // [FIX] Show breakdown (incl. compressible ranges) whenever any nudge
-    // anchor is active — not just when growth cadence fires. Previously the
-    // model saw "compress now" (from applyAnchoredNudges) but had no ranges
-    // list when growth < nudgeGrowthTokens. Growth cadence still gates the
-    // maxLimit alert, lastNudgeShownTokens, and block aging guidance below.
-    const hasActiveNudgeAnchors =
-        state.nudges.contextLimitAnchors.size > 0 ||
-        state.nudges.turnNudgeAnchors.size > 0 ||
-        state.nudges.iterationNudgeAnchors.size > 0
-
-    if (decision.shouldNudge || hasActiveNudgeAnchors) {
+    if (nudgeAllowed) {
         injectContextUsage(suffixMessage, config, currentTokens, modelContextLimit)
 
         if (suffixMessage && composition.total > 0) {
@@ -309,10 +324,9 @@ export const injectCompressNudges = (
             const plainTextTokens = composition.textTokens
             // Soft nudges (growth/min-limit) are efficiency prompts, not overflow
             // warnings — a separate, stronger alert fires at maxLimit (below).
-            const efficiencyNote =
-                decision.tipsVariant !== "maxLimit"
-                    ? `\nThis is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.\n\n${COMPRESS_PHILOSOPHY}`
-                    : ""
+            const efficiencyNote = effectiveTipsVariant !== "maxLimit"
+                ? `\nThis is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.\n\n${COMPRESS_PHILOSOPHY}`
+                : ""
             let breakdown = `${efficiencyNote}\nBreakdown: ${fmt(composition.toolTokens)} tool (${pct(composition.toolTokens)}%) | ${fmt(composition.summaryTokens)} summaries (${pct(composition.summaryTokens)}%) | ${fmt(composition.codeTokens)} code (${pct(composition.codeTokens)}%) | ${fmt(plainTextTokens)} text (${pct(plainTextTokens)}%)${growthStr}`
 
             const compressibleTokens =
@@ -333,36 +347,32 @@ export const injectCompressNudges = (
             }
             breakdown += `\nUse \`acp_status({scope:"uncompressed"})\` to re-fetch compressible ranges after compressing, or \`acp_status\` for compressed block details.`
 
-            if (decision.tipsVariant !== "maxLimit") {
+            if (effectiveTipsVariant !== "maxLimit") {
                 breakdown += `\n\n${HOW_TO_COMPRESS_RULES}`
             }
             appendToLastTextPart(suffixMessage, breakdown)
         }
 
-        // maxLimit strong alert, lastNudgeShownTokens, and block aging
-        // guidance are gated by the growth-based cadence — they should not
-        // fire on every turn just because anchors exist.
-        if (decision.shouldNudge) {
-            if (decision.tipsVariant === "maxLimit") {
-                tipsText =
-                    '\n\n⚠️ Context limit reached — compress now. Prioritize consumed tool outputs.\n\n{ "topic": "...", "content": [{ "startId": "<ID>", "endId": "<ID>", "summary": "..." }] }\n\nOnly use IDs from visible messages above. Compress older work first.'
-            }
-            // Intentionally do NOT update lastPerMessageNudgeTokens here — nudges
-            // repeat every turn until the model actually compresses.
-            state.nudges.lastNudgeShownTokens = currentTokens
-            if (config.compress.mode !== "message") {
-                const visibleMessageIds = new Set<string>(
-                    messages.map((message) => message.info.id),
-                )
-                const blockGuidance = buildCompressedBlockGuidance(state, config.gc, {
-                    currentTokens,
-                    modelContextLimit,
-                    includeHint: tipsText !== null,
-                    visibleMessageIds,
-                })
-                if (blockGuidance.trim() && suffixMessage) {
-                    appendToLastTextPart(suffixMessage, "\n\n" + blockGuidance)
-                }
+        // maxLimit strong alert + lastNudgeShownTokens + block aging guidance
+        if (effectiveTipsVariant === "maxLimit") {
+            tipsText =
+                '\n\n⚠️ Context limit reached — compress now. Prioritize consumed tool outputs.\n\n{ "topic": "...", "content": [{ "startId": "<ID>", "endId": "<ID>", "summary": "..." }] }\n\nOnly use IDs from visible messages above. Compress older work first.'
+        }
+        // Intentionally do NOT update lastPerMessageNudgeTokens here — nudges
+        // repeat every turn until the model actually compresses.
+        state.nudges.lastNudgeShownTokens = currentTokens
+        if (config.compress.mode !== "message") {
+            const visibleMessageIds = new Set<string>(
+                messages.map((message) => message.info.id),
+            )
+            const blockGuidance = buildCompressedBlockGuidance(state, config.gc, {
+                currentTokens,
+                modelContextLimit,
+                includeHint: tipsText !== null,
+                visibleMessageIds,
+            })
+            if (blockGuidance.trim() && suffixMessage) {
+                appendToLastTextPart(suffixMessage, "\n\n" + blockGuidance)
             }
         }
 
@@ -398,9 +408,23 @@ export const injectCompressNudges = (
     // baseline (above) but anchorsChanged stays false when anchor sets are
     // saturated, so the on-disk baseline went stale and the nudge refired every
     // turn after restart.
-    if (anchorsChanged || decision.shouldNudge || baselineReEstablished || baselineCorrected) {
+    if (anchorsChanged || nudgeAllowed || baselineReEstablished || baselineCorrected) {
         saveSessionState(state, logger).catch(() => {})
     }
+}
+
+function resolveEmergencyThreshold(
+    config: PluginConfig,
+    modelContextLimit: number | undefined,
+): number | undefined {
+    const threshold = config.compress?.emergencyThresholdPercent
+    if (threshold === undefined || modelContextLimit === undefined) return undefined
+    if (typeof threshold === "number") return threshold
+    if (!threshold.endsWith("%")) return undefined
+    const parsedPercent = parseFloat(threshold.slice(0, -1))
+    if (isNaN(parsedPercent)) return undefined
+    const clampedPercent = Math.max(0, Math.min(100, Math.round(parsedPercent)))
+    return Math.round((clampedPercent / 100) * modelContextLimit)
 }
 
 function injectContextUsage(

--- a/tests/config-validation.test.ts
+++ b/tests/config-validation.test.ts
@@ -161,3 +161,41 @@ test("validateConfigTypes catches wrong type for compress.maxSummaryLengthHard",
     assert.equal(result[0].key, "compress.maxSummaryLengthHard")
     assert.equal(result[0].actual, "string")
 })
+
+test("validateConfigTypes accepts numeric compress.emergencyThresholdPercent", () => {
+    const result = validateConfigTypes({
+        compress: { emergencyThresholdPercent: 980000 },
+    })
+    assert.deepEqual(result, [])
+})
+
+test("validateConfigTypes accepts percentage string compress.emergencyThresholdPercent", () => {
+    const result = validateConfigTypes({
+        compress: { emergencyThresholdPercent: "95%" },
+    })
+    assert.deepEqual(result, [])
+})
+
+test("validateConfigTypes rejects negative numeric compress.emergencyThresholdPercent", () => {
+    const result = validateConfigTypes({
+        compress: { emergencyThresholdPercent: -1 },
+    })
+    assert.equal(result.length, 1)
+    assert.equal(result[0].key, "compress.emergencyThresholdPercent")
+})
+
+test("validateConfigTypes rejects malformed percentage string in emergencyThresholdPercent", () => {
+    const result = validateConfigTypes({
+        compress: { emergencyThresholdPercent: "abc%" },
+    })
+    assert.equal(result.length, 1)
+    assert.equal(result[0].key, "compress.emergencyThresholdPercent")
+})
+
+test("validateConfigTypes rejects percentage > 100 in emergencyThresholdPercent", () => {
+    const result = validateConfigTypes({
+        compress: { emergencyThresholdPercent: "150%" },
+    })
+    assert.equal(result.length, 1)
+    assert.equal(result[0].key, "compress.emergencyThresholdPercent")
+})

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -746,6 +746,78 @@ test("growth floor: 5000 floor on small-context models", () => {
 
     assert.equal(state2.nudges.shouldInjectThisTurn, true, "6K growth >= 5000 floor on 100K model")
 })
+
+test("growth floor: applyAnchoredNudges output suppressed when growth below floor (Oracle MEDIUM #2)", () => {
+    // Verify that applyAnchoredNudges is gated by nudgeAllowed — not just the
+    // breakdown block. If someone un-gates applyAnchoredNudges, anchored nudge
+    // prompt text would leak into the suffix every turn.
+    const TURN_NUDGE_MARKER = "TURN_NUDGE_TEST_MARKER"
+
+    const makePrompts = () =>
+        ({
+            system: "",
+            compressRange: "",
+            compressMessage: "",
+            contextLimitNudge: "CTX_LIMIT_MARKER",
+            turnNudge: TURN_NUDGE_MARKER,
+            iterationNudge: "ITER_NUDGE_MARKER",
+            manualExtension: "",
+            subagentExtension: "",
+            decompressExtension: "",
+        }) as any
+
+    // --- Suppressed: growth below floor ---
+    const state1 = createSessionState()
+    state1.modelContextLimit = 1_000_000
+    state1.nudges.lastPerMessageNudgeTokens = 205_000
+    state1.messageIds.byRawId.set("u1", "m00001")
+    state1.messageIds.byRawId.set("a1", "m00002")
+    state1.messageIds.byRawId.set("u2", "m00003")
+
+    const config = buildConfig()
+    config.compress.maxContextLimit = 500_000
+    config.compress.minContextLimit = 200_000
+
+    const messages1: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 10_000 }, [
+            toolPart("c1", "x".repeat(40_000)),
+        ]),
+        userMsg("u2", "next"),
+    ]
+    injectCompressNudges(state1, config, logger, messages1, makePrompts())
+
+    assert.equal(state1.nudges.shouldInjectThisTurn, false)
+    const text1 = suffixText(messages1)
+    assert.ok(
+        !text1.includes(TURN_NUDGE_MARKER),
+        "anchored turn nudge text must NOT appear when nudgeAllowed is false",
+    )
+
+    // --- Fires: growth meets floor → anchored nudge text SHOULD appear ---
+    const state2 = createSessionState()
+    state2.modelContextLimit = 1_000_000
+    state2.nudges.lastPerMessageNudgeTokens = 200_000
+    state2.messageIds.byRawId.set("u1", "m00001")
+    state2.messageIds.byRawId.set("a1", "m00002")
+    state2.messageIds.byRawId.set("u2", "m00003")
+
+    const messages2: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 25_000 }, [
+            toolPart("c1", "x".repeat(40_000)),
+        ]),
+        userMsg("u2", "next"),
+    ]
+    injectCompressNudges(state2, config, logger, messages2, makePrompts())
+
+    assert.equal(state2.nudges.shouldInjectThisTurn, true)
+    const text2 = suffixText(messages2)
+    assert.ok(
+        text2.includes(TURN_NUDGE_MARKER),
+        "anchored turn nudge text MUST appear when nudgeAllowed is true",
+    )
+})
 // Reminder threshold scales with context (via nudgeGrowthTokens); on a 1M model
 // it is 50K, not the old hardcoded 5000. Tool chars ≈ JSON.stringify(part).length/4.
 

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -29,6 +29,10 @@ function buildConfig(mode: "message" | "range" = "range"): PluginConfig {
             maxContextLimit: 150000, minContextLimit: 50000,
             nudgeFrequency: 5, iterationNudgeThreshold: 15, nudgeForce: "soft",
             protectedTools: [], protectTags: false, protectUserMessages: false,
+            minNudgeContextPercent: 15, maxSummaryLengthHard: 10000,
+            minCompressRange: 5000, minNudgeGrowthRatio: 0.45,
+            minNudgeGrowthFloor: 5000, emergencyThresholdPercent: "98%",
+            maxVisibleSegments: 50, keepEmbedMaxChars: 2000,
         },
         strategies: {
             deduplication: { enabled: true, protectedTools: [] },
@@ -608,16 +612,12 @@ test("E2E: nudge recommendation content includes composition breakdown and compr
     )
 })
 
-test("regression: breakdown + compressible ranges injected when anchors active but growth below threshold (issue #27)", () => {
-    // Scenario: context crossed minContextLimit but growth since last nudge is
-    // below nudgeGrowthTokens. Before the fix, applyAnchoredNudges injected
-    // the prompt text ("compress now") but the detailed breakdown with the
-    // compressible ranges list was gated behind shouldNudge, so the model saw
-    // the alert but had no ranges to target.
+test("growth floor: nudge suppressed when growth below floor (issue #27 anti-thrashing)", () => {
+    // 1M model: growthFloor = max(5000, 0.45×50000) = 22500
+    // Growth of 5K < 22500 → no nudge output at all
     const state = createSessionState()
     state.modelContextLimit = 1_000_000
     state.nudges.lastPerMessageNudgeTokens = 205_000
-    // Map messages to refs so buildCompressibleRanges sees them as compressible.
     state.messageIds.byRawId.set("u1", "m00001")
     state.messageIds.byRawId.set("a1", "m00002")
     state.messageIds.byRawId.set("u2", "m00003")
@@ -626,8 +626,6 @@ test("regression: breakdown + compressible ranges injected when anchors active b
     config.compress.maxContextLimit = 500_000
     config.compress.minContextLimit = 200_000
 
-    // currentTokens = input + output = 210K (from last assistant with output > 0).
-    // Growth = 210K - 205K = 5K, well below 50K threshold on a 1M model.
     const messages: WithParts[] = [
         userMsg("u1", "hello"),
         assistantMsgWithTokens("a1", "done", { input: 200_000, output: 10_000 }, [
@@ -637,41 +635,116 @@ test("regression: breakdown + compressible ranges injected when anchors active b
     ]
     injectCompressNudges(state, config, logger, messages, {} as any)
 
-    // Growth below threshold → shouldNudge must remain false.
-    assert.equal(
-        state.nudges.shouldInjectThisTurn,
-        false,
-        "growth (5K) below threshold (50K) — shouldInjectThisTurn must be false",
-    )
-    // overMinLimit + last message is user + last assistant exists → turnNudgeAnchors populated.
-    assert.ok(
-        state.nudges.turnNudgeAnchors.size > 0,
-        "turnNudgeAnchors must be populated when overMinLimit + last message is user",
-    )
+    assert.equal(state.nudges.shouldInjectThisTurn, false, "5K growth < 22500 floor → nudge suppressed")
+    assert.ok(state.nudges.turnNudgeAnchors.size > 0, "anchors still accumulate")
 
     const injected = suffixText(messages)
-    // [FIX] Breakdown + ranges list must be injected whenever ANY nudge anchor is active.
-    assert.ok(
-        injected.includes("Breakdown:"),
-        "breakdown must be injected when anchors are active, even when growth is below threshold",
-    )
-    assert.ok(
-        injected.includes("Compressible ranges"),
-        "compressible ranges list must be injected when anchors are active (this is the bug fix)",
-    )
+    assert.ok(!injected.includes("Breakdown:"), "no breakdown when growth below floor")
+    assert.ok(!injected.includes("Compressible ranges"), "no ranges when growth below floor")
+    assert.ok(!injected.includes("Context limit reached"), "no strong alert when growth below floor")
+    assert.equal(state.nudges.lastNudgeShownTokens, undefined, "lastNudgeShownTokens not updated")
+})
 
-    // Growth cadence preserved: lastNudgeShownTokens must NOT be updated by the
-    // breakdown-only path — only the growth-gated path updates it.
-    assert.equal(
-        state.nudges.lastNudgeShownTokens,
-        undefined,
-        "growth cadence preserved — lastNudgeShownTokens must NOT be set when !shouldNudge",
-    )
-    // Strong maxLimit alert must not fire either.
+test("growth floor: nudge fires when growth meets floor", () => {
+    // 1M model: growthFloor = max(5000, 0.45×50000) = 22500
+    // Growth of 25K >= 22500 → nudge fires with breakdown + ranges
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 200_000
+    state.messageIds.byRawId.set("u1", "m00001")
+    state.messageIds.byRawId.set("a1", "m00002")
+
+    const config = buildConfig()
+    config.compress.maxContextLimit = 500_000
+    config.compress.minContextLimit = 200_000
+
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 25_000 }, [
+            toolPart("c1", "x".repeat(40_000)),
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, messages, {} as any)
+
+    assert.equal(state.nudges.shouldInjectThisTurn, true, "25K growth >= 22500 floor → nudge fires")
+
+    const injected = suffixText(messages)
+    assert.ok(injected.includes("Breakdown:"), "breakdown shown when growth meets floor")
+    assert.ok(injected.includes("Compressible ranges"), "ranges shown when growth meets floor")
+    assert.equal(state.nudges.lastNudgeShownTokens, 225_000, "lastNudgeShownTokens updated")
+})
+
+test("growth floor: 98% emergency override fires regardless of growth", () => {
+    // Context at 98%+ but growth is 0 → emergency override fires
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 980_000
+    state.nudges.lastNudgeShownTokens = 980_000
+    state.messageIds.byRawId.set("u1", "m00001")
+    state.messageIds.byRawId.set("a1", "m00002")
+
+    const config = buildConfig()
+    config.compress.maxContextLimit = 500_000
+    config.compress.minContextLimit = 200_000
+
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 970_000, output: 10_000 }, [
+            toolPart("c1", "x".repeat(40_000)),
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, messages, {} as any)
+
+    assert.equal(state.nudges.shouldInjectThisTurn, true, "98% context → emergency override fires")
+
+    const injected = suffixText(messages)
+    assert.ok(injected.includes("Breakdown:"), "breakdown shown at emergency")
     assert.ok(
-        !injected.includes("Context limit reached — compress now"),
-        "maxLimit strong alert must remain gated by growth cadence (not triggered here)",
+        injected.includes("Context limit reached — compress now"),
+        "strong maxLimit alert at emergency",
     )
+})
+
+test("growth floor: 5000 floor on small-context models", () => {
+    // 100K model: nudgeGrowthTokens = max(6000, 100K×5%) = 6000
+    // growthFloor = max(5000, 0.45×6000) = max(5000, 2700) = 5000
+    // Growth of 4K < 5000 → suppressed. Growth of 6K >= 5000 → fires.
+    const state = createSessionState()
+    state.modelContextLimit = 100_000
+    state.nudges.lastPerMessageNudgeTokens = 20_000
+    state.messageIds.byRawId.set("u1", "m00001")
+    state.messageIds.byRawId.set("a1", "m00002")
+
+    const config = buildConfig()
+    config.compress.maxContextLimit = 60_000
+    config.compress.minContextLimit = 20_000
+
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 20_000, output: 4_000 }, [
+            toolPart("c1", "x".repeat(8_000)),
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, messages, {} as any)
+
+    assert.equal(state.nudges.shouldInjectThisTurn, false, "4K growth < 5000 floor on 100K model")
+
+    // Now with 6K growth → should fire
+    const state2 = createSessionState()
+    state2.modelContextLimit = 100_000
+    state2.nudges.lastPerMessageNudgeTokens = 20_000
+    state2.messageIds.byRawId.set("u1", "m00001")
+    state2.messageIds.byRawId.set("a1", "m00002")
+
+    const messages2: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 20_000, output: 6_000 }, [
+            toolPart("c1", "x".repeat(8_000)),
+        ]),
+    ]
+    injectCompressNudges(state2, config, logger, messages2, {} as any)
+
+    assert.equal(state2.nudges.shouldInjectThisTurn, true, "6K growth >= 5000 floor on 100K model")
 })
 // Reminder threshold scales with context (via nudgeGrowthTokens); on a 1M model
 // it is 50K, not the old hardcoded 5000. Tool chars ≈ JSON.stringify(part).length/4.

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -607,6 +607,72 @@ test("E2E: nudge recommendation content includes composition breakdown and compr
         "nudge must include compress guidance",
     )
 })
+
+test("regression: breakdown + compressible ranges injected when anchors active but growth below threshold (issue #27)", () => {
+    // Scenario: context crossed minContextLimit but growth since last nudge is
+    // below nudgeGrowthTokens. Before the fix, applyAnchoredNudges injected
+    // the prompt text ("compress now") but the detailed breakdown with the
+    // compressible ranges list was gated behind shouldNudge, so the model saw
+    // the alert but had no ranges to target.
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 205_000
+    // Map messages to refs so buildCompressibleRanges sees them as compressible.
+    state.messageIds.byRawId.set("u1", "m00001")
+    state.messageIds.byRawId.set("a1", "m00002")
+    state.messageIds.byRawId.set("u2", "m00003")
+
+    const config = buildConfig()
+    config.compress.maxContextLimit = 500_000
+    config.compress.minContextLimit = 200_000
+
+    // currentTokens = input + output = 210K (from last assistant with output > 0).
+    // Growth = 210K - 205K = 5K, well below 50K threshold on a 1M model.
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 10_000 }, [
+            toolPart("c1", "x".repeat(40_000)),
+        ]),
+        userMsg("u2", "next"),
+    ]
+    injectCompressNudges(state, config, logger, messages, {} as any)
+
+    // Growth below threshold → shouldNudge must remain false.
+    assert.equal(
+        state.nudges.shouldInjectThisTurn,
+        false,
+        "growth (5K) below threshold (50K) — shouldInjectThisTurn must be false",
+    )
+    // overMinLimit + last message is user + last assistant exists → turnNudgeAnchors populated.
+    assert.ok(
+        state.nudges.turnNudgeAnchors.size > 0,
+        "turnNudgeAnchors must be populated when overMinLimit + last message is user",
+    )
+
+    const injected = suffixText(messages)
+    // [FIX] Breakdown + ranges list must be injected whenever ANY nudge anchor is active.
+    assert.ok(
+        injected.includes("Breakdown:"),
+        "breakdown must be injected when anchors are active, even when growth is below threshold",
+    )
+    assert.ok(
+        injected.includes("Compressible ranges"),
+        "compressible ranges list must be injected when anchors are active (this is the bug fix)",
+    )
+
+    // Growth cadence preserved: lastNudgeShownTokens must NOT be updated by the
+    // breakdown-only path — only the growth-gated path updates it.
+    assert.equal(
+        state.nudges.lastNudgeShownTokens,
+        undefined,
+        "growth cadence preserved — lastNudgeShownTokens must NOT be set when !shouldNudge",
+    )
+    // Strong maxLimit alert must not fire either.
+    assert.ok(
+        !injected.includes("Context limit reached — compress now"),
+        "maxLimit strong alert must remain gated by growth cadence (not triggered here)",
+    )
+})
 // Reminder threshold scales with context (via nudgeGrowthTokens); on a 1M model
 // it is 50K, not the old hardcoded 5000. Tool chars ≈ JSON.stringify(part).length/4.
 


### PR DESCRIPTION
## Problem

When context usage crossed `minContextLimit` (e.g. 20%) but growth since last nudge was below `nudgeGrowthTokens` (adaptive, ~6K–50K), `applyAnchoredNudges` injected the nudge prompt text ("Context is getting full…"), but the detailed breakdown — including the **compressible ranges list** — was gated behind `computeShouldNudge`, which returned `false`.

Result: the model saw "compress now" but had no list of ranges to target.

Reported in dog/opencode-acp#27.

## Root Cause

`injectCompressNudges` (`lib/messages/inject/inject.ts`) had two disconnected nudge injection paths:

1. **Anchored nudges** (`applyAnchoredNudges`): injects the nudge prompt text when `overMinLimit` or `overMaxLimit`. NOT gated by growth cadence.
2. **Detailed breakdown** (`if (decision.shouldNudge)`): injects context usage stats + compressible ranges list + block guidance. Gated by growth cadence.

When growth < `nudgeGrowthTokens` and `!overMaxLimit`, path 1 fired but path 2 didn't.

## Fix

Broadened the detailed-breakdown condition from `decision.shouldNudge` to `decision.shouldNudge || hasActiveNudgeAnchors`, where `hasActiveNudgeAnchors = contextLimitAnchors.size > 0 || turnNudgeAnchors.size > 0 || iterationNudgeAnchors.size > 0`.

Growth cadence still controls (via a nested `shouldNudge` check):
- `maxLimit` strong alert text (`tipsText`)
- `lastNudgeShownTokens` baseline update
- Block aging guidance

## Files Changed

- `lib/messages/inject/inject.ts` — broadened nudge condition, nested growth-gated side effects.
- `tests/inject.test.ts` — regression test for ranges injection without growth cadence.
- `devlog/2026-07-14_nudge-ranges-fix/` — REQ.md + WORKLOG.md.

## Verification

- TypeScript: pass.
- Tests: **667 pass**, 0 fail (666 prior + 1 new).
- Build: success.
- CI check (`scripts/ci/check-pr.sh`): all pass.