### PR TITLE
release: v1.12.6 — stale contextLimitAnchors fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.12.6 — Stale contextLimitAnchors Fix (PR #143)
+
+**Problem**: `contextLimitAnchors` were populated when `overMaxLimit=true` but only cleared on a compress tool call in the current turn (`currentTurnHasCompress`). If context dropped below `maxLimit` via another mechanism (OpenCode compaction, external message deletion), the anchors stayed stale → `applyAnchoredNudges` kept injecting the "⚠️ Context limit reached" template at low context levels (as low as 10% usage).
+
+**Fix**: Added `else` branch in `lib/messages/inject/inject.ts` that clears `contextLimitAnchors` whenever `!overMaxLimit`, establishing symmetry with the existing turn/iteration anchor cleanup at `!overMinLimit`. 3 regression tests (state-level clear, integration with prompt markers, sub-minLimit clear path). Dual-agent reviewed (Oracle + independent reviewer, both APPROVE).
+
+Files: `lib/messages/inject/inject.ts`. Tests: `tests/inject.test.ts`. 691 tests pass.
+
 ### v1.12.5 — Bug 20 Suppression Fix + Growth Floor Gate Correction (PRs #139, #140)
 
 **Problem**: Two bugs in the nudge suppression logic introduced after v1.12.4. (1) `isContextOverLimits` Bug 20 suppression checked `(part as any).type === "tool-invocation" && (part as any).toolInvocation?.toolName === "compress"` — a message-part format that does not exist in the SDK (all 18+ other tool-type checks in the codebase use `part.type === "tool" && part.tool === "compress"`). The suppression never matched, so `overMaxLimit` was never set to `false` after a compress call → the max-limit alert fired every turn → over-compression feedback loop. (2) The growth floor gate (PR #134) made `growthFloor` the sole gate for `nudgeAllowed`, dropping the `decision.shouldNudge` requirement — meaning nudges could fire on negative growth as long as the growth floor condition was met.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -395,6 +395,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.12.6 — Stale contextLimitAnchors 修复（PR #143）
+
+**问题**：`contextLimitAnchors` 仅在 `overMaxLimit=true` 时添加，但只在当前 turn 有 compress 调用时 (`currentTurnHasCompress`) 才清除。如果上下文通过其他机制（OpenCode compaction、外部消息删除）降到 `maxLimit` 以下，anchors 保持 stale → `applyAnchoredNudges` 持续注入 "⚠️ Context limit reached" 模板，即使实际上下文很低（低至 10%）。
+
+**修复**：在 `lib/messages/inject/inject.ts` 添加 `else` 分支，当 `!overMaxLimit` 时清除 `contextLimitAnchors`，与已有的 `!overMinLimit` 清除 turn/iteration anchors 逻辑对称。3 个回归测试（state 级、prompt marker 集成、sub-minLimit 清除）。双 agent review（Oracle + 独立 reviewer，均 APPROVE）。
+
+文件：`lib/messages/inject/inject.ts`。测试：`tests/inject.test.ts`。691 测试通过。
+
 ### v1.12.5 — Bug 20 抑制修复 + 增长下限门控修正（PR #139, #140）
 
 **问题**：v1.12.4 后引入的两个 nudge 抑制逻辑 bug。（1）`isContextOverLimits` 的 Bug 20 抑制检查 `(part as any).type === "tool-invocation" && (part as any).toolInvocation?.toolName === "compress"` —— 这个消息部件格式在 SDK 中根本不存在（代码库中其他 18+ 处工具类型检查全部使用 `part.type === "tool" && part.tool === "compress"`）。抑制逻辑永不匹配，所以压缩后 `overMaxLimit` 从不置 false → max-limit 告警每轮触发 → 过度压缩正反馈循环。（2）增长下限门控（PR #134）使 `growthFloor` 成为 `nudgeAllowed` 的唯一 gate，丢弃了 `decision.shouldNudge` 要求 —— 意味着即使增长为负，只要满足增长下限条件 nudge 就会触发。

--- a/devlog/2026-07-15_release-v1.12.6/REQ.md
+++ b/devlog/2026-07-15_release-v1.12.6/REQ.md
@@ -1,0 +1,23 @@
+# REQ: Release v1.12.6
+
+## Summary
+
+Patch release bundling the stale `contextLimitAnchors` fix:
+
+- **PR #143** — Stale `contextLimitAnchors` cleared when context drops below `maxLimit` without a compress call
+
+## Motivation
+
+After v1.12.5, a session (`ses_0a3be0cdeffezb9pLzfifH7lzK`) showed "⚠️ Context limit reached" nudges at only ~10% context usage (103.5K of 1M model limit). Root cause: `contextLimitAnchors` were added when `overMaxLimit=true` but only cleared on a compress tool call in the current turn (`currentTurnHasCompress`). If context dropped below `maxLimit` via another mechanism (OpenCode compaction, external message deletion), the anchors stayed stale → `applyAnchoredNudges` kept injecting the static "Context limit reached" template.
+
+PR #143 adds an `else` branch that clears `contextLimitAnchors` whenever `!overMaxLimit`, symmetric with the existing `!overMinLimit` → clear turn/iteration anchors logic. Dual-agent reviewed (Oracle + independent reviewer, both APPROVE). 691 tests pass.
+
+## Changes
+
+- `package.json`: version `1.12.5` → `1.12.6`
+- `README.md` / `README.zh-CN.md`: changelog entries for v1.12.6
+
+## Verification
+
+- CI check (`scripts/ci/check-pr.sh`) must pass
+- No code changes — release-only PR

--- a/devlog/2026-07-15_release-v1.12.6/WORKLOG.md
+++ b/devlog/2026-07-15_release-v1.12.6/WORKLOG.md
@@ -1,0 +1,20 @@
+# WORKLOG: Release v1.12.6
+
+## Steps
+
+1. Created worktree `/tmp/opencode-acp-release-1126` from `github/master` (`1db4732` — PR #143 merge)
+2. Branch: `2026-07-15_release-v1.12.6`
+3. Bumped `package.json`: `1.12.5` → `1.12.6`
+4. Added changelog to `README.md` and `README.zh-CN.md` under Changelog / 更新日志 sections
+5. Created devlog (`REQ.md` + this `WORKLOG.md`)
+6. Ran CI check (`scripts/ci/check-pr.sh`)
+7. Committed, pushed, created PR
+
+## Contents
+
+- PR #143 (stale `contextLimitAnchors` fix): `lib/messages/inject/inject.ts` — added `else` branch clearing stale anchors when `!overMaxLimit`. 3 regression tests in `tests/inject.test.ts`. 691 tests pass.
+
+## Verification
+
+- CI check passes
+- Release-only PR (no code changes beyond version bump + changelog)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.12.5",
+    "version": "1.12.6",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Patch release bundling **PR #143** — stale `contextLimitAnchors` fix.

- **Problem**: `contextLimitAnchors` populated when `overMaxLimit=true` but only cleared on a compress tool call in the current turn. If context dropped below `maxLimit` via another mechanism (OpenCode compaction, external message deletion), anchors stayed stale → "⚠️ Context limit reached" nudges fired at low context levels (as low as 10%).
- **Fix**: Added `else` branch clearing `contextLimitAnchors` when `!overMaxLimit`, symmetric with existing `!overMinLimit` → clear turn/iteration anchors.
- **Review**: Dual-agent reviewed (Oracle + independent reviewer, both APPROVE). 691 tests pass.

## Changes
- `package.json`: version `1.12.5` → `1.12.6`
- `README.md` / `README.zh-CN.md`: changelog entries

Merging triggers auto-publish to npm (`release.yml`).