### PR TITLE
fix: nudgeAllowed requires decision.shouldNudge (growthFloor was sole gate)

### DIFF
--- a/devlog/2026-07-15_growth-floor-fix/REQ.md
+++ b/devlog/2026-07-15_growth-floor-fix/REQ.md
@@ -1,0 +1,24 @@
+# REQ - Fix growthFloor replacing nudgeGrowthTokens as primary nudge gate
+
+- Task ID: `2026-07-15_growth-floor-fix`
+- Home Repo: `opencode-acp`
+- Created: 2026-07-15
+- Status: Done
+- Priority: P0
+- Owner: awork
+- References: Gitea issue dog/opencode-acp#20
+
+## 1. Background
+
+Commit `914f004` ("feat: growth floor gate for compress nudges") introduced an anti-thrashing growth floor but accidentally **replaced** `decision.shouldNudge` (threshold: `nudgeGrowthTokens` = 50K for 1M model) with `nudgeAllowed` (threshold: `growthFloor` = 22.5K). This lowered the effective nudge threshold by 55%, causing nudges to fire at 5.6% context usage instead of the intended ~5% growth from baseline.
+
+## 2. Fix
+
+`lib/messages/inject/inject.ts:285-287`: Added `decision.shouldNudge &&` to the `nudgeAllowed` condition. Now both conditions must be true: `computeShouldNudge` says growth >= nudgeGrowthTokens, AND growth >= growthFloor (anti-thrashing).
+
+## 3. Acceptance Criteria
+
+- [x] 688/688 tests pass
+- [x] TypeScript: 0 errors
+- [x] Build: success
+- [x] 2 tests updated to use 55K growth (>= 50K nudgeGrowthTokens) instead of 25K

--- a/devlog/2026-07-15_growth-floor-fix/WORKLOG.md
+++ b/devlog/2026-07-15_growth-floor-fix/WORKLOG.md
@@ -1,0 +1,20 @@
+# WORKLOG
+
+## Commits
+1. `fix: nudgeAllowed requires decision.shouldNudge (growthFloor was sole gate)` — inject.ts + tests
+
+## Changes
+
+### `lib/messages/inject/inject.ts`
+- Line 285-288: `nudgeAllowed = emergencyOverride || (decision.shouldNudge && growth >= growthFloor)`
+- Before: `nudgeAllowed = emergencyOverride || (growth >= growthFloor)` — growthFloor (22.5K) was the sole gate
+- After: requires BOTH `decision.shouldNudge` (growth >= 50K nudgeGrowthTokens) AND `growth >= growthFloor` (22.5K)
+
+### `tests/inject.test.ts`
+- Test "growth floor: nudge fires when growth meets floor" → renamed to "nudge fires when growth meets nudgeGrowthTokens". Added 25K-growth suppressed assertion, 55K-growth fires assertion.
+- Test "applyAnchoredNudges output suppressed" fires case: changed 25K → 55K growth.
+
+## Results
+- 688/688 tests pass
+- TypeScript: 0 errors
+- Build: 393.65 KB

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -284,7 +284,9 @@ export const injectCompressNudges = (
             : undefined
     const nudgeAllowed =
         emergencyOverride ||
-        (growthSinceBaseline !== undefined && growthSinceBaseline >= growthFloor)
+        (decision.shouldNudge &&
+            growthSinceBaseline !== undefined &&
+            growthSinceBaseline >= growthFloor)
 
     state.nudges.shouldInjectThisTurn = nudgeAllowed
 

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -645,9 +645,10 @@ test("growth floor: nudge suppressed when growth below floor (issue #27 anti-thr
     assert.equal(state.nudges.lastNudgeShownTokens, undefined, "lastNudgeShownTokens not updated")
 })
 
-test("growth floor: nudge fires when growth meets floor", () => {
-    // 1M model: growthFloor = max(5000, 0.45×50000) = 22500
-    // Growth of 25K >= 22500 → nudge fires with breakdown + ranges
+test("growth floor: nudge fires when growth meets nudgeGrowthTokens (not just growthFloor)", () => {
+    // 1M model: nudgeGrowthTokens = 50000, growthFloor = max(5000, 0.45×50000) = 22500
+    // Growth of 25K >= growthFloor (22500) but < nudgeGrowthTokens (50000) → suppressed
+    // Growth of 55K >= nudgeGrowthTokens (50000) AND >= growthFloor (22500) → fires
     const state = createSessionState()
     state.modelContextLimit = 1_000_000
     state.nudges.lastPerMessageNudgeTokens = 200_000
@@ -658,6 +659,7 @@ test("growth floor: nudge fires when growth meets floor", () => {
     config.compress.maxContextLimit = 500_000
     config.compress.minContextLimit = 200_000
 
+    // 25K growth: below nudgeGrowthTokens → suppressed
     const messages: WithParts[] = [
         userMsg("u1", "hello"),
         assistantMsgWithTokens("a1", "done", { input: 200_000, output: 25_000 }, [
@@ -666,12 +668,28 @@ test("growth floor: nudge fires when growth meets floor", () => {
     ]
     injectCompressNudges(state, config, logger, messages, {} as any)
 
-    assert.equal(state.nudges.shouldInjectThisTurn, true, "25K growth >= 22500 floor → nudge fires")
+    assert.equal(state.nudges.shouldInjectThisTurn, false, "25K growth < 50K nudgeGrowthTokens → nudge suppressed")
 
-    const injected = suffixText(messages)
-    assert.ok(injected.includes("Breakdown:"), "breakdown shown when growth meets floor")
-    assert.ok(injected.includes("Compressible ranges"), "ranges shown when growth meets floor")
-    assert.equal(state.nudges.lastNudgeShownTokens, 225_000, "lastNudgeShownTokens updated")
+    // 55K growth: above nudgeGrowthTokens AND above growthFloor → fires
+    const state2 = createSessionState()
+    state2.modelContextLimit = 1_000_000
+    state2.nudges.lastPerMessageNudgeTokens = 200_000
+    state2.messageIds.byRawId.set("u1", "m00001")
+    state2.messageIds.byRawId.set("a2", "m00003")
+
+    const messages2: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a2", "done", { input: 200_000, output: 55_000 }, [
+            toolPart("c1", "x".repeat(80_000)),
+        ]),
+    ]
+    injectCompressNudges(state2, config, logger, messages2, {} as any)
+
+    assert.equal(state2.nudges.shouldInjectThisTurn, true, "55K growth >= 50K nudgeGrowthTokens → nudge fires")
+
+    const injected = suffixText(messages2)
+    assert.ok(injected.includes("Breakdown:"), "breakdown shown when growth meets threshold")
+    assert.ok(injected.includes("Compressible ranges"), "ranges shown when growth meets threshold")
 })
 
 test("growth floor: 98% emergency override fires regardless of growth", () => {
@@ -794,7 +812,7 @@ test("growth floor: applyAnchoredNudges output suppressed when growth below floo
         "anchored turn nudge text must NOT appear when nudgeAllowed is false",
     )
 
-    // --- Fires: growth meets floor → anchored nudge text SHOULD appear ---
+    // --- Fires: growth meets nudgeGrowthTokens → anchored nudge text SHOULD appear ---
     const state2 = createSessionState()
     state2.modelContextLimit = 1_000_000
     state2.nudges.lastPerMessageNudgeTokens = 200_000
@@ -804,8 +822,8 @@ test("growth floor: applyAnchoredNudges output suppressed when growth below floo
 
     const messages2: WithParts[] = [
         userMsg("u1", "hello"),
-        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 25_000 }, [
-            toolPart("c1", "x".repeat(40_000)),
+        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 55_000 }, [
+            toolPart("c1", "x".repeat(80_000)),
         ]),
         userMsg("u2", "next"),
     ]


### PR DESCRIPTION
## Summary

**Problem**: Commit `914f004` replaced `decision.shouldNudge` with `growthFloor` as the sole nudge gate. `growthFloor` (22.5K for 1M model) was much lower than `nudgeGrowthTokens` (50K), causing efficiency nudges to fire at 5.6% context usage — far too aggressive.

**Root cause**: `nudgeAllowed = emergencyOverride || (growth >= growthFloor)` — the growth floor was designed as an anti-thrashing **suppression** gate, but commit `914f004` made it the **primary trigger**, bypassing `computeShouldNudge`'s threshold entirely.

**Fix**: `nudgeAllowed = emergencyOverride || (decision.shouldNudge && growth >= growthFloor)`. Now requires BOTH conditions: `computeShouldNudge` says growth >= `nudgeGrowthTokens`, AND growth >= `growthFloor` (anti-thrashing).

## Verification

- Tests: 688/688 pass (2 updated to use 55K growth >= 50K nudgeGrowthTokens)
- TypeScript: 0 errors
- Build: success (393.65 KB)

Files: `lib/messages/inject/inject.ts`. Tests: `tests/inject.test.ts`.