### PR TITLE
release: v1.12.5 — Bug 20 suppression fix + growth floor gate correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.12.5 — Bug 20 Suppression Fix + Growth Floor Gate Correction (PRs #139, #140)
+
+**Problem**: Two bugs in the nudge suppression logic introduced after v1.12.4. (1) `isContextOverLimits` Bug 20 suppression checked `(part as any).type === "tool-invocation" && (part as any).toolInvocation?.toolName === "compress"` — a message-part format that does not exist in the SDK (all 18+ other tool-type checks in the codebase use `part.type === "tool" && part.tool === "compress"`). The suppression never matched, so `overMaxLimit` was never set to `false` after a compress call → the max-limit alert fired every turn → over-compression feedback loop. (2) The growth floor gate (PR #134) made `growthFloor` the sole gate for `nudgeAllowed`, dropping the `decision.shouldNudge` requirement — meaning nudges could fire on negative growth as long as the growth floor condition was met.
+
+**Fix**: (1) PR #139: Changed the format check to `part.type === "tool" && part.tool === "compress"` and removed the `(part as any)` casts. Suppression now correctly detects compress tool calls in recent messages and resets `overMaxLimit`. (2) PR #140: `nudgeAllowed` now requires `decision.shouldNudge || emergencyOverride`, restoring the intended two-condition gate.
+
+Files: `lib/messages/inject/utils.ts` (Bug 20 fix), `lib/messages/inject/inject.ts` (growth floor correction). 688 tests pass.
+
 ### v1.12.4 — Protection-Aware Stats + Nudge Ranges Fix + Growth Floor Gate (PRs #132, #133, #134)
 
 **Problem**: Three issues since v1.12.3. (1) `buildCompressibleRanges` and `estimateContextComposition` listed ALL messages as compressible, silently including protected tool output — the model saw inflated ranges, compressed, and most content was filtered out → ineffective compression with confusing stats. (2) When nudge anchors were active (context over minLimit) but growth was below the cadence threshold, the nudge text fired but the compressible ranges list was gated by growth cadence → model saw "compress now" with no ranges. (3) After fixing #2, the model could be nudged every turn (turn anchors re-add every turn) → thrashing risk.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -395,6 +395,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.12.5 — Bug 20 抑制修复 + 增长下限门控修正（PR #139, #140）
+
+**问题**：v1.12.4 后引入的两个 nudge 抑制逻辑 bug。（1）`isContextOverLimits` 的 Bug 20 抑制检查 `(part as any).type === "tool-invocation" && (part as any).toolInvocation?.toolName === "compress"` —— 这个消息部件格式在 SDK 中根本不存在（代码库中其他 18+ 处工具类型检查全部使用 `part.type === "tool" && part.tool === "compress"`）。抑制逻辑永不匹配，所以压缩后 `overMaxLimit` 从不置 false → max-limit 告警每轮触发 → 过度压缩正反馈循环。（2）增长下限门控（PR #134）使 `growthFloor` 成为 `nudgeAllowed` 的唯一 gate，丢弃了 `decision.shouldNudge` 要求 —— 意味着即使增长为负，只要满足增长下限条件 nudge 就会触发。
+
+**修复**：（1）PR #139：将格式检查改为 `part.type === "tool" && part.tool === "compress"`，移除了 `(part as any)` 类型断言。抑制现在正确检测最近消息中的 compress 工具调用并重置 `overMaxLimit`。（2）PR #140：`nudgeAllowed` 现在要求 `decision.shouldNudge || emergencyOverride`，恢复预期的双条件门控。
+
+文件：`lib/messages/inject/utils.ts`（Bug 20 修复）、`lib/messages/inject/inject.ts`（增长下限修正）。688 测试通过。
+
 ### v1.12.4 — 保护感知统计 + Nudge 范围修复 + 增长下限门控（PR #132, #133, #134）
 
 **问题**：v1.12.3 以来三个问题。（1）`buildCompressibleRanges` 和 `estimateContextComposition` 将所有消息列为可压缩，静默包含受保护工具输出 → 模型看到虚高的范围，压缩后大部分被过滤 → 无效压缩和混乱统计。（2）当 nudge anchors 激活（context 超过 minLimit）但增长低于节奏阈值时，nudge 文本触发但可压缩范围列表被增长节奏门控 → 模型看到"立即压缩"但没有范围。（3）修复 #2 后，模型可能每轮被 nudge（turn anchors 每轮重新添加）→ thrashing 风险。

--- a/devlog/2026-07-15_release-v1.12.5/REQ.md
+++ b/devlog/2026-07-15_release-v1.12.5/REQ.md
@@ -1,0 +1,26 @@
+# REQ: Release v1.12.5
+
+## Summary
+
+Patch release bundling two bug fixes merged after v1.12.4:
+
+- **PR #139** — Bug 20 suppression format mismatch fix
+- **PR #140** — Growth floor gate correction (`nudgeAllowed` requires `decision.shouldNudge`)
+
+## Motivation
+
+v1.12.4 introduced the growth floor gate (PR #134) but had two regressions:
+1. The Bug 20 suppression in `isContextOverLimits` used a non-existent SDK part format (`tool-invocation` / `toolInvocation`), so `overMaxLimit` was never suppressed after a compress call → over-compression feedback loop.
+2. The growth floor gate made `growthFloor` the sole condition for `nudgeAllowed`, dropping the `decision.shouldNudge` requirement.
+
+Both are fixed on master. This release ships them to npm.
+
+## Changes
+
+- `package.json`: version `1.12.4` → `1.12.5`
+- `README.md` / `README.zh-CN.md`: changelog entries for v1.12.5
+
+## Verification
+
+- CI check (`scripts/ci/check-pr.sh`) must pass
+- No code changes — release-only PR

--- a/devlog/2026-07-15_release-v1.12.5/WORKLOG.md
+++ b/devlog/2026-07-15_release-v1.12.5/WORKLOG.md
@@ -1,0 +1,21 @@
+# WORKLOG: Release v1.12.5
+
+## Steps
+
+1. Created worktree `/tmp/opencode-acp-release-1125` from `github/master` (d976c71)
+2. Bumped `package.json` version 1.12.4 → 1.12.5
+3. Added changelog entry to `README.md` (English) and `README.zh-CN.md` (Chinese)
+4. Created devlog `devlog/2026-07-15_release-v1.12.5/REQ.md` + `WORKLOG.md`
+5. CI check: `./scripts/ci/check-pr.sh 2026-07-15_release-v1.12.5 github/master`
+6. Commit + push + create PR
+
+## Contents
+
+This release includes:
+- PR #139: Bug 20 suppression format mismatch — `overMaxLimit` never suppressed after compress
+- PR #140: Growth floor gate correction — `nudgeAllowed` requires `decision.shouldNudge`
+
+## Verification
+
+- No code changes, release-only
+- CI check script validates branch name, devlog existence, changelog format

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.12.4",
+    "version": "1.12.5",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Patch release bundling two bug fixes merged after v1.12.4:

- **PR #139** — Bug 20 suppression format mismatch: `isContextOverLimits` checked `(part as any).type === "tool-invocation"` (non-existent SDK format) → `overMaxLimit` never suppressed after compress → over-compression feedback loop. Fixed to `part.type === "tool" && part.tool === "compress"`.
- **PR #140** — Growth floor gate correction: `nudgeAllowed` was solely gated by `growthFloor`, dropping the `decision.shouldNudge` requirement. Now requires `decision.shouldNudge || emergencyOverride`.

## Changes

- `package.json`: version `1.12.4` → `1.12.5`
- `README.md` / `README.zh-CN.md`: changelog entries

No code changes — release-only PR. All code already merged to master via PRs #139 and #140.

## Verification

- CI check (`scripts/ci/check-pr.sh`): all checks passed
- 688 tests pass (on master)