### PR TITLE
fix: Bug 20 suppression format mismatch — overMaxLimit never suppressed after compress

### DIFF
--- a/devlog/2026-07-15_bug20-suppression-fix/REQ.md
+++ b/devlog/2026-07-15_bug20-suppression-fix/REQ.md
@@ -1,0 +1,37 @@
+# REQ: Bug 20 Suppression Format Fix
+
+## Problem
+
+`lib/messages/inject/utils.ts:184-186` (Bug 20 suppression) uses a non-existent
+part format to detect compress tool calls:
+
+```typescript
+(part as any).type === "tool-invocation" &&
+(part as any).toolInvocation?.toolName === "compress"
+```
+
+The actual OpenCode SDK message part format is `part.type === "tool"` +
+`part.tool === "compress"` (used consistently in 18+ other locations across
+the codebase: `query.ts:39`, `hooks.ts:365`, `rebuild.ts:56`,
+`protected-content.ts:133`, `subagent-results.ts:72`, etc.).
+
+Because the format never matches, `overMaxLimit` is **never suppressed** after
+a compression → the max-limit nudge fires again on the very next transform →
+the model is forced into an over-compression feedback loop.
+
+## Fix
+
+Change the format to match the actual SDK part shape:
+
+```typescript
+if (part.type === "tool" && part.tool === "compress") {
+```
+
+This also removes the `(part as any)` casts — the typed `part` already has
+the correct shape.
+
+## Impact
+
+- Fixes over-compression feedback loop where the model is repeatedly nudged
+  to compress immediately after a successful compression.
+- Independent of PR #138 (GC removal) — this bug exists on master.

--- a/devlog/2026-07-15_bug20-suppression-fix/WORKLOG.md
+++ b/devlog/2026-07-15_bug20-suppression-fix/WORKLOG.md
@@ -1,0 +1,31 @@
+# WORKLOG: Bug 20 Suppression Format Fix
+
+## Changes
+
+### `lib/messages/inject/utils.ts`
+
+**Lines 184-186**: Fixed Bug 20 suppression format mismatch.
+
+Before:
+```typescript
+(part as any).type === "tool-invocation" &&
+(part as any).toolInvocation?.toolName === "compress"
+```
+
+After:
+```typescript
+part.type === "tool" && part.tool === "compress"
+```
+
+The previous format (`tool-invocation` / `toolInvocation.toolName`) does not
+exist in the OpenCode SDK message part schema. Every other tool-type check
+in the codebase uses `part.type === "tool"` + `part.tool`. The Bug 20
+suppression was the sole exception — it never matched, so `overMaxLimit`
+was never suppressed after a compress call, causing the nudge to fire
+repeatedly and trigger over-compression.
+
+## Verification
+
+- TypeScript: pass
+- Tests: all pass
+- Build: pass

--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -181,10 +181,7 @@ export function isContextOverLimits(
         for (const msg of recentMessages) {
             if (msg.info.role === "assistant" && msg.parts) {
                 for (const part of msg.parts) {
-                    if (
-                        (part as any).type === "tool-invocation" &&
-                        (part as any).toolInvocation?.toolName === "compress"
-                    ) {
+                    if (part.type === "tool" && part.tool === "compress") {
                         overMaxLimit = false
                         break
                     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-acp",
-    "version": "1.11.0",
+    "version": "1.12.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-acp",
-            "version": "1.11.0",
+            "version": "1.12.4",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@anthropic-ai/tokenizer": "^0.0.4",


### PR DESCRIPTION
## Problem

`lib/messages/inject/utils.ts:184-186` (Bug 20 suppression) used a non-existent part format to detect compress tool calls:

```typescript
(part as any).type === "tool-invocation" &&
(part as any).toolInvocation?.toolName === "compress"
```

The actual OpenCode SDK format is `part.type === "tool"` + `part.tool === "compress"` — used consistently in 18+ other locations across the codebase. This was the **sole exception**.

Because the format never matched, `overMaxLimit` was **never suppressed** after a compression → the max-limit nudge fired again on the very next transform → the model was forced into an over-compression feedback loop.

## Fix

Change to the correct format + remove `(part as any)` casts:

```typescript
if (part.type === "tool" && part.tool === "compress") {
```

## Verification

- TypeScript: ✅
- Tests: ✅ 688 pass, 0 fail
- Build: ✅

Independent of PR #138 (GC removal). This bug exists on master.