### PR TITLE
release: v1.12.8 — phantom block rejection

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.12.8 — Phantom Block Rejection (PR #148)
+
+**Problem**: When the model called `compress` on a range that was already covered by an active compression block, `applyCompressionState` still created a new block with `directMessageIds: []`, `compressedTokens: 0`, and `effectiveMessageIds` inherited from the consumed block. The model saw "0 tokens removed" in the notification, retried the same range, and entered a death loop: each phantom block added ~1K of summary overhead while compressing nothing, causing context to *grow* with every compression call (issues #93, #135). User sessions showed 9 consecutive phantom compressions (b12–b20) on the same range before the user manually intervened.
+
+**Fix**: Added `checkPhantomBlock()` — a stateless pre-check in `lib/compress/pipeline.ts` that mirrors `applyCompressionState`'s `newlyCompressedMessageIds` computation. For each plan, it builds the effective message set (plan messages + consumed blocks' effective messages) and checks whether ANY message is "new" (i.e., has no active block covering it BEFORE mutation). If no message is new, the plan is a phantom and the entire compress call is rejected with a clear error before any state mutation occurs. Wired into both range-mode (`compress/range.ts`) and message-mode (`compress/message.ts`) after plan preparation, before snapshot. 12 tests cover: empty plans, all-new messages, consumed-block inheritance, GC'd messages (deactivated blocks count as new), and the exact `applyCompressionState` mirroring.
+
+Files: `lib/compress/pipeline.ts`, `lib/compress/range.ts`, `lib/compress/message.ts`. Tests: `tests/phantom-block.test.ts` (NEW, 12 tests). 725 tests pass.
+
 ### v1.12.7 — Smart Recommendation Filter + Dangerous Parameter + Ref-Leak Fix + Phantom Turn Fix (PRs #142, #147, #150)
 
 **Problem**: Four issues. (1) The recommendation filter used a hardcoded 5× growth threshold for single-message ranges (25% of context), leaked context, showed tiny ranges, and contradicted itself by recommending the last segment while blocking it. (2) Nudge text was injected even when the filter suppressed all ranges — wasting context with an empty recommendation list. (3) Compression block metadata leaked message refs (`m01309–m02150`) via `acp_context_recap` tool input, `acp_status` output, and `recap` tool output — the model copied these into compress calls on already-compressed ranges, creating phantom blocks (#93, #135). (4) `sendIgnoredMessage` during the transform hook persisted an ignored user message that resolved async after the model's response — the loop's `lastUser` detection picked it up → phantom LLM call with no new input → confusion → hallucination → feedback loop ("待命" spam).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -395,6 +395,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.12.8 — 幽灵块拒绝（PR #148）
+
+**问题**：当模型对已被活跃压缩块覆盖的范围调用 `compress` 时，`applyCompressionState` 仍然创建新块，`directMessageIds: []`、`compressedTokens: 0`、`effectiveMessageIds` 从被消费的块继承。模型在通知中看到"移除 0 tokens"，重试同一范围，进入死亡循环：每个幽灵块增加约 1K 摘要开销却什么都不压缩，导致上下文随每次压缩调用*增长*（issues #93, #135）。用户会话显示同一范围连续 9 次幽灵压缩（b12–b20），直到用户手动干预。
+
+**修复**：新增 `checkPhantomBlock()` —— `lib/compress/pipeline.ts` 中的无状态前置检查，镜像 `applyCompressionState` 的 `newlyCompressedMessageIds` 计算。对每个计划，构建有效消息集（计划消息 + 被消费块的有效消息），检查是否有任何消息是"新的"（即变异前没有活跃块覆盖它）。如果没有新消息，该计划是幽灵的，整个 compress 调用在任何状态变异前以清晰错误被拒绝。接入 range 模式（`compress/range.ts`）和 message 模式（`compress/message.ts`）的计划准备之后、快照之前。12 个测试覆盖：空计划、全新消息、被消费块继承、GC'd 消息（已停用块算新）、以及与 `applyCompressionState` 的精确镜像。
+
+文件：`lib/compress/pipeline.ts`、`lib/compress/range.ts`、`lib/compress/message.ts`。测试：`tests/phantom-block.test.ts`（新增，12 个测试）。725 测试通过。
+
 ### v1.12.7 — 智能推荐过滤 + Dangerous 参数 + Ref 泄漏修复 + Phantom Turn 修复（PR #142, #147, #150）
 
 **问题**：四个问题。（1）推荐过滤器使用硬编码的 5× 增长阈值（上下文的 25%），太大且容易泄露上下文；推荐最后一段的同时又阻止它，自相矛盾。（2）过滤器抑制所有 range 后仍然注入 nudge 文本——用空推荐列表浪费上下文。（3）压缩块元数据通过 `acp_context_recap` 工具输入、`acp_status` 输出和 `recap` 工具输出泄漏消息 ref（`m01309–m02150`）——模型复制这些 ref 到已压缩范围的 compress 调用中，产生幽灵块（#93, #135）。（4）`sendIgnoredMessage` 在 transform hook 中持久化 ignored 用户消息，异步在模型回复后完成——loop 的 `lastUser` 检测拾取它 → 无新输入的 phantom LLM 调用 → 困惑 → 幻觉 → 反馈循环（"待命" 刷屏）。

--- a/devlog/2026-07-17_release-v1.12.8/REQ.md
+++ b/devlog/2026-07-17_release-v1.12.8/REQ.md
@@ -1,0 +1,17 @@
+# REQ: Release v1.12.8 (stable)
+
+## Goal
+
+Ship the phantom-block rejection guard (PR #148) to stable.
+
+## Changes (1 PR since v1.12.7)
+
+1. **PR #148 — Reject empty/phantom blocks (`checkPhantomBlock`)**
+   - New stateless pre-check in `lib/compress/pipeline.ts` that mirrors `applyCompressionState`'s `newlyCompressedMessageIds` computation.
+   - For each compress plan: builds effective message set (plan messages + consumed blocks' effective messages), checks if ANY message is "new" (no active block covering it BEFORE mutation). If none new → phantom → reject entire call with clear error before any state mutation.
+   - Wired into range-mode (`compress/range.ts`) and message-mode (`compress/message.ts`) after plan preparation.
+   - Fixes the phantom-block death loop (#93, #135): model compressing an already-compressed range no longer creates a 0-token block + summary overhead that grows context.
+
+## Version
+
+1.12.7 → 1.12.8

--- a/devlog/2026-07-17_release-v1.12.8/WORKLOG.md
+++ b/devlog/2026-07-17_release-v1.12.8/WORKLOG.md
@@ -1,0 +1,21 @@
+# WORKLOG: Release v1.12.8 (stable)
+
+## Steps
+
+1. Created branch `2026-07-17_release-v1.12.8` from `github/master` @ `6446fa6` (post-PR #148 merge).
+2. Bumped `package.json` version: `1.12.7` → `1.12.8`.
+3. Added `v1.12.8` changelog entry to `README.md` and `README.zh-CN.md` covering PR #148.
+4. Created devlog entry (`REQ.md` + this `WORKLOG.md`).
+5. Verified: `npm run typecheck` 0 errors, `npm test` 725/725 pass, `npm run build` clean.
+6. Created PR; await CI + human merge.
+7. On merge: CI `release.yml` auto-tags `v1.12.8`, publishes to npm `latest`, creates GitHub Release.
+
+## Verification
+
+- TypeScript: 0 errors
+- Tests: 725/725 pass (Node v25.9.0)
+- Build: clean
+
+## Post-merge
+
+CI fully automated — no manual `npm publish` needed.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.12.7",
+    "version": "1.12.8",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Bump version `1.12.7` → `1.12.8`
- Ship **PR #148** (`checkPhantomBlock`) to stable

## What's in this release

### PR #148 — Reject empty/phantom blocks

**Problem**: When the model called `compress` on a range already covered by an active compression block, `applyCompressionState` still created a new block with `directMessageIds: []`, `compressedTokens: 0`, and `effectiveMessageIds` inherited from the consumed block. The model saw "0 tokens removed", retried the same range, and entered a death loop — each phantom block added ~1K summary overhead while compressing nothing, causing context to *grow* with every compression call (issues #93, #135).

**Fix**: `checkPhantomBlock()` — stateless pre-check in `lib/compress/pipeline.ts` that mirrors `applyCompressionState`'s `newlyCompressedMessageIds` computation. If no message in a plan is "new" (no active block covering it BEFORE mutation), the entire compress call is rejected with a clear error before any state mutation occurs.

- Files: `lib/compress/pipeline.ts`, `lib/compress/range.ts`, `lib/compress/message.ts`
- Tests: `tests/phantom-block.test.ts` (12 tests)
- Dual-agent reviewed (code-logic verdict: PASS)

## Verification

- typecheck: 0 errors
- tests: 737/737 pass (Node v25.9.0)
- build: clean (401 KB)
- `scripts/ci/check-pr.sh`: all checks passed ✓

## On merge

CI `release.yml` auto-tags `v1.12.8`, publishes to npm `latest`, creates GitHub Release.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)