### PR TITLE
release: v1.12.9 — compress-as-anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.12.9 — Compress-as-Anchor (PR #153)
+
+**Problem**: Since v1.12.1, compression summaries were injected as synthetic tool-result messages via a registered `acp_context_recap` tool, while `stripStaleCompressCalls` removed past `compress` tool calls from the API context to avoid duplication. This doubled summary overhead: each block's summary existed both as a synthetic recap message AND in the original (now-stripped) compress call's `summary` parameter. For sessions with many compressions, this "recap overhead" consumed 10–20% of context with no additional information value. The `acp_context_recap` tool description also claimed it "automatically injects" summaries, which was misleading.
+
+**Fix**: Removed the synthetic recap injection entirely. Compression summaries now live **inside the model's own past `compress` tool calls** — the `summary` parameter of each historical `compress({ summary: "..." })` call serves as the anchor, visible to the model like any other tool call. Deleted `createSyntheticToolRecap` (prune.ts), `stripStaleCompressCalls` (prune.ts), and the automatic recap injection path. The `acp_context_recap` tool is now manual-only (model-callable for re-fetching summaries that scrolled out of context). Updated `system.ts` prompt to describe compress-as-anchor behavior and warn against reusing historical `startId`/`endId` without `acp_status` verification. Updated `RECAP_TOOL_DESCRIPTION` to reflect manual-only usage. Net effect: ~50% reduction in summary overhead for compression-heavy sessions.
+
+Files: `lib/messages/prune.ts`, `lib/messages/utils.ts`, `lib/compress/recap.ts`, `lib/prompts/system.ts`. Tests: updated for compress-anchor behavior; 725 pass.
+
 ### v1.12.8 — Phantom Block Rejection (PR #148)
 
 **Problem**: When the model called `compress` on a range that was already covered by an active compression block, `applyCompressionState` still created a new block with `directMessageIds: []`, `compressedTokens: 0`, and `effectiveMessageIds` inherited from the consumed block. The model saw "0 tokens removed" in the notification, retried the same range, and entered a death loop: each phantom block added ~1K of summary overhead while compressing nothing, causing context to *grow* with every compression call (issues #93, #135). User sessions showed 9 consecutive phantom compressions (b12–b20) on the same range before the user manually intervened.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -395,6 +395,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.12.9 — Compress-as-Anchor（PR #153）
+
+**问题**：自 v1.12.1 起，压缩摘要通过注册的 `acp_context_recap` 工具以 synthetic tool-result 消息注入，同时 `stripStaleCompressCalls` 从 API 上下文中移除历史 `compress` 工具调用以避免重复。这导致摘要开销翻倍：每个块的摘要同时存在于 synthetic recap 消息和原始（已移除的）compress 调用的 `summary` 参数中。对于压缩频繁的会话，这个 "recap 开销" 占用 10–20% 上下文却没有额外信息价值。`acp_context_recap` 工具描述也声称它"自动注入"摘要，具有误导性。
+
+**修复**：完全移除 synthetic recap 注入。压缩摘要现在保留在**模型自己的历史 `compress` 工具调用中** —— 每个历史 `compress({ summary: "..." })` 调用的 `summary` 参数作为锚点，像其他工具调用一样对模型可见。删除了 `createSyntheticToolRecap`（prune.ts）、`stripStaleCompressCalls`（prune.ts）和自动 recap 注入路径。`acp_context_recap` 工具改为手动调用（模型可调用以重新获取滚动出上下文的摘要）。更新 `system.ts` 提示描述 compress-as-anchor 行为，警告不要不经 `acp_status` 验证就重用历史 `startId`/`endId`。更新 `RECAP_TOOL_DESCRIPTION` 反映手动调用语义。净效果：压缩频繁会话的摘要开销减少约 50%。
+
+文件：`lib/messages/prune.ts`、`lib/messages/utils.ts`、`lib/compress/recap.ts`、`lib/prompts/system.ts`。测试：更新为 compress-anchor 行为；725 通过。
+
 ### v1.12.8 — 幽灵块拒绝（PR #148）
 
 **问题**：当模型对已被活跃压缩块覆盖的范围调用 `compress` 时，`applyCompressionState` 仍然创建新块，`directMessageIds: []`、`compressedTokens: 0`、`effectiveMessageIds` 从被消费的块继承。模型在通知中看到"移除 0 tokens"，重试同一范围，进入死亡循环：每个幽灵块增加约 1K 摘要开销却什么都不压缩，导致上下文随每次压缩调用*增长*（issues #93, #135）。用户会话显示同一范围连续 9 次幽灵压缩（b12–b20），直到用户手动干预。

--- a/devlog/2026-07-18_release-v1.12.9/REQ.md
+++ b/devlog/2026-07-18_release-v1.12.9/REQ.md
@@ -1,0 +1,28 @@
+# REQ: Release v1.12.9 — Compress-as-Anchor
+
+## Motivation
+
+PR #153 (compress-as-anchor) was merged to master. Need a stable release to publish the change to npm `latest`.
+
+## Scope
+
+Bundle PR #153 content into a stable release:
+- Remove synthetic recap injection (`createSyntheticToolRecap`, `stripStaleCompressCalls`)
+- Use `compress` tool calls as anchors (summary stays in `summary` parameter)
+- `acp_context_recap` tool becomes manual-only
+- Updated system prompt and tool descriptions
+
+## Changes
+
+- `package.json`: version `1.12.8` → `1.12.9`
+- `README.md`: add v1.12.9 changelog entry
+- `README.zh-CN.md`: add v1.12.9 changelog entry
+- `devlog/2026-07-18_release-v1.12.9/`: REQ.md + WORKLOG.md
+
+## Acceptance Criteria
+
+- [x] typecheck passes (0 errors)
+- [x] all tests pass
+- [x] build succeeds
+- [x] `check-pr.sh` passes
+- [x] PR created with correct branch name

--- a/devlog/2026-07-18_release-v1.12.9/WORKLOG.md
+++ b/devlog/2026-07-18_release-v1.12.9/WORKLOG.md
@@ -1,0 +1,20 @@
+# WORKLOG: Release v1.12.9 — Compress-as-Anchor
+
+## 2026-07-18
+
+### Branch
+- Created `2026-07-18_release-v1.12.9` from `github/master` @ `419f506` (Merge PR #153)
+
+### Content (1 PR)
+**PR #153 — Compress-as-Anchor**: Removed synthetic recap injection. Compression summaries now live inside `compress` tool calls (the model's own past calls) as anchors. `acp_context_recap` tool becomes manual-only. Updated system prompt + tool descriptions. ~50% reduction in summary overhead for compression-heavy sessions.
+
+### Artifacts
+- `package.json`: version bumped to `1.12.9`
+- `README.md`: v1.12.9 changelog entry added
+- `README.zh-CN.md`: v1.12.9 changelog entry added
+- devlog created
+
+### Verification
+- typecheck: 0 errors
+- tests: 725/725 pass
+- build: succeeds

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.12.8",
+    "version": "1.12.9",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Stable release of PR #153 (compress-as-anchor).

- Removed synthetic recap injection (`createSyntheticToolRecap`, `stripStaleCompressCalls`)
- Compression summaries now live inside `compress` tool calls as anchors
- `acp_context_recap` tool becomes manual-only
- ~50% reduction in summary overhead for compression-heavy sessions

## Changes

- `package.json`: version `1.12.8` → `1.12.9`
- `README.md` + `README.zh-CN.md`: v1.12.9 changelog entries
- `devlog/2026-07-18_release-v1.12.9/`: REQ.md + WORKLOG.md

## Verification

- typecheck: 0 errors
- tests: 725/725 pass
- build: 396.94 KB
- `check-pr.sh`: all checks passed