### PR TITLE
feat: batch compress with per-entry topics

### DIFF
--- a/devlog/2026-07-18_batch-compress/REQ.md
+++ b/devlog/2026-07-18_batch-compress/REQ.md
@@ -1,0 +1,31 @@
+# REQ: Batch Compress — Per-Entry Topics
+
+## Problem
+
+When the recommendation list shows many compressible ranges, the model faces two failure modes:
+
+1. **Under-compression**: Compresses only one topic, then doesn't know what else to compress (recommendation list disappears after first call).
+2. **Quality degradation**: Forces all unrelated ranges under one shared topic to fit in a single call, producing poor summaries.
+
+## Solution
+
+Allow each `content` entry to carry its own optional `topic`. The top-level `topic` becomes optional — it serves as a fallback for entries that don't specify their own.
+
+```
+compress({ content: [
+  { topic: "Auth", startId: "m10", endId: "m50", summary: "..." },
+  { topic: "Deploy", startId: "m60", endId: "m80", summary: "..." },
+]})
+```
+
+Each entry becomes its own block with its own topic, sharing one `runId` (same tool call). Fully backward compatible: existing calls with top-level `topic` work unchanged.
+
+## Scope
+
+- `lib/compress/types.ts` — `CompressRangeEntry.topic?`, `CompressRangeToolArgs.topic?`
+- `lib/compress/range.ts` — schema, execute (per-entry topic resolution)
+- `lib/compress/range-utils.ts` — `validateArgs` (entry needs own or fallback), `resolveRanges` (preserve topic)
+- `lib/compress/types.ts` — `CompressionStateInput.batchTopic` → `string | undefined`
+- `lib/state/rebuild.ts` — per-entry topic resolution in state rebuild
+- `lib/prompts/compress-range.ts` — document batch topic in BATCHING section
+- `tests/batch-compress.test.ts` — 10 tests (6 validation + 4 integration)

--- a/devlog/2026-07-18_batch-compress/WORKLOG.md
+++ b/devlog/2026-07-18_batch-compress/WORKLOG.md
@@ -1,0 +1,42 @@
+# WORKLOG: Batch Compress — Per-Entry Topics
+
+## Branch
+`2026-07-18_batch-compress` from `github/master` @ `2f534a7`
+
+## Changes
+
+### 1. Types (`lib/compress/types.ts`)
+- `CompressRangeEntry`: added `topic?: string` (per-entry topic)
+- `CompressRangeToolArgs`: `topic` changed from `string` to `topic?: string` (fallback)
+- `CompressionStateInput.batchTopic`: changed from `string` to `string | undefined`
+
+### 2. Schema (`lib/compress/range.ts:39-82`)
+- Top-level `topic`: `string()` → `string().optional()` with updated description
+- Content entry: added `topic: string().optional()` with guidance for batch usage
+
+### 3. Validation (`lib/compress/range-utils.ts:15-47`)
+- `validateArgs`: removed top-level topic requirement; added per-entry check: each entry needs its own `topic` OR the top-level fallback
+- `resolveRanges`: normalized entry now preserves `topic` field
+
+### 4. Execute (`lib/compress/range.ts:294`)
+- Block topic: `input.topic` → `preparedPlan.entry.topic ?? input.topic ?? ""`
+- `batchTopic`: `input.topic` (now `string | undefined`)
+- Log: `Compress Range: ${input.topic}` → `Compress Range: ${input.topic ?? "(batch)"}`
+
+### 5. State rebuild (`lib/state/rebuild.ts`)
+- Range rebuild: `topic: input.topic` → `topic: plan.entry.topic ?? input.topic ?? ""`
+- `batchTopic`: guarded with `typeof input.topic === "string"`
+- Message rebuild: `batchTopic` guarded similarly
+
+### 6. Prompt (`lib/prompts/compress-range.ts`)
+- BATCHING section: added guidance for per-entry topics when compressing unrelated ranges
+- Added example with 3 entries each having its own topic
+
+### 7. Tests (`tests/batch-compress.test.ts`)
+- 6 validation tests: per-entry topics, fallback, mixed, missing topic errors
+- 4 integration tests: block topic assignment for all patterns
+
+## Verification
+- TypeScript: 0 errors
+- Tests: 760/760 pass (750 existing + 10 new)
+- Backward compat: existing calls with top-level `topic` work unchanged

--- a/lib/compress/range-utils.ts
+++ b/lib/compress/range-utils.ts
@@ -13,9 +13,8 @@ import type {
 const BLOCK_PLACEHOLDER_REGEX = /\(b(\d+)\)|\{block_(\d+)\}/gi
 
 export function validateArgs(args: CompressRangeToolArgs): void {
-    if (typeof args.topic !== "string" || args.topic.trim().length === 0) {
-        throw new Error("topic is required and must be a non-empty string")
-    }
+    const hasTopLevelTopic =
+        typeof args.topic === "string" && args.topic.trim().length > 0
 
     if (!Array.isArray(args.content) || args.content.length === 0) {
         throw new Error("content is required and must be a non-empty array")
@@ -36,6 +35,14 @@ export function validateArgs(args: CompressRangeToolArgs): void {
         if (typeof entry?.summary !== "string" || entry.summary.trim().length === 0) {
             throw new Error(`${prefix}.summary is required and must be a non-empty string`)
         }
+
+        const hasEntryTopic =
+            typeof entry?.topic === "string" && entry.topic.trim().length > 0
+        if (!hasEntryTopic && !hasTopLevelTopic) {
+            throw new Error(
+                `${prefix} needs a topic — provide ${prefix}.topic or the top-level topic`,
+            )
+        }
     }
 }
 
@@ -46,6 +53,10 @@ export function resolveRanges(
 ): ResolvedRangeCompression[] {
     return args.content.map((entry, index) => {
         const normalizedEntry = {
+            topic:
+                typeof entry.topic === "string" && entry.topic.trim().length > 0
+                    ? entry.topic.trim()
+                    : undefined,
             startId: entry.startId.trim(),
             endId: entry.endId.trim(),
             summary: entry.summary,

--- a/lib/compress/range.ts
+++ b/lib/compress/range.ts
@@ -40,10 +40,19 @@ function buildSchema(maxSummaryLengthHard: number) {
     return {
         topic: tool.schema
             .string()
-            .describe("Short label (3-5 words) for display - e.g., 'Auth System Exploration'"),
+            .optional()
+            .describe(
+                "Fallback topic for entries without their own. Omit when each content entry specifies its own topic.",
+            ),
         content: tool.schema
             .array(
                 tool.schema.object({
+                    topic: tool.schema
+                        .string()
+                        .optional()
+                        .describe(
+                            "Short label (3-5 words) for THIS range, e.g. 'Auth System Exploration'. Omit to use top-level topic. When compressing multiple unrelated ranges, give each its own topic for better quality.",
+                        ),
                     startId: tool.schema
                         .string()
                         .describe(
@@ -60,7 +69,7 @@ function buildSchema(maxSummaryLengthHard: number) {
                 }),
             )
             .describe(
-                "One or more ranges to compress, each with start/end boundaries and a summary",
+                "One or more ranges to compress, each with start/end boundaries and a summary. When compressing multiple unrelated ranges in one call, give each its own topic.",
             ),
         summaryMaxChars: tool.schema
             .number()
@@ -107,7 +116,7 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
             const { rawMessages, searchContext } = await prepareSession(
                 ctx,
                 toolCtx,
-                `Compress Range: ${input.topic}`,
+                `Compress Range: ${input.topic ?? "(batch)"}`,
             )
             const resolvedPlans = resolveRanges(input, searchContext, ctx.state)
             validateNonOverlapping(resolvedPlans)
@@ -282,7 +291,7 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
                     const applied = applyCompressionState(
                         ctx.state,
                         {
-                            topic: input.topic,
+                            topic: preparedPlan.entry.topic ?? input.topic ?? "",
                             batchTopic: input.topic,
                             startId: preparedPlan.entry.startId,
                             endId: preparedPlan.entry.endId,
@@ -310,7 +319,13 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
                     })
                 }
 
-                await finalizeSession(ctx, toolCtx, rawMessages, notifications, input.topic)
+                await finalizeSession(
+                    ctx,
+                    toolCtx,
+                    rawMessages,
+                    notifications,
+                    input.topic,
+                )
             } catch (error) {
                 restoreCompressionState(ctx.state, snapshot)
                 throw error

--- a/lib/compress/types.ts
+++ b/lib/compress/types.ts
@@ -12,13 +12,16 @@ export interface ToolContext {
 }
 
 export interface CompressRangeEntry {
+    /** Per-entry topic for batch compression. Falls back to top-level `topic`. */
+    topic?: string
     startId: string
     endId: string
     summary: string
 }
 
 export interface CompressRangeToolArgs {
-    topic: string
+    /** Fallback topic for entries without their own. Optional if every entry has one. */
+    topic?: string
     content: CompressRangeEntry[]
 }
 
@@ -97,7 +100,7 @@ export interface AppliedCompressionResult {
 
 export interface CompressionStateInput {
     topic: string
-    batchTopic: string
+    batchTopic: string | undefined
     startId: string
     endId: string
     mode: CompressionMode

--- a/lib/prompts/compress-range.ts
+++ b/lib/prompts/compress-range.ts
@@ -35,6 +35,16 @@ Rules:
 BATCHING
 When multiple independent ranges are ready and their boundaries do not overlap, include all of them as separate entries in the \`content\` array of a single tool call. Each entry should have its own \`startId\`, \`endId\`, and \`summary\`.
 
+When the ranges cover unrelated topics, give each entry its own \`topic\` for better summary quality — do not force unrelated content under a single shared topic. Omit the top-level \`topic\` when every entry has its own. Use the top-level \`topic\` only as a fallback when entries don't specify one.
+
+\`\`\`
+compress({ content: [
+  { topic: "Auth System Exploration", startId: "m00010", endId: "m00050", summary: "..." },
+  { topic: "Bug Hunt", startId: "m00060", endId: "m00080", summary: "..." },
+  { topic: "Deployment", startId: "m00090", endId: "m00110", summary: "..." },
+]})
+\`\`\`
+
 KEEP AND REF MARKERS
 When writing a summary, you may embed markers that reference specific messages in the compressed range. The system resolves them automatically:
 

--- a/lib/prompts/extensions/tool.ts
+++ b/lib/prompts/extensions/tool.ts
@@ -3,20 +3,27 @@
 // match the tool's input validation and are not safe to change independently.
 
 export const RANGE_FORMAT_EXTENSION = `
+
 THE FORMAT OF COMPRESS
 
 \`\`\`
 {
-  topic: string,           // Short label (3-5 words) - e.g., "Auth System Exploration"
+  topic?: string,          // OPTIONAL fallback topic for entries without their own.
+                           //   Omit when every content entry specifies its own topic.
   content: [               // One or more ranges to compress
     {
+      topic?: string,      // OPTIONAL per-entry topic for this range.
+                           //   Falls back to top-level topic.
+                           //   Give each entry its own topic when compressing
+                           //   unrelated ranges in one call.
       startId: string,     // Boundary ID at range start: mNNNNN or bN
       endId: string,       // Boundary ID at range end: mNNNNN or bN
       summary: string      // Complete technical summary replacing all content in range
     }
   ]
 }
-\`\`\``
+\`\`\`
+Each entry needs a topic — either its own or the top-level fallback.`
 
 export const MESSAGE_FORMAT_EXTENSION = `
 THE FORMAT OF COMPRESS

--- a/lib/prompts/system.ts
+++ b/lib/prompts/system.ts
@@ -23,7 +23,7 @@ TOOLS
 
 You have five context-management tools:
 
-- \`compress\` — Replace a contiguous range of older conversation with a single detailed summary you write. Use when content is genuinely consumed (no longer needed for the current task step). Example: \`compress({ topic: "API exploration", content: [{ startId: "m00150", endId: "m00220", summary: "..." }] })\`.
+- \`compress\` — Replace a contiguous range of older conversation with a single detailed summary you write. Use when content is genuinely consumed (no longer needed for the current task step). Single range: \`compress({ topic: "API exploration", content: [{ startId: "m00150", endId: "m00220", summary: "..." }] })\`. Batch (multiple unrelated ranges, each with its own topic): \`compress({ content: [{ topic: "Auth", startId: "m00150", endId: "m00220", summary: "..." }, { topic: "Deploy", startId: "m00300", endId: "m00350", summary: "..." }] })\`.
 - \`decompress\` — Restore a previously compressed block's full original content, optionally to a file for large blocks. Use when a summary lacks the exact detail you need. Example: \`decompress({ blockId: "b5" })\` or \`decompress({ blockId: "b5", toFile: "path" })\`.
 - \`search_context\` — Search compressed block summaries (and optionally visible messages) by keyword. Use BEFORE decompressing to find the right block. Example: \`search_context({ query: "auth token refresh" })\`.
 - \`prune\` — Remove old tool outputs by tool type, keeping only recent calls. Unlike compress (which creates summaries), prune directly strips outputs. Use for disposable outputs like old todowrite states or edit echoes. Example: \`prune({ toolType: "todowrite", keepLatest: 3 })\`.

--- a/lib/state/rebuild.ts
+++ b/lib/state/rebuild.ts
@@ -164,8 +164,8 @@ function rebuildRangeInvocation(
         applyCompressionState(
             state,
             {
-                topic: input.topic,
-                batchTopic: input.topic,
+                topic: plan.entry.topic ?? input.topic ?? "",
+                batchTopic: typeof input.topic === "string" ? input.topic : undefined,
                 startId: plan.entry.startId,
                 endId: plan.entry.endId,
                 mode: "range",
@@ -260,7 +260,7 @@ function rebuildMessageInvocation(
             state,
             {
                 topic: entry.topic,
-                batchTopic: input.topic,
+                batchTopic: typeof input.topic === "string" ? input.topic : undefined,
                 startId: entry.messageId,
                 endId: entry.messageId,
                 mode: "message",

--- a/lib/ui/notification.ts
+++ b/lib/ui/notification.ts
@@ -210,12 +210,18 @@ export async function sendCompressNotification(
         }
     }
 
+    const entryBlockTopics = entries
+        .map((e) => state.prune.messages.blocksById.get(e.blockId)?.topic)
+        .filter((t): t is string => typeof t === "string" && t.length > 0)
+
     const topic =
         batchTopic ??
         (entries.length === 1
             ? (state.prune.messages.blocksById.get(entries[0]?.blockId ?? -1)?.topic ??
               "(unknown topic)")
-            : "(unknown topic)")
+            : entryBlockTopics.length > 0
+              ? entryBlockTopics.join(" · ")
+              : "(unknown topic)")
 
     const contextTokensAfter = Math.max(
         0,

--- a/tests/batch-compress.test.ts
+++ b/tests/batch-compress.test.ts
@@ -22,6 +22,7 @@ mkdirSync(testConfigHome, { recursive: true })
 function buildConfig(): PluginConfig {
     return {
         enabled: true,
+        autoUpdate: true,
         debug: false,
         pruneNotification: "off",
         pruneNotificationType: "chat",
@@ -132,36 +133,39 @@ function buildToolCtx(sessionID: string, state: ReturnType<typeof createSessionS
 test("validateArgs: per-entry topics, no top-level topic — valid", () => {
     const args: CompressRangeToolArgs = {
         content: [
-            { topic: "Exploration", startId: "m1", endId: "m3", summary: "..." },
-            { topic: "Bug Hunt", startId: "m4", endId: "m6", summary: "..." },
+            { topic: "Exploration", startId: "m00001", endId: "m00003", summary: "..." },
+            { topic: "Bug Hunt", startId: "m00004", endId: "m00006", summary: "..." },
         ],
     }
+    assert.doesNotThrow(() => validateArgs(args))
 })
 
 test("validateArgs: top-level topic only, no per-entry topics — valid (backward compat)", () => {
     const args: CompressRangeToolArgs = {
         topic: "Shared topic",
         content: [
-            { startId: "m1", endId: "m3", summary: "..." },
-            { startId: "m4", endId: "m6", summary: "..." },
+            { startId: "m00001", endId: "m00003", summary: "..." },
+            { startId: "m00004", endId: "m00006", summary: "..." },
         ],
     }
+    assert.doesNotThrow(() => validateArgs(args))
 })
 
 test("validateArgs: mixed — some entries have topic, others use fallback", () => {
     const args: CompressRangeToolArgs = {
         topic: "Fallback topic",
         content: [
-            { topic: "Specific", startId: "m1", endId: "m3", summary: "..." },
-            { startId: "m4", endId: "m6", summary: "..." },
+            { topic: "Specific", startId: "m00001", endId: "m00003", summary: "..." },
+            { startId: "m00004", endId: "m00006", summary: "..." },
         ],
     }
+    assert.doesNotThrow(() => validateArgs(args))
 })
 
 test("validateArgs: no topic at all — entry without topic and no fallback", () => {
     const args = {
         content: [
-            { startId: "m1", endId: "m3", summary: "..." },
+            { startId: "m00001", endId: "m00003", summary: "..." },
         ],
     }
     assert.throws(
@@ -173,8 +177,8 @@ test("validateArgs: no topic at all — entry without topic and no fallback", ()
 test("validateArgs: one entry without topic in a no-topical batch", () => {
     const args = {
         content: [
-            { topic: "First", startId: "m1", endId: "m3", summary: "..." },
-            { startId: "m4", endId: "m6", summary: "..." },
+            { topic: "First", startId: "m00001", endId: "m00003", summary: "..." },
+            { startId: "m00004", endId: "m00006", summary: "..." },
         ],
     }
     assert.throws(
@@ -186,7 +190,7 @@ test("validateArgs: one entry without topic in a no-topical batch", () => {
 test("validateArgs: empty top-level topic with entry lacking topic", () => {
     const args = {
         topic: "   ",
-        content: [{ startId: "m1", endId: "m3", summary: "..." }],
+        content: [{ startId: "m00001", endId: "m00003", summary: "..." }],
     }
     assert.throws(
         () => validateArgs(args as CompressRangeToolArgs),

--- a/tests/batch-compress.test.ts
+++ b/tests/batch-compress.test.ts
@@ -1,0 +1,345 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { mkdirSync } from "node:fs"
+import { createCompressRangeTool } from "../lib/compress/range"
+import { validateArgs } from "../lib/compress/range-utils"
+import { createSessionState, type WithParts } from "../lib/state"
+import type { PluginConfig } from "../lib/config"
+import { Logger } from "../lib/logger"
+import type { CompressRangeToolArgs } from "../lib/compress/types"
+
+const testDataHome = join(tmpdir(), `opencode-dcp-tests-${process.pid}`)
+const testConfigHome = join(tmpdir(), `opencode-dcp-config-tests-${process.pid}`)
+
+process.env.XDG_DATA_HOME = testDataHome
+process.env.XDG_CONFIG_HOME = testConfigHome
+
+mkdirSync(testDataHome, { recursive: true })
+mkdirSync(testConfigHome, { recursive: true })
+
+function buildConfig(): PluginConfig {
+    return {
+        enabled: true,
+        debug: false,
+        pruneNotification: "off",
+        pruneNotificationType: "chat",
+        commands: {
+            enabled: true,
+            protectedTools: [],
+        },
+        manualMode: {
+            enabled: false,
+            automaticStrategies: true,
+        },
+        turnProtection: {
+            enabled: false,
+            turns: 4,
+        },
+        experimental: {
+            allowSubAgents: true,
+            customPrompts: false,
+        },
+        protectedFilePatterns: [],
+        compress: {
+            mode: "range",
+            permission: "allow",
+            showCompression: false,
+            maxContextLimit: 150000,
+            minContextLimit: 50000,
+            nudgeFrequency: 5,
+            iterationNudgeThreshold: 15,
+            nudgeForce: "soft",
+            protectedTools: [],
+            protectTags: false,
+            protectUserMessages: false,
+            lastSegmentSoftBlock: false,
+        },
+        strategies: {
+            deduplication: {
+                enabled: true,
+                protectedTools: [],
+            },
+            purgeErrors: {
+                enabled: true,
+                turns: 4,
+                protectedTools: [],
+            },
+        },
+        gc: {
+            algorithm: "truncate",
+            promotionThreshold: 5,
+            maxBlockAge: 15,
+            maxOldGenSummaryLength: 3000,
+            majorGcThresholdPercent: "100%",
+            batchCleanup: { lowThreshold: "60%", highThreshold: "75%", forceThreshold: "90%" },
+        },
+    }
+}
+
+function textPart(messageID: string, sessionID: string, id: string, text: string) {
+    return {
+        id,
+        messageID,
+        sessionID,
+        type: "text" as const,
+        text,
+    }
+}
+
+function buildBatchMessages(sessionID: string): WithParts[] {
+    const messages: WithParts[] = []
+    for (let i = 1; i <= 6; i++) {
+        const isUser = i % 2 === 1
+        messages.push({
+            info: {
+                id: `msg-${i}`,
+                role: isUser ? "user" : "assistant",
+                sessionID,
+                ...(isUser
+                    ? { model: { providerID: "anthropic", modelID: "claude-test" } }
+                    : {}),
+                time: { created: i },
+            } as WithParts["info"],
+            parts: [textPart(`msg-${i}`, sessionID, `part-${i}`, `Message ${i} content`)],
+        })
+    }
+    return messages
+}
+
+function buildToolCtx(sessionID: string, state: ReturnType<typeof createSessionState>) {
+    return {
+        client: {
+            session: {
+                messages: async () => ({ data: buildBatchMessages(sessionID) }),
+                get: async () => ({ data: { parentID: null } }),
+            },
+        },
+        state,
+        logger: new Logger(false),
+        config: buildConfig(),
+        prompts: {
+            reload() {},
+            getRuntimePrompts() {
+                return { compressRange: "", compressMessage: "" }
+            },
+        },
+    } as any
+}
+
+
+test("validateArgs: per-entry topics, no top-level topic — valid", () => {
+    const args: CompressRangeToolArgs = {
+        content: [
+            { topic: "Exploration", startId: "m1", endId: "m3", summary: "..." },
+            { topic: "Bug Hunt", startId: "m4", endId: "m6", summary: "..." },
+        ],
+    }
+})
+
+test("validateArgs: top-level topic only, no per-entry topics — valid (backward compat)", () => {
+    const args: CompressRangeToolArgs = {
+        topic: "Shared topic",
+        content: [
+            { startId: "m1", endId: "m3", summary: "..." },
+            { startId: "m4", endId: "m6", summary: "..." },
+        ],
+    }
+})
+
+test("validateArgs: mixed — some entries have topic, others use fallback", () => {
+    const args: CompressRangeToolArgs = {
+        topic: "Fallback topic",
+        content: [
+            { topic: "Specific", startId: "m1", endId: "m3", summary: "..." },
+            { startId: "m4", endId: "m6", summary: "..." },
+        ],
+    }
+})
+
+test("validateArgs: no topic at all — entry without topic and no fallback", () => {
+    const args = {
+        content: [
+            { startId: "m1", endId: "m3", summary: "..." },
+        ],
+    }
+    assert.throws(
+        () => validateArgs(args as CompressRangeToolArgs),
+        /content\[0\] needs a topic/,
+    )
+})
+
+test("validateArgs: one entry without topic in a no-topical batch", () => {
+    const args = {
+        content: [
+            { topic: "First", startId: "m1", endId: "m3", summary: "..." },
+            { startId: "m4", endId: "m6", summary: "..." },
+        ],
+    }
+    assert.throws(
+        () => validateArgs(args as CompressRangeToolArgs),
+        /content\[1\] needs a topic/,
+    )
+})
+
+test("validateArgs: empty top-level topic with entry lacking topic", () => {
+    const args = {
+        topic: "   ",
+        content: [{ startId: "m1", endId: "m3", summary: "..." }],
+    }
+    assert.throws(
+        () => validateArgs(args as CompressRangeToolArgs),
+        /content\[0\] needs a topic/,
+    )
+})
+
+
+test("batch compress: each entry creates a block with its own topic", async () => {
+    const sessionID = `ses_batch_topics_${Date.now()}`
+    const state = createSessionState()
+    const tool = createCompressRangeTool(buildToolCtx(sessionID, state))
+
+    await tool.execute(
+        {
+            content: [
+                {
+                    topic: "Exploration",
+                    startId: "m00001",
+                    endId: "m00002",
+                    summary: "Explored the codebase structure and module dependencies.",
+                },
+                {
+                    topic: "Bug Hunt",
+                    startId: "m00003",
+                    endId: "m00004",
+                    summary: "Found the root cause of the compression bug.",
+                },
+            ],
+        },
+        {
+            ask: async () => {},
+            metadata: () => {},
+            sessionID,
+            messageID: "msg-compress",
+        } as any,
+    )
+
+    const blocks = [...state.prune.messages.blocksById.values()]
+    assert.equal(blocks.length, 2, "should create 2 blocks")
+    assert.equal(blocks[0]!.topic, "Exploration")
+    assert.equal(blocks[1]!.topic, "Bug Hunt")
+})
+
+test("batch compress: backward compat — entries without topic use top-level", async () => {
+    const sessionID = `ses_batch_fallback_${Date.now()}`
+    const state = createSessionState()
+    const tool = createCompressRangeTool(buildToolCtx(sessionID, state))
+
+    await tool.execute(
+        {
+            topic: "Shared topic",
+            content: [
+                {
+                    startId: "m00001",
+                    endId: "m00002",
+                    summary: "First range summary.",
+                },
+                {
+                    startId: "m00003",
+                    endId: "m00004",
+                    summary: "Second range summary.",
+                },
+            ],
+        },
+        {
+            ask: async () => {},
+            metadata: () => {},
+            sessionID,
+            messageID: "msg-compress",
+        } as any,
+    )
+
+    const blocks = [...state.prune.messages.blocksById.values()]
+    assert.equal(blocks.length, 2, "should create 2 blocks")
+    assert.equal(blocks[0]!.topic, "Shared topic")
+    assert.equal(blocks[1]!.topic, "Shared topic")
+})
+
+test("batch compress: mixed — entry topic overrides top-level fallback", async () => {
+    const sessionID = `ses_batch_mixed_${Date.now()}`
+    const state = createSessionState()
+    const tool = createCompressRangeTool(buildToolCtx(sessionID, state))
+
+    await tool.execute(
+        {
+            topic: "Fallback",
+            content: [
+                {
+                    topic: "Override",
+                    startId: "m00001",
+                    endId: "m00002",
+                    summary: "First range with explicit topic.",
+                },
+                {
+                    startId: "m00003",
+                    endId: "m00004",
+                    summary: "Second range using fallback.",
+                },
+            ],
+        },
+        {
+            ask: async () => {},
+            metadata: () => {},
+            sessionID,
+            messageID: "msg-compress",
+        } as any,
+    )
+
+    const blocks = [...state.prune.messages.blocksById.values()]
+    assert.equal(blocks.length, 2, "should create 2 blocks")
+    assert.equal(blocks[0]!.topic, "Override", "entry topic should override top-level")
+    assert.equal(blocks[1]!.topic, "Fallback", "entry without topic should use fallback")
+})
+
+test("batch compress: no top-level topic, all entries have own — blocks get entry topics", async () => {
+    const sessionID = `ses_batch_notopical_${Date.now()}`
+    const state = createSessionState()
+    const tool = createCompressRangeTool(buildToolCtx(sessionID, state))
+
+    await tool.execute(
+        {
+            content: [
+                {
+                    topic: "Auth",
+                    startId: "m00001",
+                    endId: "m00002",
+                    summary: "Auth implementation details.",
+                },
+                {
+                    topic: "Deploy",
+                    startId: "m00003",
+                    endId: "m00004",
+                    summary: "Deployment configuration.",
+                },
+                {
+                    topic: "Test",
+                    startId: "m00005",
+                    endId: "m00006",
+                    summary: "Test suite results.",
+                },
+            ],
+        },
+        {
+            ask: async () => {},
+            metadata: () => {},
+            sessionID,
+            messageID: "msg-compress",
+        } as any,
+    )
+
+    const blocks = [...state.prune.messages.blocksById.values()]
+    assert.equal(blocks.length, 3, "should create 3 blocks")
+    const topics = blocks.map((b) => b.topic)
+    assert.deepEqual(topics, ["Auth", "Deploy", "Test"])
+})


### PR DESCRIPTION
## Summary

Allow each `content` entry in a `compress` call to carry its own optional `topic`. The top-level `topic` becomes a fallback. This lets the model compress multiple unrelated ranges in a single call — each under its appropriate topic.

**Problem solved**: When the recommendation list shows many ranges, the model previously had to either:
1. Compress only one topic (under-compression — doesn't know what else to compress after the first call)
2. Force all unrelated ranges under one shared topic (quality degradation)

**Now**:
```
compress({ content: [
  { topic: "Auth", startId: "m10", endId: "m50", summary: "..." },
  { topic: "Deploy", startId: "m60", endId: "m80", summary: "..." },
  { topic: "Test", startId: "m90", endId: "m110", summary: "..." },
]})
```

Each entry → its own block with its own topic, sharing one `runId`.

## Changes

- `lib/compress/types.ts` — `CompressRangeEntry.topic?`, `CompressRangeToolArgs.topic?` (optional), `CompressionStateInput.batchTopic` → `string | undefined`
- `lib/compress/range.ts` — schema (per-entry optional topic), execute (topic = `entry.topic ?? input.topic`)
- `lib/compress/range-utils.ts` — `validateArgs` (entry needs own or fallback), `resolveRanges` (preserve topic)
- `lib/state/rebuild.ts` — per-entry topic resolution in state rebuild
- `lib/prompts/compress-range.ts` — BATCHING section updated with per-entry topic guidance + example

## Backward Compatibility

Fully backward compatible. Existing calls with top-level `topic` work unchanged — entries without their own `topic` use the top-level fallback.

## Verification

- TypeScript: 0 errors
- Tests: 760/760 pass (750 existing + 10 new)
- `tests/batch-compress.test.ts`: 6 validation + 4 integration tests

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)