### PR TITLE
release: v1.12.7-dev.1 — smart filter + dangerous param + deploy guard (dev tag)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -697,6 +697,66 @@ npm view opencode-acp version
 
 Only use this as a fallback. The automated workflow (Section 5.4.2) is the standard release process.
 
+#### 5.4.5 Dev / Prerelease Publishing
+
+For testing changes before a stable release, publish a **dev prerelease** to npm's `dev` tag (not `latest`). This lets users opt in via `opencode-acp@dev` without affecting stable users on `@latest`.
+
+**How CI detects prereleases**: The `release.yml` workflow checks if the version string contains `-` (e.g., `1.13.0-dev.1`, `1.12.7-beta.2`). If it does, it publishes with `--tag dev` and marks the GitHub Release as `prerelease: true`. If not, it publishes with `--tag latest` (normal stable release).
+
+**Step-by-step**:
+
+```bash
+# 1. Create a release branch (same naming convention as stable releases)
+git checkout master && git pull origin master
+git checkout -b YYYY-MM-DD_release-v{VERSION}-dev
+
+# 2. Set a prerelease version in package.json (MUST contain a hyphen)
+#    e.g., "1.12.7-dev.1", "1.13.0-beta.1", "2.0.0-rc.1"
+
+# 3. Add changelog entries to README.md and README.zh-CN.md
+#    (header must contain ### v{VERSION} including the suffix, e.g. ### v1.12.7-dev.1)
+
+# 4. Create devlog entry
+
+# 5. Verify, commit, push, create PR
+./scripts/ci/check-pr.sh YYYY-MM-DD_release-v{VERSION}-dev origin/master
+git add -A && git commit -m "release: v{VERSION}-dev.1 — title"
+git push origin YYYY-MM-DD_release-v{VERSION}-dev
+gh pr create --title "release: v{VERSION}-dev.1 — title" --body "..."
+
+# 6. Merge PR (requires human confirmation)
+
+# 7. CI auto-publishes to npm dev tag + creates prerelease GitHub Release
+```
+
+**Installing a dev prerelease**:
+
+```json
+{
+    "plugin": {
+        "opencode-acp": "dev"
+    }
+}
+```
+
+Or via CLI:
+
+```bash
+opencode plugin opencode-acp@dev --global
+```
+
+**Key differences from stable releases**:
+
+| Aspect               | Stable                          | Dev/Prerelease                   |
+| -------------------- | ------------------------------- | -------------------------------- |
+| Version format       | `1.12.7`                        | `1.12.7-dev.1` (contains `-`)    |
+| npm tag              | `latest`                        | `dev`                            |
+| GitHub Release       | stable                          | prerelease                       |
+| Install              | `opencode-acp@latest`           | `opencode-acp@dev`               |
+| Branch naming        | `YYYY-MM-DD_release-v{VERSION}` | same convention                  |
+
+**Promoting dev → stable**: When ready, create a new release branch with the stable version (remove the `-suffix`), e.g., `1.12.7-dev.1` → `1.12.7`. CI will publish to `latest`.
+
 ### 5.5 Commit Convention
 
 Use descriptive commit messages. Historical examples:

--- a/README.md
+++ b/README.md
@@ -422,6 +422,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.12.7-dev.1 — Smart Recommendation Filter + Dangerous Parameter + Deploy Version Guard (PR #142, dev)
+
+**Problem**: The recommendation filter had three issues. (1) It used a hardcoded 5× growth threshold for single-message ranges, which was too large (25% of context) and could leak context. (2) The filter showed tiny ranges (71 tokens) alongside meaningful ones. (3) The last segment was always shown with a position-based "recent" annotation, but compressing it requires explicit opt-in — a contradiction between recommending and blocking. Additionally, `dev-deploy.sh` deploys were silently overwritten by npm on opencode restart when the npm version was newer than the local version.
+
+**Fix**: (1) Rewrote `filterRecommendedRanges` with a single coherent design: last segment excluded if < 2× growth threshold; included with `dangerous: true` flag if ≥ 2×. Gate: "effective compressible" = non-last-segment tokens + max(0, last-segment − 2× floor); suppress all if < growth threshold. (2) Protected ranges no longer affect filtering logic. (3) Replaced state-tracking soft-block with stateless `dangerous?: boolean` parameter on the compress tool schema — model must explicitly opt-in to compress the tail. Net −70 lines. (4) Added debug filter decision logging via `sendIgnoredMessage` (model-invisible, user-visible when `debug: true`). (5) `dev-deploy.sh` now queries `npm view` and auto-bumps the deployed version above npm's latest to prevent overwrite on restart.
+
+Files: `lib/messages/inject/utils.ts`, `lib/messages/inject/inject.ts`, `lib/compress/pipeline.ts`, `lib/compress/range.ts`, `lib/compress/message.ts`, `scripts/dev-deploy.sh`. Tests: `tests/smart-nudge-gating.test.ts` (rewritten, 17 tests), `tests/soft-block.test.ts` (5 tests), `tests/inject.test.ts` (updated). 711 tests pass.
+
 ### v1.12.6 — Stale contextLimitAnchors Fix (PR #143)
 
 **Problem**: `contextLimitAnchors` were populated when `overMaxLimit=true` but only cleared on a compress tool call in the current turn (`currentTurnHasCompress`). If context dropped below `maxLimit` via another mechanism (OpenCode compaction, external message deletion), the anchors stayed stale → `applyAnchoredNudges` kept injecting the "⚠️ Context limit reached" template at low context levels (as low as 10% usage).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -395,6 +395,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.12.7-dev.1 — 智能推荐过滤 + Dangerous 参数 + 部署版本守卫（PR #142, dev）
+
+**问题**：推荐过滤器有三个问题。（1）使用硬编码的 5× 增长阈值（上下文的 25%），太大且容易泄露上下文。（2）过滤器会显示极小的 range（71 tokens）。（3）最后一段总是显示位置标注 "recent"，但压缩它需要显式确认——推荐和阻止矛盾。此外，`dev-deploy.sh` 的部署在 opencode 重启时被 npm 静默覆盖（当 npm 版本比本地新时）。
+
+**修复**：（1）重写 `filterRecommendedRanges`：最后一段 < 2× 增长阈值 → 剔除；≥ 2× → 保留并标记 `dangerous: true`。门槛："有效可压缩" = 非最后段 + max(0, 最后段 − 2× 阈值)；< 增长阈值则全部抑制。（2）受保护内容不再影响过滤逻辑。（3）用无状态的 `dangerous?: boolean` 参数替换状态追踪 soft-block——模型必须显式 opt-in 才能压缩尾部。净减 70 行。（4）通过 `sendIgnoredMessage` 注入过滤决策调试信息（模型不可见，`debug: true` 时用户可见）。（5）`dev-deploy.sh` 查询 `npm view` 并自动将部署版本 bump 到 npm 最新版之上，防止重启覆盖。
+
+文件：`lib/messages/inject/utils.ts`、`lib/messages/inject/inject.ts`、`lib/compress/pipeline.ts`、`lib/compress/range.ts`、`lib/compress/message.ts`、`scripts/dev-deploy.sh`。测试：`tests/smart-nudge-gating.test.ts`（重写，17 测试）、`tests/soft-block.test.ts`（5 测试）、`tests/inject.test.ts`（更新）。711 测试通过。
+
 ### v1.12.6 — Stale contextLimitAnchors 修复（PR #143）
 
 **问题**：`contextLimitAnchors` 仅在 `overMaxLimit=true` 时添加，但只在当前 turn 有 compress 调用时 (`currentTurnHasCompress`) 才清除。如果上下文通过其他机制（OpenCode compaction、外部消息删除）降到 `maxLimit` 以下，anchors 保持 stale → `applyAnchoredNudges` 持续注入 "⚠️ Context limit reached" 模板，即使实际上下文很低（低至 10%）。

--- a/devlog/2026-07-15_release-v1.12.7/REQ.md
+++ b/devlog/2026-07-15_release-v1.12.7/REQ.md
@@ -1,0 +1,19 @@
+# REQ: Release v1.12.7
+
+## Goal
+
+Release smart recommendation filter + dangerous parameter + deploy version guard.
+
+## Changes (from PR #142, merged)
+
+1. **filterRecommendedRanges rewrite**: Last segment < 2× growth → excluded; ≥ 2× → included with `dangerous: true`. Gate: effective compressible = non-last + max(0, last − 2× floor); suppress all if < growth threshold. Protected ranges no longer affect filtering.
+
+2. **Dangerous parameter**: Stateless `dangerous?: boolean` on compress tool schema. Replaced state-tracking soft-block (`lastSegmentConfirmAttempts`). Net −70 lines.
+
+3. **Debug filter decision**: `sendIgnoredMessage` injects filter reasoning into chat (model-invisible, user-visible when `debug: true`). Also logged to daily debug log.
+
+4. **dev-deploy.sh version guard**: Auto-bumps deployed version above npm latest to prevent overwrite on restart.
+
+## Version
+
+1.12.6 → 1.12.7

--- a/devlog/2026-07-15_release-v1.12.7/WORKLOG.md
+++ b/devlog/2026-07-15_release-v1.12.7/WORKLOG.md
@@ -1,0 +1,14 @@
+# WORKLOG: Release v1.12.7
+
+## Steps
+
+1. Created release branch `2026-07-15_release-v1.12.7` from master (which already has PR #142 merged)
+2. Bumped version: 1.12.6 → 1.12.7 in package.json
+3. Added changelog entries to README.md (EN) and README.zh-CN.md (CN)
+4. Created devlog REQ.md + WORKLOG.md
+5. Committed, pushed, created PR
+6. CI will auto-tag v1.12.7 and publish to npm on merge
+
+## Test Status
+
+711/711 pass on feature branch. Release branch only changes version + changelog (no code changes).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.12.6",
+    "version": "1.12.7-dev.1",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

**Dev prerelease** — published to npm `dev` tag (not `latest`). Install with `opencode-acp@dev`.

Changes from PR #142 (merged to master):

- **Smart recommendation filter**: last segment < 2× growth → excluded; ≥ 2× → dangerous flag. Effective compressible gate replaces old 5×/protected-dominance rules.
- **Dangerous parameter**: stateless `dangerous?: boolean` on compress tool schema (replaces state-tracking soft-block, −70 lines).
- **Debug filter decision**: `sendIgnoredMessage` injects filter reasoning into chat (model-invisible, user-visible when `debug: true`).
- **dev-deploy.sh version guard**: auto-bumps deployed version above npm latest to prevent overwrite on restart.

711 tests pass. All CI checks pass locally.

**On merge**: CI detects `-dev.1` suffix → publishes to npm with tag `dev` → `opencode-acp@dev`. Stable `@latest` stays at v1.12.6.