### PR TITLE
release: v1.12.4 — protection-aware stats + nudge ranges fix + growth floor gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.12.4 — Protection-Aware Stats + Nudge Ranges Fix + Growth Floor Gate (PRs #132, #133, #134)
+
+**Problem**: Three issues since v1.12.3. (1) `buildCompressibleRanges` and `estimateContextComposition` listed ALL messages as compressible, silently including protected tool output — the model saw inflated ranges, compressed, and most content was filtered out → ineffective compression with confusing stats. (2) When nudge anchors were active (context over minLimit) but growth was below the cadence threshold, the nudge text fired but the compressible ranges list was gated by growth cadence → model saw "compress now" with no ranges. (3) After fixing #2, the model could be nudged every turn (turn anchors re-add every turn) → thrashing risk.
+
+**Fix**: (1) PR #132: `buildCompressibleRanges`, `estimateContextComposition`, and `acp_status` now skip protected tools/files. Per-range protected detail with mixed compressible+protected display. (2) PR #134: Broadened nudge output to fire when anchors active regardless of growth cadence. (3) PR #134: Added growth floor gate — nudges suppressed unless context grew by `max(minNudgeGrowthFloor, minNudgeGrowthRatio × nudgeGrowthTokens)` tokens since last nudge, with emergency override at `emergencyThresholdPercent` (98%). Also raised `minCompressRange` default 2000→5000. PR #133: `getCurrentTokenUsage` accepts input-only token data (output=0 fix). Oracle-reviewed.
+
+Files: `lib/messages/inject/inject.ts`, `lib/messages/inject/utils.ts`, `lib/compress/status.ts`, `lib/config.ts`, `lib/config-validation.ts`, `lib/token-utils.ts`, `dcp.schema.json`. Tests: `tests/inject.test.ts`, `tests/config-validation.test.ts`, `tests/protection-aware-stats.test.ts`, `tests/token-counting.test.ts`. 688 tests pass.
+
 ### v1.12.3 — Regex Tag Fragment Leak Fix (PR #130)
 
 **Problem**: Three regexes in `lib/messages/utils.ts` had missing opening-tag `<` and tag-name matchers, causing ACP internal XML tag fragments and stale message IDs to leak into user-visible chat after multiple compression rounds (issue #123).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -395,6 +395,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.12.4 — 保护感知统计 + Nudge 范围修复 + 增长下限门控（PR #132, #133, #134）
+
+**问题**：v1.12.3 以来三个问题。（1）`buildCompressibleRanges` 和 `estimateContextComposition` 将所有消息列为可压缩，静默包含受保护工具输出 → 模型看到虚高的范围，压缩后大部分被过滤 → 无效压缩和混乱统计。（2）当 nudge anchors 激活（context 超过 minLimit）但增长低于节奏阈值时，nudge 文本触发但可压缩范围列表被增长节奏门控 → 模型看到"立即压缩"但没有范围。（3）修复 #2 后，模型可能每轮被 nudge（turn anchors 每轮重新添加）→ thrashing 风险。
+
+**修复**：（1）PR #132：`buildCompressibleRanges`、`estimateContextComposition`、`acp_status` 现在跳过受保护工具/文件。逐范围保护详情，混合可压缩+受保护显示。（2）PR #134：放宽 nudge 输出，当 anchors 激活时无论增长节奏都触发。（3）PR #134：新增增长下限门控 — 除非 context 自上次 nudge 增长了 `max(minNudgeGrowthFloor, minNudgeGrowthRatio × nudgeGrowthTokens)` tokens，否则 nudge 被抑制，紧急覆盖在 `emergencyThresholdPercent`（98%）。同时将 `minCompressRange` 默认值 2000→5000。PR #133：`getCurrentTokenUsage` 接受仅输入 token 数据（output=0 修复）。Oracle 审查通过。
+
+文件：`lib/messages/inject/inject.ts`、`lib/messages/inject/utils.ts`、`lib/compress/status.ts`、`lib/config.ts`、`lib/config-validation.ts`、`lib/token-utils.ts`、`dcp.schema.json`。测试：`tests/inject.test.ts`、`tests/config-validation.test.ts`、`tests/protection-aware-stats.test.ts`、`tests/token-counting.test.ts`。688 个测试通过。
+
 ### v1.12.3 — 正则标签碎片泄漏修复（PR #130）
 
 **问题**：`lib/messages/utils.ts` 中三个正则表达式缺少开标签 `<` 和标签名匹配，导致 ACP 内部 XML 标签碎片和过期消息 ID 在多轮压缩后泄漏到用户可见的对话框中（issue #123）。

--- a/devlog/2026-07-14_release-v1.12.4/REQ.md
+++ b/devlog/2026-07-14_release-v1.12.4/REQ.md
@@ -1,0 +1,23 @@
+# REQ: Release v1.12.4
+
+## Version
+1.12.3 → 1.12.4 (patch)
+
+## Contents (PRs since v1.12.3)
+
+- PR #132: Protection-aware compressible ranges and context stats
+- PR #133: getCurrentTokenUsage accepts input-only token data (output=0 fix)
+- PR #134: Inject compressible ranges when nudge anchors active + growth floor gate (anti-thrashing)
+- PR #136: Support dev npm tag for prerelease publishing (CI only)
+
+## Key changes
+- `buildCompressibleRanges`, `estimateContextComposition`, `acp_status` skip protected tools/files
+- Growth floor gate: nudges suppressed unless growth >= max(5000, 0.45 × nudgeGrowthTokens), with 98% emergency override
+- `minCompressRange` default 2000 → 5000
+- New config: `minNudgeGrowthRatio`, `minNudgeGrowthFloor`, `emergencyThresholdPercent`
+- `getCurrentTokenUsage` accepts input-only token data (output=0)
+
+## Verification
+- TypeScript: pass
+- Tests: 688 pass, 0 fail
+- Build: success

--- a/devlog/2026-07-14_release-v1.12.4/WORKLOG.md
+++ b/devlog/2026-07-14_release-v1.12.4/WORKLOG.md
@@ -1,0 +1,13 @@
+# WORKLOG: Release v1.12.4
+
+## Steps
+1. Created branch `2026-07-14_release-v1.12.4` from master
+2. Bumped version 1.12.3 → 1.12.4 in `package.json`
+3. Added changelog entries to `README.md` and `README.zh-CN.md`
+4. Created devlog entry
+
+## Verification
+- TypeScript: pass
+- Tests: 688 pass, 0 fail
+- Build: success
+- CI check: pass

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.12.3",
+    "version": "1.12.4",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Release v1.12.4 (patch). Includes all PRs merged since v1.12.3:

- **PR #132**: Protection-aware compressible ranges and context stats
- **PR #133**: `getCurrentTokenUsage` accepts input-only token data (output=0 fix)
- **PR #134**: Inject compressible ranges when nudge anchors active + growth floor gate (anti-thrashing)
- **PR #136**: Support dev npm tag for prerelease publishing (CI only)

### Key changes
- `buildCompressibleRanges`, `estimateContextComposition`, `acp_status` skip protected tools/files
- Growth floor gate: nudges suppressed unless growth ≥ max(5000, 0.45 × nudgeGrowthTokens), with 98% emergency override
- `minCompressRange` default 2000 → 5000
- New config: `minNudgeGrowthRatio` (0.45), `minNudgeGrowthFloor` (5000), `emergencyThresholdPercent` ("98%")

### Verification
- TypeScript: pass
- Tests: 688 pass, 0 fail
- Build: success
- CI check: all passed