### PR TITLE
fix: debug notification triggers phantom model turns

### DIFF
--- a/devlog/2026-07-15_debug-no-phantom-turn/REQ.md
+++ b/devlog/2026-07-15_debug-no-phantom-turn/REQ.md
@@ -1,0 +1,53 @@
+# REQ - Debug notification triggers phantom model turns
+
+- Task ID: `2026-07-15_debug-no-phantom-turn`
+- Home Repo: `opencode-acp`
+- Created: 2026-07-15
+- Status: Done
+- Priority: P0
+- Owner: sisyphus
+- References: dog/opencode-acp#20, GitHub #93
+
+## 1. Background & Problem Statement
+
+- **Context**: When `config.debug: true`, ACP's message-transform hook fires `debugNotify` on every run to surface the recommendation-filter decision to the user. This callback was wired to `sendIgnoredMessage()` (`lib/ui/notification.ts:299`), which sends a user-role message with `ignored: true` via `client.session.prompt({ body: { noReply: true, ... } })`.
+- **Current behavior (symptom)**: opencode does NOT respect `noReply: true` — the `session.prompt()` call triggers a full model turn. The debug notification itself is correctly filtered out of the model's context by `isIgnoredUserMessage()` (`lib/messages/query.ts:43`), so the model sees NO new user input. Its context ends in its own prior assistant output → confusion → hallucination ("user sent a summary of my reply"). This creates a loop: each model response triggers another transform hook → another debug notification → another phantom turn. Observed as agent spamming "待命" (standby) messages indefinitely.
+- **Expected behavior**: Debug notifications must NOT trigger model turns. They are diagnostic metadata, not conversation input.
+- **Impact**: Infinite phantom-turn loop, wasted tokens, model confusion/hallucination, user-visible spam in chat UI.
+
+## 2. Reproduction
+
+- **Environment**:
+  - Node: v25.9.0
+  - OS/Arch: linux-x64
+- **Minimal reproduction steps**:
+  1. Set `debug: true` in `~/.config/opencode/acp.jsonc`
+  2. Have a session with compressible ranges (enough context for the recommendation filter to produce output)
+  3. Observe: every LLM call triggers a debug notification → phantom turn → model responds → triggers another debug notification → loop
+- **Relevant configuration**: `debug: true`
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+  - Backward compatibility: `sendIgnoredMessage()` stays (used by other notification paths); only the `debugNotify` wiring changes.
+  - `noReply: true` not being respected is an opencode-core behavior the plugin cannot fix.
+- **Non-Goals**: Fixing opencode's `noReply` handling; removing `sendIgnoredMessage` entirely.
+
+## 4. Acceptance Criteria
+
+- **Correctness**:
+  - [x] `debugNotify` no longer calls `session.prompt()` — uses `logger.debug()` (pure file log, zero model turns)
+  - [x] Debug info still recorded in `logs/acp/daily/` log file for diagnostics
+- **Performance / Stability**:
+  - [x] No phantom turns triggered by debug notifications
+  - [x] No infinite "待命" loop
+- **Regression**:
+  - [x] Full test suite passing (713/713)
+
+## 5. Proposed Approach
+
+- **Affected modules & entry files**:
+  - `lib/hooks.ts:282-292` — `debugNotify` callback: `sendIgnoredMessage` → `logger.debug`
+  - `lib/hooks.ts:45` — removed unused `sendIgnoredMessage` import
+- **Risks**: Low. Debug filter decisions no longer visible in chat UI (only in log file). Acceptable tradeoff — debug mode is for diagnostics.
+- **Rollback strategy**: Revert single commit.

--- a/devlog/2026-07-15_debug-no-phantom-turn/WORKLOG.md
+++ b/devlog/2026-07-15_debug-no-phantom-turn/WORKLOG.md
@@ -1,0 +1,30 @@
+# WORKLOG - Debug notification triggers phantom model turns
+
+- Task ID: `2026-07-15_debug-no-phantom-turn`
+- Branch: `2026-07-15_debug-no-phantom-turn`
+- Base: `github/master` @ `3fa1415`
+
+## Root Cause
+
+`debugNotify` callback (`lib/hooks.ts:282-292`) was wired to `sendIgnoredMessage()`, which internally calls `client.session.prompt({ body: { noReply: true, ... } })`. opencode does NOT respect `noReply: true` — every call triggers a full model turn.
+
+The debug notification content IS correctly filtered from model context by `isIgnoredUserMessage()` (checks all parts have `ignored: true`). So the model is called with context ending in its own assistant output → hallucinates "user sent a summary of my reply" → responds → triggers another transform hook → another debug notification → infinite loop.
+
+## Fix
+
+Changed `debugNotify` callback from `sendIgnoredMessage(...)` to `logger.debug(...)`. Debug info now goes to `logs/acp/daily/` log file only — no `session.prompt()` call, zero model turns.
+
+### Files changed
+1. `lib/hooks.ts:45` — removed `import { sendIgnoredMessage } from "./ui/notification"` (now unused in this file)
+2. `lib/hooks.ts:282-292` — callback body: `sendIgnoredMessage(client, sessionId, ...)` → `logger.debug(...)`; gate simplified from `config.debug && state.sessionId` to `config.debug` (logger doesn't need session ID)
+
+## Verification
+
+- TypeScript: 0 errors (`tsc --noEmit`)
+- Tests: 713/713 pass (`node --import tsx --test tests/*.test.ts`)
+- No test references the debug-notification path (grep confirmed)
+
+## Notes
+
+- `sendIgnoredMessage()` is retained for other notification paths (compression notifications, etc.) — only the debug callback was changed.
+- The chat UI no longer shows `[ACP Debug] Nudge injected: ...` messages. Debug filter decisions are now in `~/.config/opencode/logs/acp/daily/<date>.log` only.

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -42,7 +42,6 @@ import { type HostPermissionSnapshot } from "./host-permissions"
 import { compressPermission, syncCompressPermissionState } from "./compress-permission"
 import { checkSession, ensureSessionInitialized, saveSessionState, syncToolCache } from "./state"
 import { cacheSystemPromptTokens } from "./ui/utils"
-import { sendIgnoredMessage } from "./ui/notification"
 import { runTruncateGC, shouldRunMajorGC, getGCParams } from "./gc/truncate"
 import { runBatchCleanup } from "./gc/merge"
 import { getCurrentTokenUsage } from "./token-utils"
@@ -279,15 +278,9 @@ export function createChatMessageTransformHandler(
             output.messages,
             prompts.getRuntimePrompts(),
             compressionPriorities,
-            config.debug && state.sessionId
+            config.debug
                 ? (text: string) => {
-                      sendIgnoredMessage(
-                          client,
-                          state.sessionId!,
-                          `[ACP Debug] Nudge injected:\n${text}`,
-                          {},
-                          logger,
-                      ).catch(() => {})
+                      logger.debug(`[ACP Debug] Nudge injected:\n${text}`)
                   }
                 : undefined,
             prePruneTokens,


### PR DESCRIPTION
## Summary

- **Problem**: When `config.debug: true`, the `debugNotify` callback fired on every message-transform hook run was wired to `sendIgnoredMessage()`, which calls `client.session.prompt({ body: { noReply: true } })`. opencode does NOT respect `noReply: true` — every call triggers a full model turn. The notification content IS correctly filtered from model context (`isIgnoredUserMessage`), so the model is called with no new user input → context ends in its own assistant output → confusion → hallucination → responds → triggers another transform hook → another debug notification → **infinite loop**. Observed as the agent spamming "待命" (standby) indefinitely.

- **Fix**: Changed `debugNotify` callback (`lib/hooks.ts`) from `sendIgnoredMessage(...)` to `logger.debug(...)`. Debug filter decisions now go to `logs/acp/daily/` log file only — no `session.prompt()` call, zero model turns.

- **Tradeoff**: Debug filter decisions no longer appear in chat UI. They are in the log file instead. Acceptable — debug mode is for diagnostics, not conversation.

## Files changed
- `lib/hooks.ts`: removed `sendIgnoredMessage` import + changed callback body to `logger.debug`
- `devlog/2026-07-15_debug-no-phantom-turn/`: REQ + WORKLOG

## Test plan
- [x] TypeScript: 0 errors
- [x] Tests: 713/713 pass
- [x] Deploy + verify no phantom turns with `debug: true`

Refs: dog/opencode-acp#20