### PR TITLE
release: v1.12.11 — README Refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.12.11 — README Refresh (PR #164)
+
+**Problem**: README documentation had drifted from code reality. The tagline under-emphasized ACP's core capability. The "Deletion strategy" section in the English README described a feature that no longer exists and contradicted the Chinese version. Cache hit rate and context usage statistics were stale (87%, ~30%). The `compress.protectedTools` default was documented as 5 tools (`task, skill, todowrite, todoread, decompress`) when the actual code default is only `skill`.
+
+**Fix**: (1) Added `<strong>200K tokens is enough.</strong>` tagline alongside the existing one-liner. (2) Refreshed "Proven at scale" table with real API-level data from 6 active sessions (Duration, Messages, API calls, Cumulative tokens, Cache hit %, P50/P90/P95 context), with outlier annotated. Aggregate cache hit ~91%. (3) Replaced "Deletion strategy" section (EN) with "GC safety net" matching the Chinese version. (4) Updated "How It Works" to list `acp_status` and `search_context` as supporting tools. (5) Updated cache stats: 87% → 91%, context ~30% → ~10–15% (p50 100K, p90 150K of 1M window). (6) Corrected `compress.protectedTools` default documentation to `skill` only (matches `COMPRESS_DEFAULT_PROTECTED_TOOLS` at `lib/config.ts:121`).
+
+Files: `README.md`, `README.zh-CN.md`. No code changes. Tests: 768 pass (unchanged).
+
 ### v1.12.10 — Batch Compress + Decompress Range Mode + GC Memory-Loss Fix + Token Classification + Nudge Quality (PRs #73, #155, #156, #157, #158, #159, #161)
 
 **Problem**: Seven issues across compression UX, token accounting, GC safety, and nudge quality. (1) `decompress` required a per-block `acp_status` → decompress-per-block loop to restore multiple compressed blocks. (2) Since v1.12.9 (compress-as-anchor), compress tool `summary` content was misclassified as `toolTokens` instead of `summaryTokens`, inflating tool% and deflating summary% in the context breakdown. (3) The `compress` tool only accepted a single range per call — the model had to issue multiple calls to compress unrelated ranges, wasting turns. (4) The `[PROTECTED: ...]` label listed every tool in a protected message instead of only the triggering tools. (5) When all visible content was protected, the nudge still fired with an empty recommendation list. (6) When a nudge was suppressed, the next-turn check re-evaluated every turn. (7) **The GC system was silently destroying model-written summaries**: any block with `summary.length > 6000` chars was force-truncated to 3000 regardless of context pressure (0% pressure triggered truncation), and blocks with high `survivedCount` were auto-deactivated — causing irrecoverable memory loss across hundreds of sessions.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -396,6 +396,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.12.11 — README 文档刷新（PR #164）
+
+**问题**：README 文档与代码实际脱节。tagline 没有突出 ACP 的核心能力。英文版的 "Deletion strategy" 章节描述了一个已不存在的功能，且与中文版不一致。缓存命中率和上下文使用率数据过期（87%、~30%）。`compress.protectedTools` 默认值文档列出了 5 个工具（`task, skill, todowrite, todoread, decompress`），但代码实际默认值只有 `skill`。
+
+**修复**：（1）新增 `<strong>20 万 token 足矣。</strong>` tagline。（2）"Proven at scale" 表格更新为 6 个活跃会话的真实 API 级数据（运行时长、消息数、API 调用数、累计 token、缓存命中率、P50/P90/P95），离群值标注。（3）英文版 "Deletion strategy" 替换为 "GC safety net"，与中文版 "GC 兜底" 一致。（4）"工作原理" 列出 `acp_status` 和 `search_context` 为辅助工具。（5）缓存统计更新：87% → 91%，上下文 ~30% → ~10–15%（1M 窗口的 p50 10 万、p90 15 万）。（6）`compress.protectedTools` 默认值文档更正为仅 `skill`（匹配 `lib/config.ts:121` 的 `COMPRESS_DEFAULT_PROTECTED_TOOLS`）。
+
+文件：`README.md`、`README.zh-CN.md`。无代码改动。测试：768 通过（不变）。
+
 ### v1.12.10 — 批量压缩 + Decompress 范围模式 + GC 记忆丢失修复 + Token 分类 + Nudge 质量（PR #73, #155, #156, #157, #158, #159, #161）
 
 **问题**：七个问题，涉及压缩 UX、token 统计、GC 安全和 nudge 质量。（1）`decompress` 需要先 `acp_status` 再逐块 decompress 的循环才能恢复多个压缩块。（2）自 v1.12.9 起，compress 工具的 `summary` 内容被错误分类为 `toolTokens` 而非 `summaryTokens`，导致上下文分布中 tool% 虚高、summary% 虚低。（3）`compress` 工具每次调用只能压缩一个范围 —— 模型需要多次调用才能压缩不相关的范围，浪费轮次。（4）`[PROTECTED: ...]` 标签列出受保护消息中的所有工具而非仅触发保护的工具。（5）当所有可见内容都是受保护内容时，nudge 仍然以空推荐列表注入。（6）当 nudge 被抑制时，下一轮检查每轮都重新评估。（7）**GC 系统在静默销毁模型编写的 summary**：任何 `summary.length > 6000` 字符的块在零上下文压力下被强制截断到 3000，且 `survivedCount` 过高的块被自动 deactivate —— 导致数百个会话的不可恢复记忆丢失。

--- a/devlog/2026-07-19_release-v1.12.11/REQ.md
+++ b/devlog/2026-07-19_release-v1.12.11/REQ.md
@@ -1,0 +1,45 @@
+# REQ: v1.12.11 Release
+
+## Goal
+
+Publish a stable patch release `v1.12.11` to npm `latest`, bundling the README
+documentation refresh from PR #164.
+
+## Background
+
+PR #164 (branch `2026-07-19_readme-context-data`) was squash-merged to master
+as commit `5f949bb`. It contained two rounds of README updates:
+
+1. Refreshed "Proven at scale" table with real API-level data from 6 active
+   sessions (Duration, Messages, API calls, Cumulative tokens, Cache hit %,
+   P50/P90/P95).
+2. Added "200K tokens is enough" tagline, replaced outdated "Deletion strategy"
+   section with "GC safety net", updated cache stats (87% → 91%, context ~30%
+   → ~10–15%), corrected `compress.protectedTools` default to `skill` only.
+
+No code changes — pure documentation release. Tests unchanged at 768.
+
+## Scope
+
+- Bump `package.json` version: `1.12.10` → `1.12.11`
+- Add `### v1.12.11` changelog entries to `README.md` and `README.zh-CN.md`
+- Create this devlog entry
+- Verify: typecheck, 768 tests pass, build
+- Push branch, create PR, await user merge
+
+## Out of Scope
+
+- Any code changes
+- Any new features
+- Behavior changes
+
+## Acceptance Criteria
+
+- [x] `package.json` version = `1.12.11`
+- [x] Both READMEs have `### v1.12.11` entry at the top of the changelog
+- [x] devlog/2026-07-19_release-v1.12.11/ has REQ.md + WORKLOG.md
+- [x] `npm run typecheck` passes
+- [x] `npm run test` — 768/768 pass
+- [x] PR created with `release: v1.12.11` title
+- [ ] User merges PR → CI auto-publishes to npm `latest`
+- [ ] `npm view opencode-acp version` returns `1.12.11`

--- a/devlog/2026-07-19_release-v1.12.11/WORKLOG.md
+++ b/devlog/2026-07-19_release-v1.12.11/WORKLOG.md
@@ -1,0 +1,34 @@
+# WORKLOG: v1.12.11 Release
+
+## 2026-07-19
+
+### Release preparation
+
+- Branch `2026-07-19_release-v1.12.11` created from `github/master` @ `5f949bb`
+  (post PR #164 squash merge)
+- `package.json`: `1.12.10` → `1.12.11`
+- `README.md`: Added `### v1.12.11 — README Refresh (PR #164)` changelog entry
+  describing the 6 documentation updates
+- `README.zh-CN.md`: Added matching `### v1.12.11 — README 文档刷新（PR #164）`
+  entry
+- devlog/2026-07-19_release-v1.12.11/REQ.md + WORKLOG.md created
+
+### What's bundled
+
+- PR #164 (squash-merged as `5f949bb`): README context statistics refresh +
+  tagline + GC safety net section + cache stats + protected tools default
+
+### Verification
+
+- typecheck: 0 errors
+- tests: 768/768 pass (no code changes, same as v1.12.10)
+- No build needed (docs-only release, but build still passes)
+
+### Release steps remaining
+
+1. Commit changes
+2. Push branch
+3. Create PR titled `release: v1.12.11 — README Refresh`
+4. Await user merge
+5. CI auto-publishes to npm `latest` (force=true fallback if squash-merge
+   detection fails, as with v1.12.10)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.12.10",
+    "version": "1.12.11",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Stable patch release `v1.12.11`. **Documentation-only** — no code changes, no behavior changes.

Bundles PR #164 (README context statistics refresh).

## What's in this release

- **Tagline**: Added `<strong>200K tokens is enough.</strong>` / `<strong>20 万 token 足矣。</strong>`
- **Proven at scale table**: Refreshed with real API-level data from 6 active sessions (Duration, Messages, API calls, Cumulative tokens, Cache hit %, P50/P90/P95). Aggregate cache hit ~91%. Outlier annotated.
- **Deletion strategy → GC safety net** (EN): Replaced outdated section to match Chinese version.
- **How It Works**: List `acp_status` and `search_context` as supporting tools.
- **Impact on Prompt Caching**: 87% → 91%, context ~30% → ~10–15% (p50 100K, p90 150K of 1M window).
- **`compress.protectedTools` default**: Corrected from 5 tools to `skill` only (matches code at `lib/config.ts:121`).

## Verification

- typecheck: 0 errors
- tests: 768/768 pass
- format: prettier clean
- ci check: all pass

## After merge

CI auto-publishes to npm `latest`. If squash-merge detection fails (known issue with v1.12.10), trigger release.yml manually:

```bash
gh workflow run release.yml -f force=true
```