### PR TITLE
fix: discrete 5% check intervals when nudge suppressed

### DIFF
--- a/devlog/2026-07-18_compressible-growth/REQ.md
+++ b/devlog/2026-07-18_compressible-growth/REQ.md
@@ -1,0 +1,41 @@
+# REQ: Discrete 5% Check Intervals When Nudge Suppressed
+
+## Problem
+
+When the nudge is suppressed (nothing to compress — all protected or compressible too small),
+the baseline (`lastPerMessageNudgeTokens`) is NOT advanced. This means:
+- Total growth keeps accumulating from the original baseline
+- `nudgeAllowed = true` on EVERY subsequent turn (growth always above threshold)
+- The suppression check runs every turn unnecessarily
+- Wasted computation and potential for confusion
+
+## Fix
+
+When the nudge is allowed but suppressed (`nothingToCompress && !emergencyOverride`):
+1. Advance `lastPerMessageNudgeTokens` to `currentTokens`
+2. Clear `lastNudgeShownTokens` (reset pending nudge → full threshold for next check)
+
+This creates discrete 5% check intervals:
+- Turn 1: growth=55K → suppressed → baseline advances to currentTokens
+- Turn 2: growth=5K (from advanced baseline) → below threshold → no check
+- Turn 3: growth=50K (from advanced baseline) → check fires again
+
+The compressible validation (`filterRecommendedRanges`) and suppression logic (`filterSuppressed`,
+`allProtected`) remain unchanged — they already correctly identify "nothing to compress".
+
+## Design Discussion
+
+User @dog proposed: "每增长 5% 的时候去做检测，检测的时候测试一下它里面实际可压缩的是不是接近于 5%"
+
+Analysis showed the compressible validation already exists (`filterRecommendedRanges` with 5%
+threshold). The missing piece was baseline advancement — without it, the check fires every turn
+instead of at discrete 5% intervals.
+
+## Acceptance Criteria
+
+- [x] Baseline advances when nudge suppressed (all protected)
+- [x] Baseline advances when nudge suppressed (filter suppressed — compressible too small)
+- [x] Pending nudge cleared on suppression (threshold resets to full)
+- [x] Next check fires at +5% from advanced baseline, not every turn
+- [x] Emergency override unaffected
+- [x] All tests pass

--- a/devlog/2026-07-18_compressible-growth/WORKLOG.md
+++ b/devlog/2026-07-18_compressible-growth/WORKLOG.md
@@ -1,0 +1,26 @@
+# WORKLOG: Discrete 5% Check Intervals When Nudge Suppressed
+
+## Changes
+
+### `lib/messages/inject/inject.ts`
+Added baseline advancement when nudge is suppressed (2 lines):
+```typescript
+if (nudgeAllowed && nothingToCompress && !emergencyOverride && currentTokens !== undefined) {
+    state.nudges.lastPerMessageNudgeTokens = currentTokens
+    state.nudges.lastNudgeShownTokens = undefined
+}
+```
+
+Placed after `shouldInject` determination, before `shouldInjectThisTurn` assignment.
+
+### `tests/inject.test.ts`
+Added 3 tests:
+1. "baseline advances when nudge suppressed — discrete 5% intervals (all protected)" — two-turn test verifying baseline advances and next check respects +5% interval
+2. "baseline advances when filter suppressed — compressible too small" — filter suppression also advances baseline
+3. "pending nudge cleared when suppressed — threshold resets to full" — `lastNudgeShownTokens` cleared so threshold returns to full (not halved)
+
+## Verification
+
+- TypeScript: 0 errors
+- Tests: 755/755 pass (752 existing + 3 new)
+- Node v25.9.0

--- a/devlog/2026-07-18_suppress-nudge-no-compressible/REQ.md
+++ b/devlog/2026-07-18_suppress-nudge-no-compressible/REQ.md
@@ -1,0 +1,25 @@
+# REQ: Suppress Nudge When All Content Is Protected
+
+## Problem
+
+When a user configures high-frequency tools (e.g., `read`) in `compress.protectedTools`,
+most or all context becomes non-compressible. The nudge system still fires based on total
+token growth (including protected content), creating false-positive nudges with nothing to
+compress — wasting a model turn.
+
+PR #147's `filterSuppressed` only handles the case where compressible ranges exist but are
+filtered out. When `compressible.length === 0` (all protected), `filterSuppressed = false`,
+and the nudge fires uselessly.
+
+## Fix
+
+Add `allProtected` check: when `compressible.length === 0 && protected.length > 0`, suppress
+the nudge (emergency override still bypasses). This distinguishes "all protected" from
+"no refs assigned yet" (where both arrays are empty).
+
+## Acceptance Criteria
+
+- [x] Nudge suppressed when all content is protected
+- [x] Emergency override (98% context) still fires when all content is protected
+- [x] Existing `filterSuppressed` behavior unchanged
+- [x] All tests pass

--- a/devlog/2026-07-18_suppress-nudge-no-compressible/WORKLOG.md
+++ b/devlog/2026-07-18_suppress-nudge-no-compressible/WORKLOG.md
@@ -1,0 +1,18 @@
+# WORKLOG: Suppress Nudge When All Content Is Protected
+
+## Changes
+
+### `lib/messages/inject/inject.ts`
+- Added `allProtected` check: `compressible.length === 0 && protected.length > 0`
+- Combined with existing `filterSuppressed` into `nothingToCompress`
+- `shouldInject` now suppresses when `nothingToCompress` (unless emergency override)
+
+### `tests/inject.test.ts`
+- Added test: "nudge suppressed when all content is protected (nothing to compress)"
+- Added test: "emergency override fires even when all content is protected"
+
+## Verification
+
+- TypeScript: 0 errors
+- Tests: 752/752 pass (750 existing + 2 new)
+- Node v25.9.0

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -354,6 +354,11 @@ export const injectCompressNudges = (
     const nothingToCompress = filterSuppressed || allProtected
     const shouldInject = nudgeAllowed && (!nothingToCompress || emergencyOverride)
 
+    if (nudgeAllowed && nothingToCompress && !emergencyOverride && currentTokens !== undefined) {
+        state.nudges.lastPerMessageNudgeTokens = currentTokens
+        state.nudges.lastNudgeShownTokens = undefined
+    }
+
     state.nudges.shouldInjectThisTurn = shouldInject
 
     let tipsText: string | null = null

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -349,13 +349,10 @@ export const injectCompressNudges = (
         logger.debug(lines.join("\n"))
     }
 
-    // Skip soft nudges when the filter suppressed all ranges — injecting
-    // "go compress" with an empty recommendation list wastes context and
-    // confuses the model. Emergency overrides (maxLimit) always inject.
-    // When there are no compressible ranges at all (e.g. no refs assigned yet),
-    // don't suppress — that's an edge case, not a filter decision.
     const filterSuppressed = contextRanges.compressible.length > 0 && !hasRecommendations
-    const shouldInject = nudgeAllowed && (!filterSuppressed || emergencyOverride)
+    const allProtected = contextRanges.compressible.length === 0 && contextRanges.protected.length > 0
+    const nothingToCompress = filterSuppressed || allProtected
+    const shouldInject = nudgeAllowed && (!nothingToCompress || emergencyOverride)
 
     state.nudges.shouldInjectThisTurn = shouldInject
 

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -762,6 +762,69 @@ test("nudge suppressed when filter has no recommendations (all ranges below last
     assert.ok(!injected.includes("Context limit reached"), "no emergency alert")
 })
 
+test("nudge suppressed when all content is protected (nothing to compress)", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 200_000
+    state.messageIds.byRawId.set("u1", "m00001")
+    state.messageIds.byRawId.set("a1", "m00002")
+
+    const config = buildConfig()
+    config.compress.protectedTools = ["skill"]
+    config.compress.maxContextLimit = 500_000
+    config.compress.minContextLimit = 200_000
+
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 55_000 }, [
+            {
+                id: "skill-part", messageID: "a1", sessionID: SID,
+                type: "tool" as const, tool: "skill", callID: "skill-call",
+                state: { status: "completed" as const, input: {}, output: "x".repeat(80_000) },
+            },
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, messages, {} as any)
+
+    assert.equal(
+        state.nudges.shouldInjectThisTurn,
+        false,
+        "55K growth triggers nudgeAllowed but ALL tool output is protected (skill) → nothing to compress → nudge suppressed",
+    )
+})
+
+test("emergency override fires even when all content is protected", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 980_000
+    state.nudges.lastNudgeShownTokens = 980_000
+    state.messageIds.byRawId.set("u1", "m00001")
+    state.messageIds.byRawId.set("a1", "m00002")
+
+    const config = buildConfig()
+    config.compress.protectedTools = ["skill"]
+    config.compress.maxContextLimit = 500_000
+    config.compress.minContextLimit = 200_000
+
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 970_000, output: 10_000 }, [
+            {
+                id: "skill-part", messageID: "a1", sessionID: SID,
+                type: "tool" as const, tool: "skill", callID: "skill-call",
+                state: { status: "completed" as const, input: {}, output: "x".repeat(40_000) },
+            },
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, messages, {} as any)
+
+    assert.equal(
+        state.nudges.shouldInjectThisTurn,
+        true,
+        "98% emergency override fires even when all content is protected",
+    )
+})
+
 test("emergency override fires even when filter has no recommendations", () => {
     // Context at 98%+ with small tool output (< floor) → emergency bypasses filter
     const state = createSessionState()

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -766,8 +766,7 @@ test("nudge suppressed when all content is protected (nothing to compress)", () 
     const state = createSessionState()
     state.modelContextLimit = 1_000_000
     state.nudges.lastPerMessageNudgeTokens = 200_000
-    state.messageIds.byRawId.set("u1", "m00001")
-    state.messageIds.byRawId.set("a1", "m00002")
+    state.messageIds.byRawId.set("a1", "m00001")
 
     const config = buildConfig()
     config.compress.protectedTools = ["skill"]
@@ -775,7 +774,6 @@ test("nudge suppressed when all content is protected (nothing to compress)", () 
     config.compress.minContextLimit = 200_000
 
     const messages: WithParts[] = [
-        userMsg("u1", "hello"),
         assistantMsgWithTokens("a1", "done", { input: 200_000, output: 55_000 }, [
             {
                 id: "skill-part", messageID: "a1", sessionID: SID,
@@ -798,8 +796,7 @@ test("emergency override fires even when all content is protected", () => {
     state.modelContextLimit = 1_000_000
     state.nudges.lastPerMessageNudgeTokens = 980_000
     state.nudges.lastNudgeShownTokens = 980_000
-    state.messageIds.byRawId.set("u1", "m00001")
-    state.messageIds.byRawId.set("a1", "m00002")
+    state.messageIds.byRawId.set("a1", "m00001")
 
     const config = buildConfig()
     config.compress.protectedTools = ["skill"]
@@ -807,7 +804,6 @@ test("emergency override fires even when all content is protected", () => {
     config.compress.minContextLimit = 200_000
 
     const messages: WithParts[] = [
-        userMsg("u1", "hello"),
         assistantMsgWithTokens("a1", "done", { input: 970_000, output: 10_000 }, [
             {
                 id: "skill-part", messageID: "a1", sessionID: SID,
@@ -828,8 +824,7 @@ test("emergency override fires even when all content is protected", () => {
 test("baseline advances when nudge suppressed — discrete 5% intervals (all protected)", () => {
     const state = createSessionState()
     state.modelContextLimit = 1_000_000
-    state.messageIds.byRawId.set("u1", "m00001")
-    state.messageIds.byRawId.set("a1", "m00002")
+    state.messageIds.byRawId.set("a1", "m00001")
 
     const config = buildConfig()
     config.compress.protectedTools = ["skill"]
@@ -837,7 +832,6 @@ test("baseline advances when nudge suppressed — discrete 5% intervals (all pro
     config.compress.minContextLimit = 200_000
 
     const turn1: WithParts[] = [
-        userMsg("u1", "hello"),
         assistantMsgWithTokens("a1", "done", { input: 200_000, output: 55_000 }, [
             {
                 id: "skill-part", messageID: "a1", sessionID: SID,
@@ -855,10 +849,8 @@ test("baseline advances when nudge suppressed — discrete 5% intervals (all pro
         "baseline advanced to currentTokens (200K input + 55K output)",
     )
 
-    state.messageIds.byRawId.set("u2", "m00003")
-    state.messageIds.byRawId.set("a2", "m00004")
+    state.messageIds.byRawId.set("a2", "m00002")
     const turn2: WithParts[] = [
-        userMsg("u2", "next"),
         assistantMsgWithTokens("a2", "response", { input: 253_000, output: 7_000 }, [
             {
                 id: "skill-part2", messageID: "a2", sessionID: SID,
@@ -909,8 +901,7 @@ test("baseline advances when filter suppressed — compressible too small", () =
 test("pending nudge cleared when suppressed — threshold resets to full", () => {
     const state = createSessionState()
     state.modelContextLimit = 1_000_000
-    state.messageIds.byRawId.set("u1", "m00001")
-    state.messageIds.byRawId.set("a1", "m00002")
+    state.messageIds.byRawId.set("a1", "m00001")
 
     const config = buildConfig()
     config.compress.protectedTools = ["skill"]
@@ -920,7 +911,6 @@ test("pending nudge cleared when suppressed — threshold resets to full", () =>
     state.nudges.lastPerMessageNudgeTokens = 200_000
     state.nudges.lastNudgeShownTokens = 200_000
     const turn1: WithParts[] = [
-        userMsg("u1", "hello"),
         assistantMsgWithTokens("a1", "done", { input: 225_000, output: 30_000 }, [
             {
                 id: "skill-part", messageID: "a1", sessionID: SID,
@@ -941,6 +931,46 @@ test("pending nudge cleared when suppressed — threshold resets to full", () =>
         255_000,
         "baseline advanced to currentTokens",
     )
+})
+
+test("voluntary compress after suppression does not trigger proportional baseline adjustment", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.messageIds.byRawId.set("a1", "m00001")
+
+    const config = buildConfig()
+    config.compress.protectedTools = ["skill"]
+    config.compress.maxContextLimit = 500_000
+    config.compress.minContextLimit = 200_000
+
+    state.nudges.lastPerMessageNudgeTokens = 200_000
+    const turn1: WithParts[] = [
+        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 55_000 }, [
+            {
+                id: "skill-part", messageID: "a1", sessionID: SID,
+                type: "tool" as const, tool: "skill", callID: "skill-call",
+                state: { status: "completed" as const, input: {}, output: "x".repeat(80_000) },
+            },
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, turn1, {} as any)
+    assert.equal(state.nudges.shouldInjectThisTurn, false, "turn 1: all protected → suppressed")
+    assert.equal(state.nudges.lastPerMessageNudgeTokens, 255_000, "turn 1: baseline advanced")
+    assert.equal(state.nudges.lastNudgeShownTokens, undefined, "turn 1: pending nudge cleared")
+
+    state.messageIds.byRawId.set("a2", "m00002")
+    const turn2: WithParts[] = [
+        assistantMsgWithTokens("a2", "compressed", { input: 253_000, output: 2_000 }, [
+            compressToolPart("c1", "compressed"),
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, turn2, {} as any)
+    assert.equal(
+        state.nudges.lastPerMessageNudgeTokens,
+        255_000,
+        "turn 2: voluntary compress (wasNudgeTriggered=false) keeps suppression baseline — no proportional adjustment",
+    )
+    assert.equal(state.nudges.compressBaselineSet, false, "lock not set for voluntary compress")
 })
 
 test("emergency override fires even when filter has no recommendations", () => {

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -825,6 +825,124 @@ test("emergency override fires even when all content is protected", () => {
     )
 })
 
+test("baseline advances when nudge suppressed — discrete 5% intervals (all protected)", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.messageIds.byRawId.set("u1", "m00001")
+    state.messageIds.byRawId.set("a1", "m00002")
+
+    const config = buildConfig()
+    config.compress.protectedTools = ["skill"]
+    config.compress.maxContextLimit = 500_000
+    config.compress.minContextLimit = 200_000
+
+    const turn1: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 55_000 }, [
+            {
+                id: "skill-part", messageID: "a1", sessionID: SID,
+                type: "tool" as const, tool: "skill", callID: "skill-call",
+                state: { status: "completed" as const, input: {}, output: "x".repeat(80_000) },
+            },
+        ]),
+    ]
+    state.nudges.lastPerMessageNudgeTokens = 200_000
+    injectCompressNudges(state, config, logger, turn1, {} as any)
+    assert.equal(state.nudges.shouldInjectThisTurn, false, "55K growth but all protected → suppressed")
+    assert.equal(
+        state.nudges.lastPerMessageNudgeTokens,
+        255_000,
+        "baseline advanced to currentTokens (200K input + 55K output)",
+    )
+
+    state.messageIds.byRawId.set("u2", "m00003")
+    state.messageIds.byRawId.set("a2", "m00004")
+    const turn2: WithParts[] = [
+        userMsg("u2", "next"),
+        assistantMsgWithTokens("a2", "response", { input: 253_000, output: 7_000 }, [
+            {
+                id: "skill-part2", messageID: "a2", sessionID: SID,
+                type: "tool" as const, tool: "skill", callID: "skill-call2",
+                state: { status: "completed" as const, input: {}, output: "x".repeat(10_000) },
+            },
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, turn2, {} as any)
+    assert.equal(
+        state.nudges.shouldInjectThisTurn,
+        false,
+        "5K growth from advanced baseline (260K - 255K) < 50K threshold → no nudge",
+    )
+    assert.equal(
+        state.nudges.lastPerMessageNudgeTokens,
+        255_000,
+        "baseline NOT advanced when nudgeAllowed is false (growth below threshold)",
+    )
+})
+
+test("baseline advances when filter suppressed — compressible too small", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.messageIds.byRawId.set("u1", "m00001")
+    state.messageIds.byRawId.set("a1", "m00002")
+
+    const config = buildConfig()
+    config.compress.maxContextLimit = 500_000
+    config.compress.minContextLimit = 200_000
+
+    state.nudges.lastPerMessageNudgeTokens = 200_000
+    const turn1: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 200_000, output: 55_000 }, [
+            toolPart("c1", "x".repeat(80_000)),
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, turn1, {} as any)
+    assert.equal(state.nudges.shouldInjectThisTurn, false, "55K growth but 20K compressible < 100K floor → suppressed")
+    assert.equal(
+        state.nudges.lastPerMessageNudgeTokens,
+        255_000,
+        "baseline advanced when filter suppressed (too small to recommend)",
+    )
+})
+
+test("pending nudge cleared when suppressed — threshold resets to full", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.messageIds.byRawId.set("u1", "m00001")
+    state.messageIds.byRawId.set("a1", "m00002")
+
+    const config = buildConfig()
+    config.compress.protectedTools = ["skill"]
+    config.compress.maxContextLimit = 500_000
+    config.compress.minContextLimit = 200_000
+
+    state.nudges.lastPerMessageNudgeTokens = 200_000
+    state.nudges.lastNudgeShownTokens = 200_000
+    const turn1: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 225_000, output: 30_000 }, [
+            {
+                id: "skill-part", messageID: "a1", sessionID: SID,
+                type: "tool" as const, tool: "skill", callID: "skill-call",
+                state: { status: "completed" as const, input: {}, output: "x".repeat(80_000) },
+            },
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, turn1, {} as any)
+    assert.equal(state.nudges.shouldInjectThisTurn, false, "nudge suppressed — all protected")
+    assert.equal(
+        state.nudges.lastNudgeShownTokens,
+        undefined,
+        "pending nudge cleared — threshold resets to full (not halved) for next check",
+    )
+    assert.equal(
+        state.nudges.lastPerMessageNudgeTokens,
+        255_000,
+        "baseline advanced to currentTokens",
+    )
+})
+
 test("emergency override fires even when filter has no recommendations", () => {
     // Context at 98%+ with small tool output (< floor) → emergency bypasses filter
     const state = createSessionState()


### PR DESCRIPTION
## Summary

When the nudge is triggered but suppressed (nothing to compress — all protected or compressible too small), the baseline was NOT advanced. This caused the check to fire **every turn** (growth always above threshold from original baseline), wasting computation.

This PR advances the baseline to `currentTokens` when the nudge is suppressed, creating **discrete 5% check intervals**.

## Discussion

User @dog proposed: check compressible growth at each 5% interval, skip if too small.

Analysis revealed the compressible validation already exists (`filterRecommendedRanges` with 5% threshold). The missing piece was baseline advancement — without it, the 5% trigger fires every turn instead of at discrete intervals.

## Fix

**`lib/messages/inject/inject.ts`** (2 lines):
```typescript
if (nudgeAllowed && nothingToCompress && !emergencyOverride && currentTokens !== undefined) {
    state.nudges.lastPerMessageNudgeTokens = currentTokens
    state.nudges.lastNudgeShownTokens = undefined
}
```

- `lastPerMessageNudgeTokens = currentTokens` → next check at +5% from now
- `lastNudgeShownTokens = undefined` → clears pending nudge, threshold resets to full (not halved)

## Behavior

| Turn | Before (current) | After (this PR) |
|------|------------------|-----------------|
| 1 | growth=55K → suppressed → baseline stays | growth=55K → suppressed → **baseline advances** |
| 2 | growth=110K → suppressed again (every turn) | growth=5K → below threshold (no check) |
| 3 | growth=165K → suppressed again | growth=55K → check fires |

## Tests

- "baseline advances when nudge suppressed — discrete 5% intervals (all protected)" — two-turn test
- "baseline advances when filter suppressed — compressible too small"
- "pending nudge cleared when suppressed — threshold resets to full"

755/755 tests pass.

## Branch strategy

Based on `2026-07-18_suppress-nudge-no-compressible` (PR #158). Should merge after #157 and #158.