### PR TITLE
fix: skip nudge when filter has no recommendations

### DIFF
--- a/devlog/2026-07-15_nudge-no-recs-skip/REQ.md
+++ b/devlog/2026-07-15_nudge-no-recs-skip/REQ.md
@@ -1,0 +1,49 @@
+# REQ - Skip nudge when filter has no recommendations
+
+- Task ID: `2026-07-15_nudge-no-recs-skip`
+- Home Repo: `opencode-acp`
+- Created: 2026-07-15
+- Status: Done
+- Priority: P1
+- Owner: sisyphus
+- References: issue #20
+
+## 1. Background & Problem Statement
+
+- **Context**: v1.12.7 introduced `filterRecommendedRanges` to exclude ranges below the last-segment floor from the recommendation list.
+- **Current behavior (symptom)**: When all ranges are filtered out (no recommendations), the nudge still fires — injecting "go compress" text with an empty recommendation list. The model sees the nudge but has nothing actionable to compress.
+- **Expected behavior**: Nudge text injection should be suppressed when the filter removed all ranges. Emergency overrides (maxLimit) always inject.
+- **Impact**: Model gets confused by a nudge with no recommendations. Wastes context tokens.
+
+## 2. Reproduction (if applicable)
+
+- **Environment**:
+  - Session `ses_09c3c1da9ffeZLZW3UnJs5pYG1`
+  - Model: glm-5.2 (1M context)
+- **Minimal reproduction steps**:
+  1. Context grows past growth threshold (50K for 1M model)
+  2. All compressible ranges are below last-segment floor (100K for 1M model)
+  3. Nudge fires with empty recommendation list
+- **Relevant configuration**: Default config, `modelContextLimit: 1000000`
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+  - Backward compatibility: Tests without message IDs (no ranges at all) should still nudge normally
+  - Emergency override (maxLimit) must always inject regardless of filter
+- **Non-Goals**: Changing the filter logic itself; changing nudge threshold mechanics
+
+## 4. Acceptance Criteria (must be testable)
+
+- **Correctness**:
+  - [x] Nudge suppressed when ranges exist but filter removed all
+  - [x] Nudge fires normally when no ranges exist (no message IDs)
+  - [x] Emergency override fires even when filter has no recommendations
+- **Regression**:
+  - [x] New/modified test cases added to test suite and passing
+
+## 5. Proposed Approach (optional)
+
+- **Affected modules & entry files**: `lib/messages/inject/inject.ts`
+- **Risks**: Low — only changes the nudge injection gate condition
+- **Rollback strategy**: Revert the `filterSuppressed` gate change

--- a/devlog/2026-07-15_nudge-no-recs-skip/WORKLOG.md
+++ b/devlog/2026-07-15_nudge-no-recs-skip/WORKLOG.md
@@ -1,0 +1,53 @@
+# WORKLOG - Skip nudge when filter has no recommendations
+
+- Task ID: `2026-07-15_nudge-no-recs-skip`
+- Home Repo: `opencode-acp`
+- Status: Done
+- Updated: 2026-07-15 14:00
+
+## 1. Summary
+
+- **What was done**: Added `filterSuppressed` gate to skip nudge text injection when `filterRecommendedRanges` removes all ranges. Only suppresses when ranges exist but are filtered out — tests without message IDs (0 ranges) are unaffected.
+- **Why**: Injecting "go compress" with an empty recommendation list confuses the model and wastes context.
+- **Behavior / compatibility changes**: Yes — nudge text injection now depends on both `nudgeAllowed` AND (`hasRecommendations` OR `noRangesAtAll` OR `emergencyOverride`)
+- **Risk level**: Low
+
+## 2. Change Log
+
+### Commits
+
+| Commit | Description |
+|--------|-------------|
+| (pending) | feat: skip nudge when filter has no recommendations |
+| (pending) | test: adapt existing tests for recommendation filter gate |
+
+### Key Files
+
+- `lib/messages/inject/inject.ts` — Added `filterSuppressed` gate; moved range computation before nudge block
+- `tests/inject.test.ts` — 2 new tests (suppressed + emergency); 3 tests with larger tool outputs
+- `tests/e2e-blocks-nudges.test.ts` — 1 test with tool output added
+
+## 3. Design & Implementation Notes
+
+- **Entry point**: `injectCompressNudges()` in `lib/messages/inject/inject.ts`
+- **Key logic**: `filterSuppressed = contextRanges.compressible.length > 0 && !hasRecommendations`
+  - `compressible.length > 0` distinguishes "filter removed all" (suppress) from "no ranges at all" (don't suppress)
+  - `shouldInject = nudgeAllowed && (!filterSuppressed || emergencyOverride)`
+- **Filter thresholds**: Single range needs `tokens >= 3 × growthThreshold` to pass (floor + threshold = 3× growth)
+  - 1M model: need ≥150K tokens → 600K+ chars tool output
+  - 100K model: need ≥15K tokens → 60K chars tool output
+
+## 4. Testing & Verification
+
+### Test Coverage
+
+- New test files: 0 (new tests added to existing files)
+- Test count: 713 total, 713 pass, 0 fail
+- Key scenarios verified:
+  - Nudge suppressed when ranges exist but filtered out
+  - Emergency override fires even without recommendations
+  - Existing tests pass with adapted tool output sizes
+
+### Results
+
+- **PASS**: 713/713 tests, typecheck 0 errors, build 399KB

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -295,8 +295,6 @@ export const injectCompressNudges = (
             growthSinceBaseline !== undefined &&
             growthSinceBaseline >= growthFloor)
 
-    state.nudges.shouldInjectThisTurn = nudgeAllowed
-
     const effectiveTipsVariant = emergencyOverride ? "maxLimit" : decision.tipsVariant
 
     if (nudgeAllowed) {
@@ -315,9 +313,55 @@ export const injectCompressNudges = (
         config.protectedFilePatterns,
     )
 
+    // Compute recommendation filter early — the result gates the nudge below.
+    const contextRanges = buildCompressibleRanges(
+        messages,
+        state,
+        config.compress.protectedTools,
+        config.protectedFilePatterns,
+    )
+    const recommendedRanges = filterRecommendedRanges(
+        contextRanges.compressible,
+        contextRanges.protected,
+        { modelContextLimit, growthRatio: 0.05, logger },
+    )
+    const hasRecommendations = recommendedRanges.length > 0
+
+    if (debugNotify && contextRanges.compressible.length > 0 && modelContextLimit) {
+        const growthThreshold = modelContextLimit * 0.05
+        const lastSegmentFloor = growthThreshold * 2
+        const compressible = contextRanges.compressible
+        const lastRange = compressible[compressible.length - 1]
+        const lastIncluded = lastRange.tokens >= lastSegmentFloor
+        const nonLastTokens = compressible
+            .slice(0, -1)
+            .reduce((s, r) => s + r.tokens, 0)
+        const effective = nonLastTokens + Math.max(0, lastRange.tokens - lastSegmentFloor)
+        const suppressed = effective < growthThreshold
+        const fmt = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n))
+        const lines = [
+            `[ACP Debug] Recommendation filter decision:`,
+            `  Input: ${compressible.length} range(s), ${fmt(compressible.reduce((s, r) => s + r.tokens, 0))} tokens`,
+            `  Thresholds: growth=${fmt(growthThreshold)}, lastSegmentFloor=${fmt(lastSegmentFloor)}`,
+            `  Last segment: ${lastRange.startRef}–${lastRange.endRef} ${fmt(lastRange.tokens)} tokens → ${lastIncluded ? "included (dangerous)" : "excluded (< floor)"}`,
+            `  Effective compressible: ${fmt(effective)} → ${suppressed ? "SUPPRESSED (< growth threshold)" : `${recommendedRanges.length} range(s) recommended`}`,
+        ]
+        debugNotify(lines.join("\n"))
+    }
+
+    // Skip soft nudges when the filter suppressed all ranges — injecting
+    // "go compress" with an empty recommendation list wastes context and
+    // confuses the model. Emergency overrides (maxLimit) always inject.
+    // When there are no compressible ranges at all (e.g. no refs assigned yet),
+    // don't suppress — that's an edge case, not a filter decision.
+    const filterSuppressed = contextRanges.compressible.length > 0 && !hasRecommendations
+    const shouldInject = nudgeAllowed && (!filterSuppressed || emergencyOverride)
+
+    state.nudges.shouldInjectThisTurn = shouldInject
+
     let tipsText: string | null = null
 
-    if (nudgeAllowed) {
+    if (shouldInject) {
         injectContextUsage(suffixMessage, config, currentTokens, modelContextLimit)
 
         if (suffixMessage && composition.total > 0) {
@@ -344,38 +388,6 @@ export const injectCompressNudges = (
                 breakdown += `\n⚠️ ${fmt(composition.protectedTokens)} tokens are protected (environment-managed tools) — not compressible. Effective compressible: ~${fmt(compressibleTokens)}.`
             }
 
-            const contextRanges = buildCompressibleRanges(
-                messages,
-                state,
-                config.compress.protectedTools,
-                config.protectedFilePatterns,
-            )
-            const recommendedRanges = filterRecommendedRanges(
-                contextRanges.compressible,
-                contextRanges.protected,
-                { modelContextLimit, growthRatio: 0.05, logger },
-            )
-            if (debugNotify && contextRanges.compressible.length > 0 && modelContextLimit) {
-                const growthThreshold = modelContextLimit * 0.05
-                const lastSegmentFloor = growthThreshold * 2
-                const compressible = contextRanges.compressible
-                const lastRange = compressible[compressible.length - 1]
-                const lastIncluded = lastRange.tokens >= lastSegmentFloor
-                const nonLastTokens = compressible
-                    .slice(0, -1)
-                    .reduce((s, r) => s + r.tokens, 0)
-                const effective = nonLastTokens + Math.max(0, lastRange.tokens - lastSegmentFloor)
-                const suppressed = effective < growthThreshold
-                const fmt = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n))
-                const lines = [
-                    `[ACP Debug] Recommendation filter decision:`,
-                    `  Input: ${compressible.length} range(s), ${fmt(compressible.reduce((s, r) => s + r.tokens, 0))} tokens`,
-                    `  Thresholds: growth=${fmt(growthThreshold)}, lastSegmentFloor=${fmt(lastSegmentFloor)}`,
-                    `  Last segment: ${lastRange.startRef}–${lastRange.endRef} ${fmt(lastRange.tokens)} tokens → ${lastIncluded ? "included (dangerous)" : "excluded (< floor)"}`,
-                    `  Effective compressible: ${fmt(effective)} → ${suppressed ? "SUPPRESSED (< growth threshold)" : `${recommendedRanges.length} range(s) recommended`}`,
-                ]
-                debugNotify(lines.join("\n"))
-            }
             if (recommendedRanges.length > 0) {
                 breakdown += `\n\n${formatCompressibleRanges(recommendedRanges, contextRanges.protected)}`
                 breakdown += `\n💡 Compress all ranges in one call (pass multiple content entries: \`content: [{...}, {...}]\`).`

--- a/tests/e2e-blocks-nudges.test.ts
+++ b/tests/e2e-blocks-nudges.test.ts
@@ -202,7 +202,9 @@ test("nudge injection: context usage tag injected when modelContextLimit is set"
     const output = {
         messages: [
             makeUserMessage("u1", "Hello"),
-            makeAssistantMessage("a1", "Hi", [], SID_A, { input: 100000, output: 50000 }),
+            makeAssistantMessage("a1", "Hi", [
+                makeToolPart("c1", "bash", "completed", "x".repeat(120_000)),
+            ], SID_A, { input: 100000, output: 50000 }),
             makeUserMessage("u2", "Tell me more"),
         ],
     }

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -727,6 +727,76 @@ test("growth floor: 98% emergency override fires regardless of growth", () => {
     )
 })
 
+test("nudge suppressed when filter has no recommendations (all ranges below last-segment floor)", () => {
+    // 1M model: growthThreshold=50K, lastSegmentFloor=100K
+    // Growth of 55K > 50K threshold → nudgeAllowed = true
+    // But tool output is 80K chars (~20K tokens) < 100K floor → filtered out
+    // shouldInjectThisTurn = false (no ranges to recommend, not emergency)
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 200_000
+    state.messageIds.byRawId.set("u1", "m00001")
+    state.messageIds.byRawId.set("a1", "m00002")
+
+    const config = buildConfig()
+    config.compress.maxContextLimit = 500_000
+    config.compress.minContextLimit = 200_000
+
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 55_000 }, [
+            toolPart("c1", "x".repeat(80_000)),
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, messages, {} as any)
+
+    assert.equal(
+        state.nudges.shouldInjectThisTurn,
+        false,
+        "55K growth triggers nudgeAllowed but 20K tool output < 100K floor → no recommendations → nudge suppressed",
+    )
+
+    const injected = suffixText(messages)
+    assert.ok(!injected.includes("Breakdown:"), "no breakdown when no recommendations")
+    assert.ok(!injected.includes("efficiency nudge"), "no efficiency nudge text")
+    assert.ok(!injected.includes("Context limit reached"), "no emergency alert")
+})
+
+test("emergency override fires even when filter has no recommendations", () => {
+    // Context at 98%+ with small tool output (< floor) → emergency bypasses filter
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 980_000
+    state.nudges.lastNudgeShownTokens = 980_000
+    state.messageIds.byRawId.set("u1", "m00001")
+    state.messageIds.byRawId.set("a1", "m00002")
+
+    const config = buildConfig()
+    config.compress.maxContextLimit = 500_000
+    config.compress.minContextLimit = 200_000
+
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 970_000, output: 10_000 }, [
+            toolPart("c1", "x".repeat(40_000)),
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, messages, {} as any)
+
+    assert.equal(
+        state.nudges.shouldInjectThisTurn,
+        true,
+        "98% emergency override fires even when filter has no recommendations",
+    )
+
+    const injected = suffixText(messages)
+    assert.ok(injected.includes("Breakdown:"), "breakdown shown at emergency even without recommendations")
+    assert.ok(
+        injected.includes("Context limit reached — compress now"),
+        "strong maxLimit alert at emergency",
+    )
+})
+
 test("growth floor: 5000 floor on small-context models", () => {
     // 100K model: nudgeGrowthTokens = max(6000, 100K×5%) = 6000
     // growthFloor = max(5000, 0.45×6000) = max(5000, 2700) = 5000
@@ -761,7 +831,7 @@ test("growth floor: 5000 floor on small-context models", () => {
     const messages2: WithParts[] = [
         userMsg("u1", "hello"),
         assistantMsgWithTokens("a1", "done", { input: 20_000, output: 6_000 }, [
-            toolPart("c1", "x".repeat(8_000)),
+            toolPart("c1", "x".repeat(60_000)),
         ]),
     ]
     injectCompressNudges(state2, config, logger, messages2, {} as any)
@@ -827,7 +897,7 @@ test("growth floor: applyAnchoredNudges output suppressed when growth below floo
     const messages2: WithParts[] = [
         userMsg("u1", "hello"),
         assistantMsgWithTokens("a1", "done", { input: 200_000, output: 55_000 }, [
-            toolPart("c1", "x".repeat(80_000)),
+            toolPart("c1", "x".repeat(620_000)),
         ]),
         userMsg("u2", "next"),
     ]
@@ -918,7 +988,9 @@ test("stale contextLimitAnchors: contextLimitNudge NOT injected when context bel
 
     const messages: WithParts[] = [
         userMsg("u1", "hello"),
-        assistantMsgWithTokens("a1", "done", { input: 90_000, output: 10_000 }),
+        assistantMsgWithTokens("a1", "done", { input: 90_000, output: 10_000 }, [
+            toolPart("c1", "x".repeat(620_000)),
+        ]),
         userMsg("u2", "next"),
     ]
     injectCompressNudges(state, config, logger, messages, makePrompts())


### PR DESCRIPTION
## Summary

- **Problem**: When `filterRecommendedRanges` removes all ranges (all below last-segment floor), the nudge still fires with an empty recommendation list — confusing the model and wasting context.
- **Fix**: Added `filterSuppressed` gate in `injectCompressNudges()`. When ranges exist but are all filtered out, nudge text injection is suppressed. Emergency overrides (maxLimit) always inject. Tests without message IDs (0 ranges) are unaffected.
- **Key change**: `shouldInject = nudgeAllowed && (!filterSuppressed || emergencyOverride)` where `filterSuppressed = contextRanges.compressible.length > 0 && !hasRecommendations`

## Test plan

- [x] 713/713 tests pass
- [x] typecheck 0 errors
- [x] build 399KB
- [x] 2 new tests: suppressed case + emergency override case
- [x] Existing tests adapted (larger tool outputs needed for filter to pass)