### PR TITLE
fix: suppress nudge when all content is protected

### DIFF
--- a/devlog/2026-07-18_suppress-nudge-no-compressible/REQ.md
+++ b/devlog/2026-07-18_suppress-nudge-no-compressible/REQ.md
@@ -1,0 +1,25 @@
+# REQ: Suppress Nudge When All Content Is Protected
+
+## Problem
+
+When a user configures high-frequency tools (e.g., `read`) in `compress.protectedTools`,
+most or all context becomes non-compressible. The nudge system still fires based on total
+token growth (including protected content), creating false-positive nudges with nothing to
+compress — wasting a model turn.
+
+PR #147's `filterSuppressed` only handles the case where compressible ranges exist but are
+filtered out. When `compressible.length === 0` (all protected), `filterSuppressed = false`,
+and the nudge fires uselessly.
+
+## Fix
+
+Add `allProtected` check: when `compressible.length === 0 && protected.length > 0`, suppress
+the nudge (emergency override still bypasses). This distinguishes "all protected" from
+"no refs assigned yet" (where both arrays are empty).
+
+## Acceptance Criteria
+
+- [x] Nudge suppressed when all content is protected
+- [x] Emergency override (98% context) still fires when all content is protected
+- [x] Existing `filterSuppressed` behavior unchanged
+- [x] All tests pass

--- a/devlog/2026-07-18_suppress-nudge-no-compressible/WORKLOG.md
+++ b/devlog/2026-07-18_suppress-nudge-no-compressible/WORKLOG.md
@@ -1,0 +1,18 @@
+# WORKLOG: Suppress Nudge When All Content Is Protected
+
+## Changes
+
+### `lib/messages/inject/inject.ts`
+- Added `allProtected` check: `compressible.length === 0 && protected.length > 0`
+- Combined with existing `filterSuppressed` into `nothingToCompress`
+- `shouldInject` now suppresses when `nothingToCompress` (unless emergency override)
+
+### `tests/inject.test.ts`
+- Added test: "nudge suppressed when all content is protected (nothing to compress)"
+- Added test: "emergency override fires even when all content is protected"
+
+## Verification
+
+- TypeScript: 0 errors
+- Tests: 752/752 pass (750 existing + 2 new)
+- Node v25.9.0

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -349,13 +349,10 @@ export const injectCompressNudges = (
         logger.debug(lines.join("\n"))
     }
 
-    // Skip soft nudges when the filter suppressed all ranges — injecting
-    // "go compress" with an empty recommendation list wastes context and
-    // confuses the model. Emergency overrides (maxLimit) always inject.
-    // When there are no compressible ranges at all (e.g. no refs assigned yet),
-    // don't suppress — that's an edge case, not a filter decision.
     const filterSuppressed = contextRanges.compressible.length > 0 && !hasRecommendations
-    const shouldInject = nudgeAllowed && (!filterSuppressed || emergencyOverride)
+    const allProtected = contextRanges.compressible.length === 0 && contextRanges.protected.length > 0
+    const nothingToCompress = filterSuppressed || allProtected
+    const shouldInject = nudgeAllowed && (!nothingToCompress || emergencyOverride)
 
     state.nudges.shouldInjectThisTurn = shouldInject
 

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -762,6 +762,69 @@ test("nudge suppressed when filter has no recommendations (all ranges below last
     assert.ok(!injected.includes("Context limit reached"), "no emergency alert")
 })
 
+test("nudge suppressed when all content is protected (nothing to compress)", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 200_000
+    state.messageIds.byRawId.set("u1", "m00001")
+    state.messageIds.byRawId.set("a1", "m00002")
+
+    const config = buildConfig()
+    config.compress.protectedTools = ["skill"]
+    config.compress.maxContextLimit = 500_000
+    config.compress.minContextLimit = 200_000
+
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 55_000 }, [
+            {
+                id: "skill-part", messageID: "a1", sessionID: SID,
+                type: "tool" as const, tool: "skill", callID: "skill-call",
+                state: { status: "completed" as const, input: {}, output: "x".repeat(80_000) },
+            },
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, messages, {} as any)
+
+    assert.equal(
+        state.nudges.shouldInjectThisTurn,
+        false,
+        "55K growth triggers nudgeAllowed but ALL tool output is protected (skill) → nothing to compress → nudge suppressed",
+    )
+})
+
+test("emergency override fires even when all content is protected", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 980_000
+    state.nudges.lastNudgeShownTokens = 980_000
+    state.messageIds.byRawId.set("u1", "m00001")
+    state.messageIds.byRawId.set("a1", "m00002")
+
+    const config = buildConfig()
+    config.compress.protectedTools = ["skill"]
+    config.compress.maxContextLimit = 500_000
+    config.compress.minContextLimit = 200_000
+
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 970_000, output: 10_000 }, [
+            {
+                id: "skill-part", messageID: "a1", sessionID: SID,
+                type: "tool" as const, tool: "skill", callID: "skill-call",
+                state: { status: "completed" as const, input: {}, output: "x".repeat(40_000) },
+            },
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, messages, {} as any)
+
+    assert.equal(
+        state.nudges.shouldInjectThisTurn,
+        true,
+        "98% emergency override fires even when all content is protected",
+    )
+})
+
 test("emergency override fires even when filter has no recommendations", () => {
     // Context at 98%+ with small tool output (< floor) → emergency bypasses filter
     const state = createSessionState()


### PR DESCRIPTION
## Summary

When all context is protected (e.g., user puts `read` in `protectedTools` and all messages contain `read` calls), the nudge still fires uselessly — model receives "go compress" but has nothing to compress.

PR #147's `filterSuppressed` only handles the case where compressible ranges exist but are filtered out. This PR adds the missing case: `compressible.length === 0 && protected.length > 0` → all protected → suppress nudge.

Emergency override (98% context) still fires regardless.

## Fix

**`lib/messages/inject/inject.ts`**:
```typescript
const allProtected = contextRanges.compressible.length === 0 && contextRanges.protected.length > 0
const nothingToCompress = filterSuppressed || allProtected
const shouldInject = nudgeAllowed && (!nothingToCompress || emergencyOverride)
```

The `protected.length > 0` check distinguishes "all protected" from "no refs assigned yet" (both arrays empty — edge case, not suppression).

## Tests

- "nudge suppressed when all content is protected (nothing to compress)"
- "emergency override fires even when all content is protected"

752/752 tests pass.