### PR TITLE
fix: reject phantom compression blocks (#93, #135)

### DIFF
--- a/devlog/2026-07-15_reject-empty-blocks/REQ.md
+++ b/devlog/2026-07-15_reject-empty-blocks/REQ.md
@@ -1,0 +1,52 @@
+# REQ - Reject phantom compression blocks (0 direct messages)
+
+- Task ID: `2026-07-15_reject-empty-blocks`
+- Home Repo: `opencode-acp`
+- Created: 2026-07-15
+- Status: Done
+- Priority: P1
+- Owner: awork
+- References: GitHub #93, #135; Gitea dog/opencode-acp#20
+
+## 1. Background & Problem Statement
+
+- **Context**: When the model calls `compress` on a range that contains only already-compressed messages, `applyCompressionState` creates a block with `directMessageIds: []` and `compressedTokens: 0` — a "phantom block."
+- **Current behavior (symptom)**: The compress tool succeeds, reports `+summary` but `-0 removed`. The model sees context didn't shrink, retries the same range, creates another phantom → compression loop (GitHub #135).
+- **Expected behavior**: The compress tool should REJECT ranges that would produce 0 new direct messages, with a clear error telling the model to pick visible, uncompressed content.
+- **Impact**: Wasted context (summary overhead with no savings), model confusion, compression loops. Reported by external user (GitHub #135, ChatGPT-5.6 Terra) and internally (GitHub #93).
+
+## 2. Reproduction
+
+- **Environment**: Any model, any version with compression enabled.
+- **Minimal reproduction steps**:
+  1. Compress range m1–m10 → block A created
+  2. Call compress again with range m1–m10 (or a range containing only already-compressed messages)
+  3. Block B created with `directMessageIds: []`, `compressedTokens: 0`, `effectiveMessageIds` inherited from A
+- **Relevant configuration**: Default config.
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+  - Backward compatibility: no persisted state format changes
+  - The check must be stateless (no mutation before rejection) — matches `checkLastSegmentDangerous` pattern
+  - Must handle consumed-block scenarios correctly (consuming + re-compressing is NOT new)
+- **Non-Goals**: Fixing the `prune` tool dead code (#116) — separate issue.
+
+## 4. Acceptance Criteria
+
+- **Correctness**:
+  - [x] `checkPhantomBlock` returns Error when ALL effective messages are already active
+  - [x] Returns null when ANY message is new (not active under any block)
+  - [x] Consuming a block + adding a new message → valid (not phantom)
+  - [x] Multi-plan batch: rejects if ANY plan is phantom
+- **Performance / Stability**:
+  - [x] O(n) where n = effective message count per plan
+- **Regression**:
+  - [x] 12 new tests in `tests/phantom-block.test.ts`, all passing
+  - [x] Full suite: 725/725 pass
+
+## 5. Proposed Approach
+
+- **Affected modules**: `lib/compress/pipeline.ts` (new function), `lib/compress/range.ts` + `lib/compress/message.ts` (call sites)
+- **Risks**: A legitimate re-compression that consumes an old block + adds ≥1 new message still works (not phantom). Only ALL-already-active ranges are rejected.
+- **Rollback strategy**: Remove `checkPhantomBlock` calls — no persisted state changes.

--- a/devlog/2026-07-15_reject-empty-blocks/WORKLOG.md
+++ b/devlog/2026-07-15_reject-empty-blocks/WORKLOG.md
@@ -1,0 +1,36 @@
+# WORKLOG - Reject phantom compression blocks
+
+## Commits
+
+1. `feat: reject phantom compression blocks (0 new direct messages)` — `checkPhantomBlock` in pipeline.ts + call sites in range.ts/message.ts
+2. `test: 12 tests for checkPhantomBlock phantom block detection` — `tests/phantom-block.test.ts`
+3. `docs: devlog for reject-empty-blocks`
+
+## Key Files
+
+| File | Change |
+|------|--------|
+| `lib/compress/pipeline.ts` | New `checkPhantomBlock(state, plans)` — stateless pre-check, returns Error if any plan would produce 0 newly-compressed messages |
+| `lib/compress/range.ts` | Call `checkPhantomBlock` before snapshot/compression loop (after `checkLastSegmentDangerous`) |
+| `lib/compress/message.ts` | Same call site (consumedBlockIds always `[]` in message mode) |
+| `tests/phantom-block.test.ts` | 12 tests: new messages, all-active, consumed-block, multi-plan, edge cases |
+
+## Algorithm
+
+`checkPhantomBlock` mirrors `applyCompressionState`'s `newlyCompressedMessageIds` computation:
+
+1. Build `effective` message set = `plan.messageIds` + consumed blocks' `effectiveMessageIds`
+2. A message is "new" if `!entry || entry.activeBlockIds.length === 0` (not currently active under any block)
+3. If NO message is new → phantom → return Error
+
+Key insight: messages active under consumed blocks are NOT "new" — re-labeling them under a new block doesn't newly hide them (they were already hidden by the consumed block). This matches `applyCompressionState`'s `wasActive` check.
+
+## Test Results
+
+- typecheck: 0 errors
+- phantom-block tests: 12/12 pass
+- Full suite: 725/725 pass (713 existing + 12 new)
+
+## Lesson
+
+The phantom block bug (#93) is the root cause of the "compresses zero, creates summary" loop reported in #135. It's a compress-tool validation gap, not a nudge-frequency issue. Our recent smart-nudge-gating work (filter, dangerous param, growth-floor) all REDUCE compression frequency and did NOT introduce this bug.

--- a/lib/compress/message.ts
+++ b/lib/compress/message.ts
@@ -9,6 +9,7 @@ import {
     snapshotCompressionState,
     restoreCompressionState,
     checkLastSegmentDangerous,
+    checkPhantomBlock,
     type NotificationEntry,
 } from "./pipeline"
 import { appendProtectedPromptInfo, appendProtectedTools } from "./protected-content"
@@ -170,6 +171,15 @@ export function createCompressMessageTool(ctx: ToolContext): ReturnType<typeof t
                     summaryWithTools,
                 })
             }
+
+            const phantomError = checkPhantomBlock(
+                ctx.state,
+                preparedPlans.map(({ plan }) => ({
+                    messageIds: plan.selection.messageIds,
+                    consumedBlockIds: [],
+                })),
+            )
+            if (phantomError) throw phantomError
 
             const snapshot = snapshotCompressionState(ctx.state)
             const runId = allocateRunId(ctx.state)

--- a/lib/compress/pipeline.ts
+++ b/lib/compress/pipeline.ts
@@ -152,6 +152,57 @@ export function getLastVisibleMessageId(
 }
 
 /**
+ * Stateless check: reject compression plans that would produce phantom blocks
+ * (0 new direct messages, 0 compressed tokens). A phantom block occurs when
+ * every message in the effective range is already active under an existing
+ * compression block. Returns an Error to throw if any plan is phantom.
+ *
+ * Fix for issue #93: empty compression blocks waste context (summary overhead
+ * with no token savings) and cause compression loops — the model sees 0 tokens
+ * removed, retries the same range, creates another phantom, endlessly.
+ *
+ * A message is "new" (will be newly compressed) if it is NOT currently active
+ * under any block. Messages active under consumed blocks are still "already
+ * compressed" — re-labeling them under a new block does not newly hide them
+ * (matches applyCompressionState's newlyCompressedMessageIds computation).
+ */
+export function checkPhantomBlock(
+    state: SessionState,
+    plans: Array<{ messageIds: string[]; consumedBlockIds: number[] }>,
+): Error | null {
+    for (let i = 0; i < plans.length; i++) {
+        const plan = plans[i]
+
+        // Build effective message set: selection messages + inherited from
+        // consumed blocks (mirrors applyCompressionState lines 79-93).
+        const effective = new Set(plan.messageIds)
+        for (const consumedId of plan.consumedBlockIds) {
+            const block = state.prune.messages.blocksById.get(consumedId)
+            if (block) {
+                for (const mid of block.effectiveMessageIds) {
+                    effective.add(mid)
+                }
+            }
+        }
+
+        const hasNew = [...effective].some((mid) => {
+            const entry = state.prune.messages.byMessageId.get(mid)
+            return !entry || entry.activeBlockIds.length === 0
+        })
+
+        if (!hasNew) {
+            return new Error(
+                `Compression range ${i + 1} contains only already-compressed messages ` +
+                    "(0 new direct messages, 0 tokens saved). Nothing to compress — " +
+                    'pick a range with visible, uncompressed content. Use `acp_status({scope:"uncompressed"})` ' +
+                    "to see which ranges are still compressible.",
+            )
+        }
+    }
+    return null
+}
+
+/**
  * Stateless check: if any plan covers the most recent visible message,
  * the caller must pass `dangerous: true` to proceed. Returns an Error
  * to throw if the caller did not opt in.

--- a/lib/compress/range.ts
+++ b/lib/compress/range.ts
@@ -8,6 +8,7 @@ import {
     snapshotCompressionState,
     restoreCompressionState,
     checkLastSegmentDangerous,
+    checkPhantomBlock,
     type NotificationEntry,
 } from "./pipeline"
 import {
@@ -252,6 +253,15 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
                     consumedBlockIds: mergeConsumedBlockIds,
                 })
             }
+
+            const phantomError = checkPhantomBlock(
+                ctx.state,
+                preparedPlans.map((p) => ({
+                    messageIds: p.selection.messageIds,
+                    consumedBlockIds: p.consumedBlockIds,
+                })),
+            )
+            if (phantomError) throw phantomError
 
             const snapshot = snapshotCompressionState(ctx.state)
             const runId = allocateRunId(ctx.state)

--- a/tests/phantom-block.test.ts
+++ b/tests/phantom-block.test.ts
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { checkPhantomBlock } from "../lib/compress/pipeline"
+import type { CompressionBlock, PrunedMessageEntry, SessionState } from "../lib/state/types"
+
+function makeBlock(overrides: Partial<CompressionBlock> = {}): CompressionBlock {
+    return {
+        blockId: 1,
+        runId: 1,
+        active: true,
+        deactivatedByUser: false,
+        compressedTokens: 100,
+        summaryTokens: 20,
+        durationMs: 0,
+        mode: "range",
+        topic: "test",
+        batchTopic: "test",
+        startId: "m00001",
+        endId: "m00003",
+        anchorMessageId: "anchor-1",
+        compressMessageId: "comp-1",
+        compressCallId: undefined,
+        includedBlockIds: [],
+        consumedBlockIds: [],
+        parentBlockIds: [],
+        directMessageIds: [],
+        directToolIds: [],
+        effectiveMessageIds: ["msg-a", "msg-b"],
+        effectiveToolIds: [],
+        createdAt: 1000,
+        deactivatedAt: undefined,
+        deactivatedByBlockId: undefined,
+        summary: "A summary.",
+        survivedCount: 0,
+        generation: "young",
+        ...overrides,
+    }
+}
+
+function makeState(overrides: Partial<SessionState> = {}): SessionState {
+    return {
+        sessionId: "phantom-test",
+        isSubAgent: false,
+        manualMode: false,
+        compressPermission: "allow",
+        pendingManualTrigger: null,
+        prune: {
+            tools: new Map(),
+            messages: {
+                byMessageId: new Map<string, PrunedMessageEntry>(),
+                blocksById: new Map(),
+                activeBlockIds: new Set<number>(),
+                activeByAnchorMessageId: new Map(),
+                nextBlockId: 1,
+                nextRunId: 1,
+            },
+        },
+        nudges: {
+            contextLimitAnchors: new Set(),
+            turnNudgeAnchors: new Set(),
+            iterationNudgeAnchors: new Set(),
+        },
+        stats: { pruneTokenCounter: 0, totalPruneTokens: 0 },
+        compressionTiming: {} as any,
+        toolParameters: new Map(),
+        subAgentResultCache: new Map(),
+        toolIdList: [],
+        messageIds: { byRawId: new Map(), byRef: new Map(), nextRef: 1 },
+        lastCompaction: 0,
+        currentTurn: 0,
+        modelContextLimit: undefined,
+        systemPromptTokens: undefined,
+        ...overrides,
+    }
+}
+
+function activateMessage(state: SessionState, messageId: string, blockId: number, tokenCount = 50): void {
+    const existing = state.prune.messages.byMessageId.get(messageId)
+    if (existing) {
+        if (!existing.allBlockIds.includes(blockId)) existing.allBlockIds.push(blockId)
+        if (!existing.activeBlockIds.includes(blockId)) existing.activeBlockIds.push(blockId)
+    } else {
+        state.prune.messages.byMessageId.set(messageId, {
+            tokenCount,
+            allBlockIds: [blockId],
+            activeBlockIds: [blockId],
+        })
+    }
+}
+
+// --- checkPhantomBlock: returns null when there are new messages ---
+
+test("checkPhantomBlock returns null when all messages are new (not in any block)", () => {
+    const state = makeState()
+    const result = checkPhantomBlock(state, [{ messageIds: ["m1", "m2", "m3"], consumedBlockIds: [] }])
+    assert.equal(result, null)
+})
+
+test("checkPhantomBlock returns null when some messages are new among already-active ones", () => {
+    const state = makeState()
+    activateMessage(state, "m1", 1)
+    // m1 is active, m2 is new
+    const result = checkPhantomBlock(state, [{ messageIds: ["m1", "m2"], consumedBlockIds: [] }])
+    assert.equal(result, null)
+})
+
+// --- checkPhantomBlock: returns Error for phantom plans ---
+
+test("checkPhantomBlock returns Error when ALL messages are already active", () => {
+    const state = makeState()
+    activateMessage(state, "m1", 1)
+    activateMessage(state, "m2", 1)
+    const result = checkPhantomBlock(state, [{ messageIds: ["m1", "m2"], consumedBlockIds: [] }])
+    assert.ok(result instanceof Error)
+    assert.match(result!.message, /already-compressed/)
+    assert.match(result!.message, /0 new direct messages/)
+})
+
+test("checkPhantomBlock returns Error when single message is already compressed (message mode)", () => {
+    const state = makeState()
+    activateMessage(state, "solo", 5)
+    const result = checkPhantomBlock(state, [{ messageIds: ["solo"], consumedBlockIds: [] }])
+    assert.ok(result instanceof Error)
+    assert.match(result!.message, /already-compressed/)
+})
+
+// --- checkPhantomBlock: consumed block scenarios ---
+
+test("checkPhantomBlock returns Error when consuming a block whose messages are all active under it", () => {
+    const state = makeState()
+    const block = makeBlock({
+        blockId: 10,
+        effectiveMessageIds: ["m1", "m2"],
+        anchorMessageId: "anchor-10",
+    })
+    state.prune.messages.blocksById.set(10, block)
+    state.prune.messages.activeBlockIds.add(10)
+    activateMessage(state, "m1", 10)
+    activateMessage(state, "m2", 10)
+
+    // Compressing m1+m2 again, consuming block 10 — all messages were already active
+    const result = checkPhantomBlock(state, [{ messageIds: ["m1", "m2"], consumedBlockIds: [10] }])
+    assert.ok(result instanceof Error)
+})
+
+test("checkPhantomBlock returns null when consuming a block plus adding a new message", () => {
+    const state = makeState()
+    const block = makeBlock({
+        blockId: 10,
+        effectiveMessageIds: ["m1", "m2"],
+        anchorMessageId: "anchor-10",
+    })
+    state.prune.messages.blocksById.set(10, block)
+    state.prune.messages.activeBlockIds.add(10)
+    activateMessage(state, "m1", 10)
+    activateMessage(state, "m2", 10)
+
+    // m3 is new → not phantom
+    const result = checkPhantomBlock(state, [{ messageIds: ["m1", "m2", "m3"], consumedBlockIds: [10] }])
+    assert.equal(result, null)
+})
+
+test("checkPhantomBlock returns null when a message is active under a non-consumed block but another is new", () => {
+    const state = makeState()
+    activateMessage(state, "m1", 99) // active under non-consumed block 99
+    // m2 is new
+    const result = checkPhantomBlock(state, [{ messageIds: ["m1", "m2"], consumedBlockIds: [] }])
+    assert.equal(result, null)
+})
+
+// --- checkPhantomBlock: multi-plan batches ---
+
+test("checkPhantomBlock returns Error if ANY plan in a batch is phantom", () => {
+    const state = makeState()
+    // Plan 1: m1 is new → valid
+    // Plan 2: m2 is already active → phantom
+    activateMessage(state, "m2", 1)
+    const result = checkPhantomBlock(state, [
+        { messageIds: ["m1"], consumedBlockIds: [] },
+        { messageIds: ["m2"], consumedBlockIds: [] },
+    ])
+    assert.ok(result instanceof Error)
+    assert.match(result!.message, /range 2/i)
+})
+
+test("checkPhantomBlock returns null when all plans in a batch have new messages", () => {
+    const state = makeState()
+    const result = checkPhantomBlock(state, [
+        { messageIds: ["m1"], consumedBlockIds: [] },
+        { messageIds: ["m2", "m3"], consumedBlockIds: [] },
+    ])
+    assert.equal(result, null)
+})
+
+// --- checkPhantomBlock: edge cases ---
+
+test("checkPhantomBlock returns null for empty plans array", () => {
+    const state = makeState()
+    const result = checkPhantomBlock(state, [])
+    assert.equal(result, null)
+})
+
+test("checkPhantomBlock returns null when message exists in byMessageId but has empty activeBlockIds", () => {
+    const state = makeState()
+    // Message was compressed before but its block was deactivated (GC'd)
+    state.prune.messages.byMessageId.set("m1", {
+        tokenCount: 50,
+        allBlockIds: [1],
+        activeBlockIds: [], // no longer active
+    })
+    const result = checkPhantomBlock(state, [{ messageIds: ["m1"], consumedBlockIds: [] }])
+    assert.equal(result, null)
+})
+
+test("checkPhantomBlock error message includes range index for multi-plan batches", () => {
+    const state = makeState()
+    activateMessage(state, "m3", 1)
+    activateMessage(state, "m4", 1)
+    const result = checkPhantomBlock(state, [
+        { messageIds: ["m1"], consumedBlockIds: [] },
+        { messageIds: ["m2"], consumedBlockIds: [] },
+        { messageIds: ["m3", "m4"], consumedBlockIds: [] },
+    ])
+    assert.ok(result instanceof Error)
+    assert.match(result!.message, /range 3/i)
+})


### PR DESCRIPTION
## Summary

- **Problem**: Compressing a range containing only already-compressed messages creates a "phantom block" — 0 direct messages, 0 compressed tokens, but summary overhead. The model sees context didn't shrink → retries the same range → compression loop (reported in #135, tracked in #93).
- **Fix**: New `checkPhantomBlock()` stateless pre-check in `lib/compress/pipeline.ts`. Rejects compress ranges where every effective message is already active under an existing block. Called before the compression loop in both range and message modes, alongside `checkLastSegmentDangerous`.

## Changes

| File | Change |
|------|--------|
| `lib/compress/pipeline.ts` | `checkPhantomBlock(state, plans)` — returns Error if any plan would produce 0 newly-compressed messages |
| `lib/compress/range.ts` | Call before snapshot/compression loop |
| `lib/compress/message.ts` | Same (consumedBlockIds always `[]` in message mode) |
| `tests/phantom-block.test.ts` | 12 tests: all-new, all-active, consumed-block, multi-plan, edge cases |

## Algorithm

A message is "new" (will be newly compressed) if it is NOT currently active under any block (`!entry || activeBlockIds.length === 0`). Messages active under consumed blocks are NOT new — re-labeling under a new block doesn't newly hide them. This mirrors `applyCompressionState`'s `newlyCompressedMessageIds` computation.

## Verification

- typecheck: 0 errors
- Full suite: **725/725 pass** (713 existing + 12 new)
- devlog: `devlog/2026-07-15_reject-empty-blocks/` (REQ + WORKLOG)

## Related

- Fixes #93 (phantom blocks)
- Fixes #135 (compresses zero, creates summary — external user report)
- Not caused by recent nudge-gating work; this is a compress-tool validation gap present since before v1.12.x