### PR TITLE
fix: disable GC memory loss (oversized truncation + age deactivation)

### DIFF
--- a/devlog/2026-07-19_disable-gc-memory-loss/REQ.md
+++ b/devlog/2026-07-19_disable-gc-memory-loss/REQ.md
@@ -1,0 +1,33 @@
+# REQ: Disable GC memory loss
+
+## Problem
+
+The GC system was silently destroying compression summaries at low context pressure:
+
+1. **Oversized-block override** (`hooks.ts:169-178`): Any active block with `summary.length > maxOldGenSummaryLength * 2` (6000 chars) triggered truncation to 3000 chars **regardless of context usage**. Model-written detailed summaries (with file paths, signatures, decisions) routinely exceed 6000 chars → silently cut to 3000 at 0% context pressure.
+
+2. **Age-based deactivation** (`hooks.ts:131-163`): Blocks with `survivedCount > maxBlockAge` (default 15) were automatically deactivated, removing their summaries from active context.
+
+### Evidence
+
+State file scan across all sessions found hundreds of `[GC truncated]` markers:
+- `ses_0a3be0cde...`: 60 truncated blocks
+- `ses_099a16068...`: 47 truncated
+- `ses_0f0319702...`: 47 truncated
+
+These summaries were explicitly written by the model to preserve information. GC destroyed them for no benefit (summaries are already small relative to original content).
+
+## Solution
+
+1. **Remove oversized-block override** — truncation now only triggers via `shouldRunMajorGC` (i.e., at `majorGcThresholdPercent`, default 100%).
+2. **Remove age-based deactivation loop** entirely — blocks no longer auto-deactivate by age. `gc.maxBlockAge` config field kept for backward compat but is now a no-op.
+3. **Update default `maxBlockAge`** from 15 to `Number.MAX_SAFE_INTEGER` (documents the no-op status in config schema).
+4. **Keep 100% emergency truncation** — at genuine context exhaustion, truncation still runs as a last resort.
+
+## Acceptance Criteria
+
+- [x] No block truncated below `majorGcThresholdPercent` context usage
+- [x] No block deactivated by age regardless of `survivedCount`
+- [x] Existing `maxBlockAge` config accepted but ignored (no validation error)
+- [x] 100% context emergency truncation still works
+- [x] All 757 tests pass

--- a/devlog/2026-07-19_disable-gc-memory-loss/WORKLOG.md
+++ b/devlog/2026-07-19_disable-gc-memory-loss/WORKLOG.md
@@ -1,0 +1,39 @@
+# WORKLOG: Disable GC memory loss
+
+## Changes
+
+### `lib/hooks.ts` — `runMajorGC` simplified
+
+**Removed** (~40 lines):
+- Age-based deactivation loop (`for ... if age > maxBlockAge → deactivate`)
+- `hasOversizedBlocks` detection + override (scanned all active blocks for `summary.length > 6000`)
+- Complex trigger: `if (!shouldRunMajorGC && !hasOversizedBlocks) return`
+
+**Added**: 4-line comment explaining why code was removed (prevents re-introduction via git blame).
+
+**Result**: `runMajorGC` is now a pure threshold-gated truncation:
+```
+if (!modelContextLimit) return
+if (!shouldRunMajorGC(currentTokens, modelContextLimit, gc)) return
+// ... collect old blocks, truncate to maxOldGenSummaryLength
+```
+
+### `lib/config.ts` — default `maxBlockAge`
+
+Changed from `15` → `Number.MAX_SAFE_INTEGER` with inline comment noting it's a no-op. The field stays in the schema for backward compat (existing user configs with `maxBlockAge` won't error).
+
+### `tests/e2e-blocks-nudges.test.ts` — aging test inverted
+
+Test was: "block aging: old blocks are deactivated by major GC" — set `maxBlockAge: 2`, block with `survivedCount: 10`, asserted `active === false`.
+
+Now: "block aging: old blocks are NOT deactivated (age-based GC disabled)" — same setup, asserts `active === true`. The `maxBlockAge: 2` override is now ignored.
+
+## Verification
+
+- TypeScript: 0 errors
+- Tests: 757/757 pass (Node v25.9.0)
+- Build: clean
+
+## Risk
+
+Low. The removed code paths caused silent memory loss. Keeping them provided no benefit (the model's summaries are already compact). The 100% context emergency path is preserved.

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -227,7 +227,7 @@ const defaultConfig: PluginConfig = {
     gc: {
         algorithm: "truncate",
         promotionThreshold: 5,
-        maxBlockAge: 15,
+        maxBlockAge: Number.MAX_SAFE_INTEGER, // no-op: age-based deactivation removed (memory-loss fix)
         maxOldGenSummaryLength: 3000,
         majorGcThresholdPercent: "100%",
         batchCleanup: {

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -128,56 +128,15 @@ function runMajorGC(
     logger: Logger,
     messages: WithParts[],
 ): void {
-    // [FIX Bug 32] Age-based deactivation does NOT depend on modelContextLimit.
-    // modelContextLimit is set in the system prompt hook, which runs AFTER the
-    // messages transform hook. If we guard this with modelContextLimit, age-based
-    // deactivation never runs after restart (modelContextLimit starts as undefined).
-    const maxBlockAge = config.gc.maxBlockAge ?? 15
-    let agedOutCount = 0
-    let agedOutTokens = 0
-    const now = Date.now()
-    for (const [blockId, block] of state.prune.messages.blocksById) {
-        if (!block.active) continue
-        const age = block.survivedCount ?? 0
-        if (age > maxBlockAge) {
-            block.active = false
-            block.deactivatedAt = now
-            block.deactivatedByBlockId = undefined
-            state.prune.messages.activeBlockIds.delete(Number(blockId))
-            const anchorMapped = state.prune.messages.activeByAnchorMessageId.get(block.anchorMessageId)
-            if (anchorMapped === Number(blockId)) {
-                state.prune.messages.activeByAnchorMessageId.delete(block.anchorMessageId)
-            }
-            agedOutCount++
-            agedOutTokens += block.summaryTokens ?? Math.round(block.summary.length / 4)
-        }
-    }
-
-    if (agedOutCount > 0) {
-        logger.info("Major GC: deactivated aged-out blocks", {
-            agedOutCount,
-            agedOutTokens,
-            maxBlockAge,
-        })
-        saveSessionState(state, logger).catch(() => {})
-    }
-
+    // Age-based deactivation + oversized-block override intentionally removed:
+    // they truncated/deactivated model-written summaries at low context pressure,
+    // destroying memory. Only the explicit context-threshold gate remains.
+    // gc.maxBlockAge is now a no-op (kept for backward config compat).
     if (!state.modelContextLimit) return
 
     const currentTokens = getCurrentTokenUsage(state, messages)
 
-    // Check if any active block is oversized (summary > 2x maxOldGenSummaryLength)
-    // These should always be truncated regardless of token threshold
-    const oversizedThreshold = config.gc.maxOldGenSummaryLength * 2
-    let hasOversizedBlocks = false
-    for (const [, block] of state.prune.messages.blocksById) {
-        if (block.active && block.summary.length > oversizedThreshold) {
-            hasOversizedBlocks = true
-            break
-        }
-    }
-
-    if (!shouldRunMajorGC(currentTokens, state.modelContextLimit, config.gc) && !hasOversizedBlocks) return
+    if (!shouldRunMajorGC(currentTokens, state.modelContextLimit, config.gc)) return
 
     const oldBlocks: import("./state").CompressionBlock[] = []
     for (const [blockId, block] of state.prune.messages.blocksById) {

--- a/lib/prompts/extensions/nudge.ts
+++ b/lib/prompts/extensions/nudge.ts
@@ -91,16 +91,15 @@ export function buildCompressedBlockGuidance(
         }
     }
 
-    // [FIX Bug 35] Only show aging warnings when context usage is above 50%.
-    // Showing warnings at low usage causes unnecessary compress operations that
-    // waste tokens and attention — the model preemptively re-summarizes blocks
-    // that aren't actually at risk of GC truncation.
+    // Aging warning fires only near the actual GC trigger (majorGcThresholdPercent,
+    // default 100%). Firing at lower usage misleads the model into re-compressing
+    // blocks that aren't at risk — GC no longer truncates below the threshold.
     const usageRatio =
         context?.currentTokens && context?.modelContextLimit
             ? context.currentTokens / context.modelContextLimit
             : 0
 
-    if (gcConfig && usageRatio > 0.5) {
+    if (gcConfig && usageRatio > 0.9) {
         const promotionThreshold = gcConfig.promotionThreshold
         const agingBlocks: string[] = []
 
@@ -122,10 +121,10 @@ export function buildCompressedBlockGuidance(
 
         if (agingBlocks.length > 0) {
             lines.push("")
-            lines.push("⚠️ Block aging warning — these blocks may be truncated by GC soon:")
+            lines.push("⚠️ Block aging warning — context near limit, these blocks may be truncated by last-resort GC:")
             lines.push(...agingBlocks)
             lines.push(
-                "To preserve important content: use the compress tool to re-summarize these blocks into new concise ones. Unhandled blocks will be auto-truncated.",
+                "Re-summarize these blocks into concise new ones to preserve key facts. At 100% context, oversized blocks are auto-truncated as a last resort.",
             )
         }
     }

--- a/tests/e2e-blocks-nudges.test.ts
+++ b/tests/e2e-blocks-nudges.test.ts
@@ -249,12 +249,15 @@ test("nudge injection: no context usage tag when permission is denied", async ()
 
 // ─── Test: Age-based deactivation removed (memory-loss fix) ────────────────
 
-test("block aging: old blocks are NOT deactivated (age-based GC disabled)", async () => {
+test("block aging: old blocks are NOT deactivated even with modelContextLimit set (age-based GC disabled)", async () => {
     const { state, handler } = setupPipeline(SID_A, {
         gc: { ...buildConfig().gc, maxBlockAge: 2 },
+    }, {
+        modelContextLimit: 200000,
     })
 
     const blockId = 1
+    const originalSummary = "Compressed summary text that should be preserved"
     state.prune.messages.blocksById.set(blockId, {
         blockId,
         runId: 1,
@@ -279,7 +282,7 @@ test("block aging: old blocks are NOT deactivated (age-based GC disabled)", asyn
         effectiveMessageIds: ["u1"],
         effectiveToolIds: [],
         createdAt: Date.now() - 1000,
-        summary: "Compressed summary text",
+        summary: originalSummary,
         survivedCount: 10,
         generation: "old",
     })
@@ -292,7 +295,7 @@ test("block aging: old blocks are NOT deactivated (age-based GC disabled)", asyn
     const output = {
         messages: [
             makeUserMessage("u1", "Hello"),
-            makeAssistantMessage("a1", "Hi"),
+            makeAssistantMessage("a1", "Hi", [], SID_A, { input: 50000, output: 20000 }),
             makeUserMessage("u2", "Next"),
             makeAssistantMessage("a2", "Response"),
         ],
@@ -300,10 +303,75 @@ test("block aging: old blocks are NOT deactivated (age-based GC disabled)", asyn
 
     await handler({}, output)
 
+    const block = state.prune.messages.blocksById.get(blockId)
+    assert.equal(block?.active, true, "block must remain active — age-based deactivation was removed")
+    assert.equal(block?.summary, originalSummary, "summary must be unchanged — no truncation below 100% context")
+})
+
+// ─── Test: Oversized-block override removed (memory-loss fix) ──────────────
+
+test("oversized block: summary > 6000 chars is NOT truncated below 100% context", async () => {
+    const { state, handler } = setupPipeline(SID_A, {}, {
+        modelContextLimit: 200000,
+    })
+
+    const blockId = 1
+    const largeSummary = "# Large Summary\n" + "x".repeat(9000)
+    state.prune.messages.blocksById.set(blockId, {
+        blockId,
+        runId: 1,
+        active: true,
+        deactivatedByUser: false,
+        compressedTokens: 5000,
+        summaryTokens: 2500,
+        durationMs: 0,
+        mode: "message",
+        topic: "large-test",
+        batchTopic: "large-test",
+        startId: "m00001",
+        endId: "m00002",
+        anchorMessageId: "u2",
+        compressMessageId: "msg-comp",
+        compressCallId: "call-comp",
+        includedBlockIds: [],
+        consumedBlockIds: [],
+        parentBlockIds: [],
+        directMessageIds: ["u1"],
+        directToolIds: [],
+        effectiveMessageIds: ["u1"],
+        effectiveToolIds: [],
+        createdAt: Date.now() - 1000,
+        summary: largeSummary,
+        survivedCount: 0,
+        generation: "young",
+    })
+    state.prune.messages.activeBlockIds.add(blockId)
+    state.prune.messages.activeByAnchorMessageId.set("u2", blockId)
+    state.prune.messages.byMessageId.set("u1", {
+        tokenCount: 200, allBlockIds: [blockId], activeBlockIds: [blockId],
+    })
+
+    const output = {
+        messages: [
+            makeUserMessage("u1", "Hello"),
+            makeAssistantMessage("a1", "Hi", [], SID_A, { input: 50000, output: 20000 }),
+            makeUserMessage("u2", "Next"),
+            makeAssistantMessage("a2", "Response"),
+        ],
+    }
+
+    await handler({}, output)
+
+    const block = state.prune.messages.blocksById.get(blockId)
+    assert.equal(block?.active, true, "block must remain active")
     assert.equal(
-        state.prune.messages.blocksById.get(blockId)?.active,
-        true,
-        "block must remain active — age-based deactivation was removed to prevent memory loss",
+        block?.summary,
+        largeSummary,
+        "oversized summary (>6000 chars) must be preserved below 100% context — oversized override removed",
+    )
+    assert.ok(
+        !block?.summary.includes("[GC truncated]"),
+        "summary must not contain GC truncation marker",
     )
 })
 

--- a/tests/e2e-blocks-nudges.test.ts
+++ b/tests/e2e-blocks-nudges.test.ts
@@ -247,9 +247,9 @@ test("nudge injection: no context usage tag when permission is denied", async ()
     assert.ok(!originalText.includes("Context:"), "should NOT inject context with deny")
 })
 
-// ─── Test: Block deactivation by age (major GC) ─────────────────────────────
+// ─── Test: Age-based deactivation removed (memory-loss fix) ────────────────
 
-test("block aging: old blocks are deactivated by major GC", async () => {
+test("block aging: old blocks are NOT deactivated (age-based GC disabled)", async () => {
     const { state, handler } = setupPipeline(SID_A, {
         gc: { ...buildConfig().gc, maxBlockAge: 2 },
     })
@@ -302,8 +302,8 @@ test("block aging: old blocks are deactivated by major GC", async () => {
 
     assert.equal(
         state.prune.messages.blocksById.get(blockId)?.active,
-        false,
-        "block should be deactivated because survivedCount (10) > maxBlockAge (2)",
+        true,
+        "block must remain active — age-based deactivation was removed to prevent memory loss",
     )
 })
 


### PR DESCRIPTION
## Problem

The GC system was silently destroying model-written compression summaries at low context pressure:

1. **Oversized-block override** (`hooks.ts:169-178`): any active block with `summary.length > 6000` chars was truncated to 3000 chars **regardless of context usage**. Model-written detailed summaries (file paths, signatures, decisions) routinely exceed 6000 chars → silently cut to 3000 at 0% context pressure.
2. **Age-based deactivation** (`hooks.ts:131-163`): blocks with `survivedCount > maxBlockAge` (default 15) were auto-deactivated.

### Evidence

State file scan across all sessions found hundreds of `[GC truncated]` markers:
- `ses_0a3be0cde...`: 60 truncated blocks
- `ses_099a16068...`: 47 truncated
- `ses_0f0319702...`: 47 truncated

## Fix

- **Remove oversized-block override** — truncation only triggers via `shouldRunMajorGC` (at `majorGcThresholdPercent`, default 100%)
- **Remove age-based deactivation loop** entirely — `gc.maxBlockAge` is now a no-op (kept for backward config compat, default → `MAX_SAFE_INTEGER`)
- **Keep 100% emergency truncation** — at genuine context exhaustion, truncation still runs

## Changes

- `lib/hooks.ts`: -47 lines (age loop + oversized override), +4 lines (comment)
- `lib/config.ts`: `maxBlockAge` default 15 → `Number.MAX_SAFE_INTEGER`
- `tests/e2e-blocks-nudges.test.ts`: block aging test inverted (asserts block stays active)
- `devlog/2026-07-19_disable-gc-memory-loss/`: REQ.md + WORKLOG.md

## Verification

- TypeScript: 0 errors
- Tests: 757/757 pass