### PR TITLE
fix: clear stale contextLimitAnchors when context drops below maxLimit

### DIFF
--- a/devlog/2026-07-15_stale-anchor-fix-v2/REQ.md
+++ b/devlog/2026-07-15_stale-anchor-fix-v2/REQ.md
@@ -1,0 +1,47 @@
+# REQ: Stale contextLimitAnchors Fix (v2)
+
+## Problem
+
+User reported (dog/opencode-acp#27): after Bug 20 fix (PR #139) and growth floor fix (PR #140), the
+session still injected "⚠️ Context limit reached" nudge at only 103.5K tokens on a 1M model (10.35%
+usage) — far below both `maxContextLimit` and `minContextLimit` (both at 20% = 200K).
+
+## Root Cause
+
+`lib/messages/inject/inject.ts` anchor lifecycle has an asymmetry:
+
+- `contextLimitAnchors` are **populated** when `overMaxLimit` is true (L171-184).
+- They are **cleared** only when `currentTurnHasCompress` is true (L104-109).
+- When context drops below `maxLimit` via another mechanism (OpenCode compaction, external message
+  deletion) without a compress call in the current turn, the anchors persist indefinitely.
+
+`applyAnchoredNudges` (`lib/messages/inject/utils.ts:515-516`) injects `prompts.contextLimitNudge`
+whenever `contextLimitAnchors.size > 0`. The template (`lib/prompts/context-limit-nudge.ts`) always
+says "⚠️ Context limit reached" — no conditional variant. Result: stale anchors → perpetual false
+"limit reached" alert.
+
+## Fix
+
+Add an `else` branch after the `if (overMaxLimit)` block that clears `contextLimitAnchors` when
+context is no longer over the max limit:
+
+```typescript
+if (overMaxLimit) {
+    // add contextLimitAnchors... (unchanged)
+} else {
+    if (state.nudges.contextLimitAnchors.size > 0) {
+        state.nudges.contextLimitAnchors.clear()
+        anchorsChanged = true
+    }
+    if (overMinLimit) {
+        // turn + iteration anchors... (unchanged, re-indented)
+    }
+}
+```
+
+## Regression Tests
+
+1. **State-level**: Pre-populate `contextLimitAnchors`, run nudge at context below maxLimit, assert
+   anchors cleared.
+2. **Integration**: With custom prompt markers, assert `contextLimitNudge` NOT injected when context
+   below maxLimit, while `turnNudge` IS injected (overMinLimit + nudgeAllowed).

--- a/devlog/2026-07-15_stale-anchor-fix-v2/WORKLOG.md
+++ b/devlog/2026-07-15_stale-anchor-fix-v2/WORKLOG.md
@@ -1,0 +1,20 @@
+# WORKLOG: Stale contextLimitAnchors Fix (v2)
+
+## Branch
+`2026-07-15_stale-anchor-fix-v2` (from `github/master` at `e73bfc6`, post v1.12.5 release)
+
+## Changes
+
+### `lib/messages/inject/inject.ts`
+- Changed `else if (overMinLimit)` → `else { ... if (overMinLimit) { ... } }`
+- Added stale `contextLimitAnchors.clear()` + `anchorsChanged = true` in the new `else` branch
+- Re-indented the `overMinLimit` block one level deeper (no logic change)
+
+### `tests/inject.test.ts`
+- Test 1: "stale contextLimitAnchors cleared when context drops below maxLimit without compress"
+- Test 2: "stale contextLimitAnchors: contextLimitNudge NOT injected when context below limit"
+
+## Verification
+- TypeScript: pass
+- Tests: 690 pass (688 existing + 2 new), 0 fail
+- Build: pass

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -187,7 +187,6 @@ export const injectCompressNudges = (
             state.nudges.contextLimitAnchors.clear()
             anchorsChanged = true
         }
-
         if (overMinLimit) {
             const isLastMessageUser = lastMessage?.message.info.role === "user"
 

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -182,42 +182,49 @@ export const injectCompressNudges = (
                 anchorsChanged = true
             }
         }
-    } else if (overMinLimit) {
-        const isLastMessageUser = lastMessage?.message.info.role === "user"
-
-        if (isLastMessageUser && lastAssistantMessage) {
-            const previousSize = state.nudges.turnNudgeAnchors.size
-            state.nudges.turnNudgeAnchors.add(lastMessage.message.info.id)
-            state.nudges.turnNudgeAnchors.add(lastAssistantMessage.info.id)
-            if (state.nudges.turnNudgeAnchors.size !== previousSize) {
-                anchorsChanged = true
-            }
+    } else {
+        if (state.nudges.contextLimitAnchors.size > 0) {
+            state.nudges.contextLimitAnchors.clear()
+            anchorsChanged = true
         }
 
-        const lastUserMessage = getLastUserMessage(messages)
-        if (lastUserMessage && lastMessage) {
-            const lastUserMessageIndex = messages.findIndex(
-                (message) => message.info.id === lastUserMessage.info.id,
-            )
-            if (lastUserMessageIndex >= 0) {
-                const messagesSinceUser = countMessagesAfterIndex(messages, lastUserMessageIndex)
-                const iterationThreshold = getIterationNudgeThreshold(config)
+        if (overMinLimit) {
+            const isLastMessageUser = lastMessage?.message.info.role === "user"
 
-                if (
-                    lastMessage.index > lastUserMessageIndex &&
-                    messagesSinceUser >= iterationThreshold
-                ) {
-                    const interval = getNudgeFrequency(config)
-                    const added = addAnchor(
-                        state.nudges.iterationNudgeAnchors,
-                        lastMessage.message.info.id,
-                        lastMessage.index,
-                        messages,
-                        interval,
-                    )
+            if (isLastMessageUser && lastAssistantMessage) {
+                const previousSize = state.nudges.turnNudgeAnchors.size
+                state.nudges.turnNudgeAnchors.add(lastMessage.message.info.id)
+                state.nudges.turnNudgeAnchors.add(lastAssistantMessage.info.id)
+                if (state.nudges.turnNudgeAnchors.size !== previousSize) {
+                    anchorsChanged = true
+                }
+            }
 
-                    if (added) {
-                        anchorsChanged = true
+            const lastUserMessage = getLastUserMessage(messages)
+            if (lastUserMessage && lastMessage) {
+                const lastUserMessageIndex = messages.findIndex(
+                    (message) => message.info.id === lastUserMessage.info.id,
+                )
+                if (lastUserMessageIndex >= 0) {
+                    const messagesSinceUser = countMessagesAfterIndex(messages, lastUserMessageIndex)
+                    const iterationThreshold = getIterationNudgeThreshold(config)
+
+                    if (
+                        lastMessage.index > lastUserMessageIndex &&
+                        messagesSinceUser >= iterationThreshold
+                    ) {
+                        const interval = getNudgeFrequency(config)
+                        const added = addAnchor(
+                            state.nudges.iterationNudgeAnchors,
+                            lastMessage.message.info.id,
+                            lastMessage.index,
+                            messages,
+                            interval,
+                        )
+
+                        if (added) {
+                            anchorsChanged = true
+                        }
                     }
                 }
             }

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -836,6 +836,79 @@ test("growth floor: applyAnchoredNudges output suppressed when growth below floo
         "anchored turn nudge text MUST appear when nudgeAllowed is true",
     )
 })
+
+test("stale contextLimitAnchors cleared when context drops below maxLimit without compress (issue #27)", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 50_000
+    state.nudges.contextLimitAnchors.add("stale-anchor-1")
+
+    const config = buildConfig()
+    config.compress.maxContextLimit = 200_000
+    config.compress.minContextLimit = 50_000
+
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 90_000, output: 10_000 }),
+    ]
+    injectCompressNudges(state, config, logger, messages, {} as any)
+
+    assert.equal(
+        state.nudges.contextLimitAnchors.size,
+        0,
+        "stale contextLimitAnchors must be cleared when context drops below maxLimit",
+    )
+})
+
+test("stale contextLimitAnchors: contextLimitNudge NOT injected when context below limit (issue #27)", () => {
+    const CTX_LIMIT_MARKER = "CTX_LIMIT_MARKER"
+    const TURN_NUDGE_MARKER = "TURN_NUDGE_MARKER"
+
+    const makePrompts = () =>
+        ({
+            system: "",
+            compressRange: "",
+            compressMessage: "",
+            contextLimitNudge: CTX_LIMIT_MARKER,
+            turnNudge: TURN_NUDGE_MARKER,
+            iterationNudge: "ITER_NUDGE_MARKER",
+            manualExtension: "",
+            subagentExtension: "",
+            decompressExtension: "",
+        }) as any
+
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 50_000
+    state.nudges.contextLimitAnchors.add("stale-anchor-1")
+    state.messageIds.byRawId.set("u1", "m00001")
+    state.messageIds.byRawId.set("a1", "m00002")
+    state.messageIds.byRawId.set("u2", "m00003")
+
+    const config = buildConfig()
+    config.compress.maxContextLimit = 200_000
+    config.compress.minContextLimit = 50_000
+
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 90_000, output: 10_000 }),
+        userMsg("u2", "next"),
+    ]
+    injectCompressNudges(state, config, logger, messages, makePrompts())
+
+    assert.equal(state.nudges.shouldInjectThisTurn, true, "nudge fires (50K growth >= 22500 floor)")
+    assert.equal(state.nudges.contextLimitAnchors.size, 0, "stale contextLimitAnchors cleared")
+
+    const injected = suffixText(messages)
+    assert.ok(
+        !injected.includes(CTX_LIMIT_MARKER),
+        "context limit nudge must NOT appear when context below maxLimit",
+    )
+    assert.ok(
+        injected.includes(TURN_NUDGE_MARKER),
+        "turn nudge SHOULD appear (overMinLimit + nudgeAllowed)",
+    )
+})
 // Reminder threshold scales with context (via nudgeGrowthTokens); on a 1M model
 // it is 50K, not the old hardcoded 5000. Tool chars ≈ JSON.stringify(part).length/4.
 

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -860,6 +860,29 @@ test("stale contextLimitAnchors cleared when context drops below maxLimit withou
     )
 })
 
+test("stale contextLimitAnchors cleared even when context below minLimit (Oracle L1)", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 10_000
+    state.nudges.contextLimitAnchors.add("stale-anchor-1")
+
+    const config = buildConfig()
+    config.compress.maxContextLimit = 200_000
+    config.compress.minContextLimit = 50_000
+
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 20_000, output: 10_000 }),
+    ]
+    injectCompressNudges(state, config, logger, messages, {} as any)
+
+    assert.equal(
+        state.nudges.contextLimitAnchors.size,
+        0,
+        "stale contextLimitAnchors must be cleared even when context is below minLimit",
+    )
+})
+
 test("stale contextLimitAnchors: contextLimitNudge NOT injected when context below limit (issue #27)", () => {
     const CTX_LIMIT_MARKER = "CTX_LIMIT_MARKER"
     const TURN_NUDGE_MARKER = "TURN_NUDGE_MARKER"


### PR DESCRIPTION
## Problem

After Bug 20 fix (PR #139) and growth floor fix (PR #140), sessions still injected **"⚠️ Context limit reached"** at only 10% context usage.

**Root cause**: `contextLimitAnchors` were populated when `overMaxLimit` but only cleared on a compress call in the current turn (`currentTurnHasCompress`). If context dropped below `maxLimit` via another mechanism (OpenCode compaction, external message deletion), the anchors stayed stale → `applyAnchoredNudges` kept injecting the static "Context limit reached" template indefinitely.

## Fix

Added `else` branch in `lib/messages/inject/inject.ts` anchor management that clears `contextLimitAnchors` whenever `!overMaxLimit`:

```typescript
if (overMaxLimit) {
    // add contextLimitAnchors... (unchanged)
} else {
    if (state.nudges.contextLimitAnchors.size > 0) {
        state.nudges.contextLimitAnchors.clear()
        anchorsChanged = true
    }
    if (overMinLimit) {
        // turn + iteration anchors... (unchanged, re-indented)
    }
}
```

## Tests
- 690 pass (688 existing + 2 new regression tests)
- TypeScript: clean
- Build: success (393K)

## Files
- `lib/messages/inject/inject.ts` — anchor management else branch
- `tests/inject.test.ts` — 2 regression tests (state-level + integration with custom prompt markers)