### PR TITLE
fix: protected label only shows triggering tools, not all tools in message

### DIFF
--- a/devlog/2026-07-18_protected-label-fix/REQ.md
+++ b/devlog/2026-07-18_protected-label-fix/REQ.md
@@ -1,0 +1,36 @@
+# REQ: Protected Label Fix — Only Show Triggering Tools
+
+## Problem
+
+`acp_status` and nudge recommendations display `[PROTECTED: read, grep — not compressible]`
+when only `read` is in `compress.protectedTools`. The label lists ALL tool names in a
+protected message, not just the ones that triggered protection. This causes:
+
+1. **User confusion**: users think `grep` is also protected when it's not
+2. **Inflated protection scope**: tools like `grep`/`bash` that happen to share a message
+   with a protected tool appear "protected" in the label
+
+## Root Cause
+
+`buildCompressibleRanges` (`lib/messages/inject/utils.ts:778-788`):
+```typescript
+const tools = new Set<string>()
+for (const part of msg.parts || []) {
+    // ...
+    const toolName = (part as any)?.tool
+    if (toolName) tools.add(toolName)  // ← adds ALL tools, not just protected ones
+}
+```
+
+## Fix
+
+Only collect tool names that actually trigger protection:
+- Match against `protectedTools` via `isToolNameProtected()`
+- Match against `protectedFilePatterns` via `isFilePathProtected(getFilePathsFromParameters(...))`
+
+## Acceptance Criteria
+
+- [x] `[PROTECTED: ...]` label only shows tools that triggered protection
+- [x] Non-protected tools in the same message (e.g., `grep` alongside `read`) not listed
+- [x] All existing tests pass
+- [x] New test covers the mixed-tools scenario

--- a/devlog/2026-07-18_protected-label-fix/WORKLOG.md
+++ b/devlog/2026-07-18_protected-label-fix/WORKLOG.md
@@ -1,0 +1,20 @@
+# WORKLOG: Protected Label Fix
+
+## Changes
+
+### `lib/messages/inject/utils.ts`
+- Added imports: `isToolNameProtected`, `getFilePathsFromParameters`, `isFilePathProtected` from `../../protected-patterns`
+- Fixed `buildCompressibleRanges` protected message loop (lines 779-800):
+  - **Before**: `if (toolName) tools.add(toolName)` — collects ALL tool names
+  - **After**: only adds tool names that match `protectedTools` (via `isToolNameProtected`) or `protectedFilePatterns` (via `isFilePathProtected`)
+
+### `tests/protection-aware-stats.test.ts`
+- Added test: "buildCompressibleRanges only lists tools that trigger protection, not all tools in message"
+  - Message with `skill` + `grep` + `read` tools, `protectedTools = ["skill"]`
+  - Asserts `tools` contains `skill`, does NOT contain `grep` or `read`
+
+## Verification
+
+- TypeScript: 0 errors
+- Tests: 751/751 pass (750 existing + 1 new)
+- Node v25.9.0

--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -1,6 +1,7 @@
 import type { SessionState, WithParts } from "../../state"
 import type { PluginConfig } from "../../config"
 import { messageContainsProtectedTool } from "../../compress/protected-content"
+import { isToolNameProtected, getFilePathsFromParameters, isFilePathProtected } from "../../protected-patterns"
 import {
     appendGuidanceToDcpTag,
     buildCompressedBlockGuidance,
@@ -782,7 +783,20 @@ export function buildCompressibleRanges(
                 } else if (part.type !== "text" && part.type !== "reasoning") {
                     tokens += Math.round(JSON.stringify(part).length / 4)
                     const toolName = (part as any)?.tool
-                    if (toolName) tools.add(toolName)
+                    const callID = (part as any)?.callID
+                    if (toolName && callID) {
+                        if (isToolNameProtected(toolName, protectedTools)) {
+                            tools.add(toolName)
+                        } else if (protectedFilePatterns.length > 0) {
+                            const filePaths = getFilePathsFromParameters(
+                                toolName,
+                                (part as any)?.state?.input,
+                            )
+                            if (isFilePathProtected(filePaths, protectedFilePatterns)) {
+                                tools.add(toolName)
+                            }
+                        }
+                    }
                 }
             }
             protectedMsgInfo.push({ ref, refNum: rn, tokens, tools: [...tools] })

--- a/tests/protection-aware-stats.test.ts
+++ b/tests/protection-aware-stats.test.ts
@@ -55,6 +55,27 @@ test("buildCompressibleRanges excludes messages with protected tools", () => {
     assert.ok(result.protected[0].tools.includes("skill"), "protected range lists tool name")
 })
 
+test("buildCompressibleRanges only lists tools that trigger protection, not all tools in message", () => {
+    const state = createSessionState()
+    const messages = [
+        makeMsg("m1", "user", "hello"),
+        makeMsg("m2", "assistant", "mixed tools", [
+            toolPart("t1", "skill"),
+            toolPart("t2", "grep", { pattern: "foo" }),
+            toolPart("t3", "read", { filePath: "src/file.ts" }),
+        ]),
+        makeMsg("m3", "assistant", "normal text"),
+    ]
+    setupRefs(state, messages)
+
+    const result = buildCompressibleRanges(messages, state, ["skill"])
+    assert.ok(result.protected.length >= 1, "message protected by skill")
+    const tools = result.protected[0].tools
+    assert.ok(tools.includes("skill"), "protected range lists the triggering tool")
+    assert.ok(!tools.includes("grep"), "non-protected grep not listed")
+    assert.ok(!tools.includes("read"), "non-protected read not listed")
+})
+
 test("buildCompressibleRanges includes all messages when no protected tools configured", () => {
     const state = createSessionState()
     const messages = [


### PR DESCRIPTION
## Summary

- `[PROTECTED: read, grep — not compressible]` label was showing ALL tool names in a protected message, not just the ones that triggered protection
- Fixed `buildCompressibleRanges` to only collect tools that match `protectedTools` (via `isToolNameProtected`) or `protectedFilePatterns` (via `isFilePathProtected`)
- Now `[PROTECTED: read, grep]` → `[PROTECTED: read]` when only `read` is in `protectedTools`

## Problem

User reported confusion: `grep` appeared in the protection list but was not configured in `compress.protectedTools`. Root cause: the `tools` set in `buildCompressibleRanges` collected ALL tool names from protected messages, including non-protected tools that happened to share the message.

## Fix

**`lib/messages/inject/utils.ts`**: Only add tool names that actually trigger protection:
- `isToolNameProtected(toolName, protectedTools)` — tool name match
- `isFilePathProtected(getFilePathsFromParameters(...), protectedFilePatterns)` — file pattern match

## Test

New test in `tests/protection-aware-stats.test.ts`: message with `skill` + `grep` + `read`, `protectedTools = ["skill"]` → only `skill` in protected tools list.

751/751 tests pass. TypeScript 0 errors.