### PR TITLE
feat: pluggable post-compression quality gate (v1.13.0, issue #20)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,15 @@ opencode-acp/
 │   │   ├── range-utils.ts            # Range-level utility functions
 │   │   ├── timing.ts                 # Compression timing tracking
 │   │   ├── types.ts                  # Shared type definitions (ToolContext, BoundaryReference, etc.)
+│   │   ├── quality-gate/             # Post-compression quality evaluation (non-blocking, pluggable)
+│   │   │   ├── types.ts              # QualityGate interface, QualityGateContext, QualityReport
+│   │   │   ├── registry.ts           # Singleton Map; registerQualityGate / getQualityGate / list
+│   │   │   ├── tokenizer.ts          # Hand-rolled word-level tokenizer (EN keywords + ZH uni/bigrams)
+│   │   │   ├── evaluate.ts           # Orchestrator: evaluateBlockQuality + evaluateBatchQuality
+│   │   │   ├── algorithms/
+│   │   │   │   ├── rouge-recall-v1.ts # Default gate: L1 length floor + L2 ROUGE-1 F1 AND top-20 recall
+│   │   │   │   └── index.ts          # ensureBuiltinGatesRegistered() idempotent initializer
+│   │   │   └── index.ts              # Barrel export
 │   │   └── index.ts                  # Barrel export
 │   │
 │   ├── messages/                     # Message processing pipeline
@@ -206,7 +215,7 @@ index.ts (Plugin Entry — registers hooks + tools)
             │       ├─► Update byMessageId index
             │       └─→ Track newly compressed tokens
             │
-            └─► finalizeSession() → save state, send notification
+            └─► finalizeSession() → save state, evaluate quality gate (non-blocking), send notification
 ```
 
 ### 2.3 Key Concepts

--- a/README.md
+++ b/README.md
@@ -134,6 +134,28 @@ later work.
 
 When context reaches 100%, the system automatically truncates old-gen block summaries to prevent overflow. This is a last-resort safety net and does not interfere with the model's normal compress/decompress operations.
 
+### Quality gate (non-blocking, off by default)
+
+After each `compress` call, ACP can run a pluggable quality gate to detect summaries that catastrophically lost content (e.g., a 5K-token range compressed to a 147-char summary with none of the technical keywords). Failures only emit `logger.warn` — they never reject the compression (the result is already committed to state and visible to the model).
+
+The default algorithm (`rouge-recall-v1`) is a two-layer gate calibrated against 6,913 real-world blocks:
+
+- **L1 (length floor)**: Catches catastrophic retention failures — summaries shorter than 200 chars OR with <1% retention vs. the original. 100% recall, 0% FPR.
+- **L2 (content coverage)**: Only runs on blocks that pass L1. Flags when **both** ROUGE-1 F1 < 0.05 **and** top-20 keyword recall < 0.20 (AND-combine keeps FPR at ~6.6%).
+
+The interface is pluggable: future algorithms (e.g., LLM-as-judge via external API) can be registered through `registerQualityGate()` without touching pipeline wiring. Tokenizer uses hand-rolled word-level tokenization (English keywords + Chinese unigrams/bigrams) — not ACP's BPE tokenizer, which is too coarse for ROUGE-style matching.
+
+Off by default for one release of burn-in. To enable:
+
+```jsonc
+{
+    "qualityGate": {
+        "enabled": true,
+        "algorithm": "rouge-recall-v1",
+    },
+}
+```
+
 ---
 
 ## Impact on Prompt Caching
@@ -324,6 +346,28 @@ Each level overrides the previous, so project settings take priority over global
         // run major GC when context usage exceeds this (hardcoded, not configurable)
         "majorGcThresholdPercent": "100%",
     },
+    // Post-compression quality gate (non-blocking; off by default)
+    "qualityGate": {
+        // Master switch. When false, no evaluation runs.
+        "enabled": false,
+        // Algorithm name. Pluggable — future algorithms (including external
+        // API judges) can be registered without changing pipeline wiring.
+        "algorithm": "rouge-recall-v1",
+        // Per-algorithm config
+        "algorithms": {
+            "rouge-recall-v1": {
+                // Hard floor on summary length (chars). Below this → L1 fails.
+                "layer1MinChars": 200,
+                // Min retention = summaryLen / (compressedTokens*4) * 100.
+                // Catches catastrophic retention failures (<1%) with 0% FPR.
+                "layer1MinRetentionPct": 1.0,
+                // L2 fails (combined with top20Recall via AND) when below this.
+                "layer2MaxRougeF1": 0.05,
+                // L2 fails (combined with rougeF1 via AND) when below this.
+                "layer2MaxTop20Recall": 0.20,
+            },
+        },
+    },
 }
 ```
 
@@ -426,6 +470,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 ---
 
 ## Changelog
+
+### v1.13.0 — Pluggable Quality Gate (Issue #20)
+
+**Problem**: ACP had no mechanism to detect summaries that catastrophically lost content. The model could compress a 5K-token range into a 147-char summary missing every technical keyword, and the system would silently accept it. Issue #20 (calibrated against 6,913 real-world blocks from real sessions) identified two distinct failure modes: (1) length-floor failures — summaries <1% the size of the original (caught with 100% recall, 0% FPR via simple char count), and (2) content-coverage failures — summaries long enough to pass the length floor but capturing none of the original's keywords (e.g., a 996-char summary of a 5K-token original that recovers 0.6% of content words).
+
+**Fix**: Added a pluggable `qualityGate` subsystem under `lib/compress/quality-gate/` with a `QualityGate` interface (`name`, `version`, `description`, `evaluate(ctx, config)`). The pipeline calls `evaluateBatchQuality()` in `finalizeSession()` after state is saved — failures only emit `logger.warn` (non-blocking: the compression result is already committed). The default algorithm `rouge-recall-v1` is a two-layer gate: L1 is a length/retention floor (200 chars AND 1% retention), L2 is an AND-combine of ROUGE-1 F1 < 0.05 AND top-20 keyword recall < 0.20 (AND keeps FPR at ~6.6% while still catching the long-but-empty failure mode). Tokenizer is hand-rolled word-level (English keywords ≥4 chars + Chinese unigrams/bigrams) — separate from ACP's BPE tokenizer, which is too coarse for ROUGE matching. Config defaults `enabled: false` for one release of burn-in. Interface leaves room for future algorithms including external API judges (sync signature today; future async gates need either type widening or internal wait+timeout wrap, registry/config unchanged).
+
+Files: `lib/compress/quality-gate/{types,registry,tokenizer,evaluate,index}.ts`, `lib/compress/quality-gate/algorithms/{rouge-recall-v1,index}.ts`, `lib/compress/pipeline.ts`, `lib/config.ts`, `lib/config-validation.ts`, `dcp.schema.json`. Tests: `tests/quality-gate-{tokenizer,registry,rouge-recall-v1,pipeline-integration}.test.ts` (NEW, 74 tests). 842 tests pass.
 
 ### v1.12.11 — README Refresh (PR #164)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -109,6 +109,28 @@ stateDiagram-v2
 
 当上下文达到 100% 时，系统自动截断老年代 block 摘要，防止上下文溢出。这是最后的兜底机制，不影响模型的正常压缩/解压操作。
 
+### 质量门控（非阻塞，默认关闭）
+
+每次 `compress` 调用之后，ACP 可以运行一个可拔插的质量门控，检测摘要是否灾难性丢失了内容（例如：5K token 的范围被压缩成 147 字符、且不含任何技术关键词的摘要）。失败只发出 `logger.warn`——绝不拒绝压缩（结果已经提交到状态、对模型可见）。
+
+默认算法 `rouge-recall-v1` 是基于 6,913 个真实块校准的两层门控：
+
+- **L1（长度下限）**：捕获灾难性留存失败——摘要短于 200 字符 OR 留存率低于原始的 1%。100% 召回，0% 误报。
+- **L2（内容覆盖）**：只在通过 L1 的块上运行。当 **同时** ROUGE-1 F1 < 0.05 **且** top-20 关键词召回 < 0.20 时触发（AND 合并使误报率维持在 ~6.6%）。
+
+接口可拔插：未来算法（例如通过外部 API 的 LLM-as-judge）可通过 `registerQualityGate()` 注册，无需改动 pipeline 接线。分词器使用手写的词级分词（英文关键词 + 中文 unigram/bigram），不使用 ACP 的 BPE 分词器——后者对 ROUGE 风格的匹配粒度过粗。
+
+默认关闭，发布一个版本的烧入期后再开启。启用方式：
+
+```jsonc
+{
+    "qualityGate": {
+        "enabled": true,
+        "algorithm": "rouge-recall-v1",
+    },
+}
+```
+
 ---
 
 ## 对 Prompt 缓存的影响
@@ -293,6 +315,27 @@ ACP 使用自己的配置文件，按以下顺序搜索：
         // 上下文使用率超过此值时执行主 GC（兜底，硬编码为 100%）
         "majorGcThresholdPercent": "100%",
     },
+    // 压缩后质量门控（非阻塞；默认关闭）
+    "qualityGate": {
+        // 主开关。false 时不执行任何评估
+        "enabled": false,
+        // 算法名。可拔插——未来算法（包括外部 API 评审）可以注册而无需改 pipeline
+        "algorithm": "rouge-recall-v1",
+        // 各算法的独立配置
+        "algorithms": {
+            "rouge-recall-v1": {
+                // 摘要长度硬下限（字符）。低于此值 → L1 失败
+                "layer1MinChars": 200,
+                // 最小留存率 = summaryLen / (compressedTokens*4) * 100
+                // 捕获灾难性留存失败（<1%），0% 误报
+                "layer1MinRetentionPct": 1.0,
+                // 当 ROUGE-1 F1 低于此值时（与 top20Recall 经 AND 合并）L2 失败
+                "layer2MaxRougeF1": 0.05,
+                // 当 top-20 关键词召回低于此值时（与 rougeF1 经 AND 合并）L2 失败
+                "layer2MaxTop20Recall": 0.20,
+            },
+        },
+    },
 }
 ```
 
@@ -395,6 +438,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 ---
 
 ## 更新日志
+
+### v1.13.0 — 可拔插质量门控（Issue #20）
+
+**问题**：ACP 没有机制检测摘要是否灾难性丢失了内容。模型可能把 5K token 的范围压缩成 147 字符、且不含任何技术关键词的摘要，系统也会默默接受。Issue #20（基于真实会话的 6,913 个块校准）识别出两种不同的失败模式：(1) 长度下限失败——摘要 < 原始的 1%（通过简单的字符计数即可 100% 召回，0% 误报）；(2) 内容覆盖失败——摘要长度足够通过长度门，但没有捕获原始内容中的任何关键词（例如：5K token 原始内容的 996 字符摘要只恢复了 0.6% 的内容词）。
+
+**修复**：在 `lib/compress/quality-gate/` 下添加可拔插的 `qualityGate` 子系统，定义 `QualityGate` 接口（`name`、`version`、`description`、`evaluate(ctx, config)`）。pipeline 在 `finalizeSession()` 中状态保存之后调用 `evaluateBatchQuality()`——失败仅发出 `logger.warn`（非阻塞：压缩结果已经提交）。默认算法 `rouge-recall-v1` 是两层门控：L1 是长度/留存下限（200 字符 AND 1% 留存），L2 是 ROUGE-1 F1 < 0.05 与 top-20 关键词召回 < 0.20 的 AND 合并（AND 把误报率维持在 ~6.6%，同时仍能捕获"长但空"的失败模式）。分词器为手写的词级分词（英文关键词 ≥4 字符 + 中文 unigram/bigram），与 ACP 的 BPE 分词器分离——后者对 ROUGE 匹配粒度过粗。配置默认 `enabled: false`，发布一个版本的烧入期。接口为未来算法留出空间，包括外部 API 评审（当前为同步签名；未来异步门控需要扩展类型或在内部 wait+timeout 包装，registry/config 不变）。
+
+文件：`lib/compress/quality-gate/{types,registry,tokenizer,evaluate,index}.ts`、`lib/compress/quality-gate/algorithms/{rouge-recall-v1,index}.ts`、`lib/compress/pipeline.ts`、`lib/config.ts`、`lib/config-validation.ts`、`dcp.schema.json`。测试：`tests/quality-gate-{tokenizer,registry,rouge-recall-v1,pipeline-integration}.test.ts`（新增，74 个测试）。842 个测试通过。
 
 ### v1.12.11 — README 文档刷新（PR #164）
 

--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -472,6 +472,73 @@
                     }
                 }
             }
+        },
+        "qualityGate": {
+            "type": "object",
+            "description": "Post-compression quality evaluation. Non-blocking: failures only emit logger.warn; the compression result is already committed. Pluggable via the QualityGate interface — future algorithms (including external API judges) can be added without changing pipeline wiring.",
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable post-compression quality gate evaluation. Off by default for one release of burn-in."
+                },
+                "algorithm": {
+                    "type": "string",
+                    "default": "rouge-recall-v1",
+                    "description": "Name of the registered QualityGate algorithm to run."
+                },
+                "algorithms": {
+                    "type": "object",
+                    "description": "Per-algorithm config map. Keyed by algorithm name. Unknown algorithms ignored.",
+                    "additionalProperties": true,
+                    "properties": {
+                        "rouge-recall-v1": {
+                            "type": "object",
+                            "description": "Two-layer gate: L1 length/retention floor, L2 ROUGE-1 F1 AND top-20 keyword recall.",
+                            "additionalProperties": false,
+                            "properties": {
+                                "layer1MinChars": {
+                                    "type": "number",
+                                    "default": 200,
+                                    "minimum": 1,
+                                    "description": "Hard floor on summary length. Below this, L1 fails regardless of other metrics."
+                                },
+                                "layer1MinRetentionPct": {
+                                    "type": "number",
+                                    "default": 1.0,
+                                    "minimum": 0,
+                                    "description": "Minimum retention = (summaryLen / (compressedTokens * 4)) * 100. Catches catastrophic retention failures (<1%) with 0% FPR."
+                                },
+                                "layer2MaxRougeF1": {
+                                    "type": "number",
+                                    "default": 0.05,
+                                    "minimum": 0,
+                                    "description": "L2 fails (combined with top20Recall via AND) when ROUGE-1 F1 is below this threshold."
+                                },
+                                "layer2MaxTop20Recall": {
+                                    "type": "number",
+                                    "default": 0.20,
+                                    "minimum": 0,
+                                    "description": "L2 fails (combined with rougeF1 via AND) when top-20 keyword recall is below this threshold."
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "default": {
+                "enabled": false,
+                "algorithm": "rouge-recall-v1",
+                "algorithms": {
+                    "rouge-recall-v1": {
+                        "layer1MinChars": 200,
+                        "layer1MinRetentionPct": 1.0,
+                        "layer2MaxRougeF1": 0.05,
+                        "layer2MaxTop20Recall": 0.20
+                    }
+                }
+            }
         }
     }
 }

--- a/devlog/2026-07-19_quality-gate/DESIGN.md
+++ b/devlog/2026-07-19_quality-gate/DESIGN.md
@@ -1,0 +1,317 @@
+# DESIGN - Pluggable Compression Quality Gate
+
+- Task ID: `2026-07-19_quality-gate`
+- Home Repo: `opencode-acp`
+- Created: 2026-07-19
+- Status: Accepted
+
+## 1. Problem Statement
+
+- **What problem are we solving?** ACP silently accepts catastrophic compression failures (147-char summaries of 72K-token ranges). Need a post-compression quality check that detects these and warns, with an architecture flexible enough to support future algorithms (different metrics, external LLM judges).
+- **Why now?** Calibration research on issue #20 showed 3.3% of all blocks have <1% retention — too many to ignore. The model has no signal that its summaries are bad.
+
+## 2. Goals & Non-Goals
+
+- **Goals**:
+  - Pluggable: gate is selectable by name from config
+  - Default gate (`rouge-recall-v1`) catches the catastrophic cases (b27/b28 pattern) with FPR < 10%
+  - Future-extension surface: external-API gate, BERTScore gate, custom-model gate can be added without touching pipeline
+  - Non-blocking: failures warn, never reject
+- **Non-Goals**:
+  - External API gate implementation (interface only)
+  - Auto-decompression on failure
+  - Per-transform-hook evaluation (only on compress)
+
+## 3. Current Architecture
+
+`compress/range.ts` and `compress/message.ts`:
+1. Validate plans (phantom, dangerous last-segment)
+2. For each plan: inject placeholders, append protected content, allocate block IDs, applyCompressionState
+3. Call `finalizeSession(pipeline.ts)` — saves state, sends notification
+
+`finalizeSession` is the single integration point. It receives `NotificationEntry[]` (one per block) with `{ blockId, runId, summary, summaryTokens }`. The original messages are still in `rawMessages`.
+
+## 4. Proposed Architecture
+
+### Overview
+
+```
+pipeline.finalizeSession(ctx, toolCtx, rawMessages, entries, batchTopic)
+    │
+    ├─► (existing) saveSessionState, applyPendingCompressionDurations
+    │
+    ├─► (NEW) evaluateQualityGates(state, rawMessages, entries, config, logger)
+    │       │
+    │       ├─► for each entry:
+    │       │     build QualityGateContext { block, summary, originalChunks, originalText }
+    │       │     gate = registry.get(config.qualityGate.algorithm)
+    │       │     result = gate.evaluate(ctx)
+    │       │     if !result.passed: logger.warn + accumulate stats
+    │       │
+    │       └─► return QualityReport { failures: [...], passed: N, total: M }
+    │
+    └─► (existing) sendCompressNotification  // unchanged
+```
+
+### Key components
+
+**`lib/compress/quality-gate/types.ts`** — Pure types, no runtime.
+
+```typescript
+export interface QualityGateContext {
+    block: CompressionBlock
+    summary: string
+    /** Per-direct-message text, in original order. Chunk[i] = directMessageIds[i]'s text. */
+    originalChunks: string[]
+    /** Concatenated original text. Equal to originalChunks.join('\n'). Provided for convenience. */
+    originalText: string
+    /** Original token estimate (chars / 4). */
+    originalTokens: number
+}
+
+export interface QualityGateMetric {
+    name: string
+    value: number
+    /** Optional display format hint. */
+    format?: "raw" | "percent" | "ratio"
+}
+
+export interface QualityGateResult {
+    passed: boolean
+    /** Which layer fired (algorithm-specific). e.g. "L1-length", "L2-recall". */
+    layer?: string
+    /** Human-readable reason for failure. */
+    reason?: string
+    /** Metrics for logging/notification. */
+    metrics: QualityGateMetric[]
+}
+
+export interface QualityGate {
+    /** Unique gate name (e.g. "rouge-recall-v1"). Used in config. */
+    name: string
+    /** Algorithm version — bump when thresholds/logic change. */
+    version: string
+    /** Evaluate the gate. MUST NOT throw — on error return { passed: true, metrics: [], ... }. */
+    evaluate(ctx: QualityGateContext, config: unknown): QualityGateResult
+}
+```
+
+**`lib/compress/quality-gate/registry.ts`** — Singleton map.
+
+```typescript
+const registry = new Map<string, QualityGate>()
+
+export function registerQualityGate(gate: QualityGate): void
+export function getQualityGate(name: string): QualityGate | undefined
+export function listQualityGates(): string[]
+```
+
+**`lib/compress/quality-gate/tokenizer.ts`** — Shared tokenizer used by recall-based gates.
+
+- Tokenize: lowercase → extract EN words `[a-z][a-z0-9_]+` with length ≥ 4 → exclude stopwords → extract ZH unigrams + bigrams (excluding ZH stopwords)
+- Stopwords: EN articles/prepositions/common-verbs/code-noise + ZH particles/pronouns/conjunctions
+- Paths: extract regex `(?:[a-zA-Z0-9_-]+/){1,}[a-zA-Z0-9_-]+\.[a-zA-Z]{1,5}` for path-coverage metrics
+- tf counting: standard Map<string, number>
+
+**`lib/compress/quality-gate/algorithms/rouge-recall-v1.ts`** — Default algorithm.
+
+Layer 1 (length gate, 100% recall on catastrophic, 0% FPR):
+- FAIL if `summary.length < minChars` (default 200) OR `retentionPct < minRetentionPct` (default 1.0)
+
+Layer 2 (content coverage, ~6.6% FPR on good-zone):
+- Only run if Layer 1 passed
+- Compute `rougeF1` and `top20Recall` on content tokens
+- FAIL if `rougeF1 < maxF1` (default 0.05) AND `top20Recall < maxTop20` (default 0.20)
+
+Result includes metrics: `{ summaryLen, retentionPct, rougeF1, rougeRecall, top20Recall, nOriginalPaths, pathCoverage }`
+
+**`lib/compress/quality-gate/algorithms/index.ts`** — Auto-registers built-in gates on import.
+
+```typescript
+import { registerQualityGate } from "../registry"
+import { rougeRecallV1 } from "./rouge-recall-v1"
+
+let registered = false
+export function ensureBuiltinGatesRegistered(): void {
+    if (registered) return
+    registerQualityGate(rougeRecallV1)
+    registered = true
+}
+```
+
+**`lib/compress/quality-gate/index.ts`** — Public API barrel.
+
+```typescript
+export { evaluateBlockQuality, evaluateBatchQuality } from "./evaluate"
+export { registerQualityGate, getQualityGate, listQualityGates } from "./registry"
+export type { QualityGate, QualityGateContext, QualityGateResult, QualityGateMetric } from "./types"
+```
+
+**`lib/compress/quality-gate/evaluate.ts`** — Orchestrator.
+
+```typescript
+export function evaluateBlockQuality(
+    state: SessionState,
+    rawMessages: WithParts[],
+    entry: NotificationEntry,
+    config: PluginConfig,
+    logger: Logger,
+): QualityGateResult | null {
+    if (!config.qualityGate?.enabled) return null
+    ensureBuiltinGatesRegistered()
+    const gate = getQualityGate(config.qualityGate.algorithm)
+    if (!gate) {
+        logger.warn("Quality gate not found", { algorithm: config.qualityGate.algorithm })
+        return null
+    }
+    const block = state.prune.messages.blocksById.get(entry.blockId)
+    if (!block) return null
+    const ctx = buildContext(block, rawMessages)
+    const algoConfig = config.qualityGate.algorithms?.[gate.name] ?? {}
+    try {
+        return gate.evaluate(ctx, algoConfig)
+    } catch (err) {
+        logger.warn("Quality gate threw — treating as pass", { gate: gate.name, error: String(err) })
+        return { passed: true, metrics: [] }
+    }
+}
+
+export function evaluateBatchQuality(
+    state, rawMessages, entries, config, logger,
+): QualityReport {
+    const failures: Array<{ entry: NotificationEntry; result: QualityGateResult }> = []
+    for (const entry of entries) {
+        const result = evaluateBlockQuality(state, rawMessages, entry, config, logger)
+        if (result && !result.passed) failures.push({ entry, result })
+    }
+    return { total: entries.length, passed: entries.length - failures.length, failures }
+}
+```
+
+### Config schema
+
+Add to `PluginConfig`:
+
+```typescript
+export interface QualityGateConfig {
+    enabled: boolean
+    /** Which gate to use (must exist in registry). */
+    algorithm: string
+    /** Per-algorithm config. Keys are gate names. */
+    algorithms: {
+        "rouge-recall-v1"?: RougeRecallV1Config
+        // Future: "external-api-v1"?: ExternalApiConfig
+        [key: string]: unknown
+    }
+}
+
+export interface RougeRecallV1Config {
+    layer1MinChars: number
+    layer1MinRetentionPct: number
+    layer2MaxRougeF1: number
+    layer2MaxTop20Recall: number
+}
+
+export interface PluginConfig {
+    // ... existing
+    qualityGate: QualityGateConfig
+}
+```
+
+Default:
+```typescript
+qualityGate: {
+    enabled: false,  // opt-in for v1; flip to true in next release after burn-in
+    algorithm: "rouge-recall-v1",
+    algorithms: {
+        "rouge-recall-v1": {
+            layer1MinChars: 200,
+            layer1MinRetentionPct: 1.0,
+            layer2MaxRougeF1: 0.05,
+            layer2MaxTop20Recall: 0.20,
+        },
+    },
+},
+```
+
+### Pipeline integration
+
+`pipeline.ts::finalizeSession` after `applyPendingCompressionDurations`:
+
+```typescript
+const qualityReport = evaluateBatchQuality(
+    ctx.state, rawMessages, entries, ctx.config, ctx.logger,
+)
+if (qualityReport.failures.length > 0) {
+    for (const { entry, result } of qualityReport.failures) {
+        ctx.logger.warn("Compression quality gate FAILED", {
+            blockId: entry.blockId,
+            algorithm: ctx.config.qualityGate.algorithm,
+            layer: result.layer,
+            reason: result.reason,
+            metrics: Object.fromEntries(result.metrics.map(m => [m.name, m.value])),
+        })
+    }
+}
+// Non-blocking: continue to saveSessionState + notification
+```
+
+`Logger.warn` goes to `logs/acp/daily/<date>.log`. Future iterations can surface in TUI.
+
+### Data flow
+
+```
+compress call (range/message)
+    │
+    ▼
+applyCompressionState → creates CompressionBlock with directMessageIds
+    │
+    ▼
+finalizeSession(entries)
+    │
+    ├─► evaluateBatchQuality
+    │       │
+    │       ├─► for each entry.blockId:
+    │       │     fetch block from state.prune.messages.blocksById
+    │       │     for each directMessageId: extract text parts from rawMessages
+    │       │     build QualityGateContext
+    │       │     registry.get(algorithm).evaluate(ctx, algoConfig)
+    │       │
+    │       └─► return QualityReport
+    │
+    ├─► saveSessionState (unchanged)
+    └─► sendCompressNotification (unchanged)
+```
+
+## 5. Design Decisions & Rationale
+
+| Decision | Options Considered | Chosen | Why |
+|----------|--------------------|--------|-----|
+| Gate location | (a) Inside compress tool before applyCompressionState (b) After applyCompressionState in finalizeSession (c) Transform hook | (b) | Block already exists, original messages still in scope, runs once per compress |
+| Failure behavior | (a) Reject compression (b) Auto-decompress (c) Warn only | (c) | Block is already created, model already moved on. Warn = info, no disruption |
+| Tokenizer | (a) Reuse Anthropic tokenizer (b) Hand-rolled EN+ZH (c) External lib | (b) | Anthropic tokenizer is for cost estimation (BPE); we want word-level tokens for recall metrics. Hand-rolled avoids new deps. |
+| ZH tokenization | (a) Unigrams only (b) Bigrams only (c) Both | (c) | Unigrams catch single-char matches; bigrams reduce false positives (single chars like 的/了 are noisy even with stopword removal) |
+| Config default `enabled` | (a) true (b) false | (b) | Ship behind a flag for one release to burn-in; flip to true next release after telemetry confirms thresholds |
+| Algorithm versioning | (a) Implicit in git history (b) Bump `version` field | (b) | If we tweak thresholds, downstream tools can detect via version |
+| Multiple algorithms per call | (a) Run only configured one (b) Run all registered | (a) | Keep it simple; user picks one. Future: support array. |
+| Registry pattern | (a) Map singleton (b) DI container (c) Function params | (a) | Matches existing ACP pattern (no DI); registry is module-local, easy to test |
+
+## 6. Impact Analysis
+
+- **Backward compatibility**: ✅ New `qualityGate` config section is optional; defaults to `enabled: false`. Existing configs work unchanged.
+- **Performance**: ⚠️ Adds N evaluations per compress call where N = blocks in batch. Each evaluation is O(summary_tokens + original_tokens) for tokenization, plus O(topK log) for sorting. ~5ms typical, < 10ms for 50K-token originals.
+- **Security**: ✅ No external calls in v1. External-API gate (future) will need auth + URL allow-list.
+- **Dependencies**: ✅ None. Pure TS implementation.
+
+## 7. Migration Plan
+
+- **Steps**:
+  1. Add new config section with `enabled: false` default — no behavior change
+  2. Code ships; users can opt-in via config
+  3. After 1 release burn-in, flip default to `enabled: true`
+- **Feature flags**: `qualityGate.enabled` is the feature flag
+
+## 8. Open Questions
+
+- [ ] Should quality failures surface in TUI notification? (For now: logger only. Future iteration may add a warning emoji to the chat notification.)
+- [ ] Should we collect aggregate stats (per-session failure rate) for diagnostics? (Future: add to `state.stats`.)

--- a/devlog/2026-07-19_quality-gate/REQ.md
+++ b/devlog/2026-07-19_quality-gate/REQ.md
@@ -1,0 +1,68 @@
+# REQ - Pluggable Compression Quality Gate
+
+- Task ID: `2026-07-19_quality-gate`
+- Home Repo: `opencode-acp`
+- Created: 2026-07-19
+- Status: InProgress
+- Priority: P1
+- Owner: awork (bot)
+- References: dog/opencode-acp#20
+
+## 1. Background & Problem Statement
+
+- **Context**: Calibration research on 6913 real compression blocks (issue #20) showed that ~3.3% of all summaries retain <1% of original content — catastrophic quality failures. Some pass length checks but still miss all key content (rougeF1 < 0.01 at 5-8% retention).
+- **Current behavior (symptom)**: ACP happily accepts 147-char summaries of 72K-token original ranges; the model loses critical content silently.
+- **Expected behavior**: A pluggable quality-gate framework evaluates each block post-compression; failures emit a non-blocking warning (do NOT reject the compression — the model already committed to it).
+- **Impact**: Detect bad summaries early so future model calls can self-correct, and surface the issue for human review.
+
+## 2. Reproduction (if applicable)
+
+- **Environment**: All sessions. Worst case `ses_096cf8c43ffecAx2ProIeW6KHS` block b27: 72K tokens → 147 chars (0.05% retention), 0/20 top keywords covered.
+- **Minimal reproduction steps**:
+  1. Run any long session
+  2. Inspect blocks via `acp-inspect <sid> --blocks`
+  3. Look for summaries < 200 chars or with content coverage near zero
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+  - Backward compatibility: existing configs must keep working (qualityGate section is optional, defaults to disabled-or-defaults)
+  - Performance: gate runs ONCE per compress call, not per transform hook. Must be < 10ms for typical blocks.
+  - No new runtime dependencies (tokenizer is hand-rolled, no nltk/bert).
+  - TypeScript strict mode, ESM, no `as any`.
+- **Non-Goals** (explicitly out of scope for THIS iteration):
+  - External API gate (HTTP call to LLM judge) — interface must ALLOW it, but not implemented now
+  - Auto-rejection of bad compressions (only warn + log)
+  - Auto-decompression of bad blocks (future iteration)
+  - Multilingual tokenization beyond EN + ZH (future)
+
+## 4. Acceptance Criteria (must be testable)
+
+- **Correctness**:
+  - [ ] `QualityGate` interface defined with `name`, `evaluate(ctx)` returning `{ passed, layer?, reason?, metrics? }`
+  - [ ] Registry: `registerQualityGate(gate)`, `getQualityGate(name)`
+  - [ ] Default algorithm `rouge-recall-v1` implements Layer 1 (length) + Layer 2 (rougeF1 AND top20Recall)
+  - [ ] Config schema supports `qualityGate.enabled`, `qualityGate.algorithm`, `qualityGate.algorithms["rouge-recall-v1"]`
+  - [ ] `pipeline.finalizeSession` calls the active gate for each block, logs warning on failure
+  - [ ] Failed gates do NOT block compression or throw
+- **Performance / Stability**:
+  - [ ] Gate evaluation < 10ms for 50K-token original + 3K-char summary
+  - [ ] Tokenizer allocates no unnecessary intermediate strings
+- **Regression**:
+  - [ ] New tests: tokenizer, gate logic, registry, pipeline integration
+  - [ ] All 599 existing tests pass
+  - [ ] Type check + build pass
+
+## 5. Proposed Approach
+
+See `DESIGN.md` for the full architecture.
+
+- **Affected modules & entry files**:
+  - New: `lib/compress/quality-gate/` (tokenizer.ts, types.ts, registry.ts, algorithms/rouge-recall-v1.ts, index.ts)
+  - Modified: `lib/config.ts` (add `qualityGate` config + merge logic), `lib/config-validation.ts` (add keys)
+  - Modified: `lib/compress/pipeline.ts` (call gate in `finalizeSession`)
+  - Modified: `dcp.schema.json` (add schema for new config keys)
+- **Risks**:
+  - Gate false-positives annoy users — mitigated by conservative thresholds (rougeF1<0.05 AND top20<0.20 = 6.6% FPR)
+  - Tokenizer ZH coverage — mitigated by combining ZH unigrams + bigrams
+- **Rollback strategy**: Set `qualityGate.enabled = false` in config. No persisted state changes.

--- a/devlog/2026-07-19_quality-gate/WORKLOG.md
+++ b/devlog/2026-07-19_quality-gate/WORKLOG.md
@@ -1,0 +1,80 @@
+# WORKLOG — Quality Gate (Issue #20, v1.13.0)
+
+## Goal
+
+Add a pluggable post-compression quality gate that detects summaries which catastrophically lost content. Non-blocking — failures only `logger.warn`. Default algorithm `rouge-recall-v1` calibrated against 6,913 real-world blocks.
+
+## Branch
+
+`2026-07-19_quality-gate` from `master`.
+
+## Implementation
+
+### Files created
+
+| File | Purpose |
+|---|---|
+| `lib/compress/quality-gate/types.ts` | `QualityGate`, `QualityGateContext`, `QualityGateResult`, `QualityGateMetric`, `QualityReport` |
+| `lib/compress/quality-gate/registry.ts` | Singleton `Map` of registered gates. Idempotent registration; conflicts on same-name+different-version throw. |
+| `lib/compress/quality-gate/tokenizer.ts` | Hand-rolled word-level tokenizer (English keywords ≥4 chars + Chinese unigrams/bigrams). Separate from ACP's BPE tokenizer — too coarse for ROUGE. |
+| `lib/compress/quality-gate/algorithms/rouge-recall-v1.ts` | Default algorithm. Two-layer: L1 length floor (200 chars OR 1% retention), L2 AND-combine (ROUGE-1 F1 < 0.05 AND top-20 recall < 0.20). |
+| `lib/compress/quality-gate/algorithms/index.ts` | `ensureBuiltinGatesRegistered()` idempotent initializer. |
+| `lib/compress/quality-gate/evaluate.ts` | `evaluateBlockQuality()` + `evaluateBatchQuality()`. Walks `block.directMessageIds`, extracts text/tool content, runs gate. Try/catch wraps evaluate — on throw → `{ passed: true, metrics: [] }`. |
+| `lib/compress/quality-gate/index.ts` | Barrel export. |
+| `tests/quality-gate-tokenizer.test.ts` | 33 tests covering empty input, EN length filter, lowercase, digit filter, alphanumeric words, ZH unigrams+bigrams, ZH stopword filter, mixed EN+ZH, opts flags, termFrequency, topKByTf, extractFilePaths, rouge1 recall/precision/F1, topKRecall, jaccard. |
+| `tests/quality-gate-registry.test.ts` | 8 tests: getQualityGate for unknown, register+get roundtrip, same-object re-register, same-name+same-version allowed, same-name+different-version throws, listQualityGates sorted, list empty, clear. |
+| `tests/quality-gate-rouge-recall-v1.test.ts` | 21 tests: name/version stability, defaults, L1 failures (short/retention/boundary), L2 failures (b27 regression, AND-combine), metrics field coverage, pathCoverage, empty original skip-L2, custom config overrides, invalid config fallback, undefined config, mixed EN+ZH, b27 retention regression. |
+| `tests/quality-gate-pipeline-integration.test.ts` | 12 tests covering `evaluateBlockQuality` + `evaluateBatchQuality`: disabled returns null, enabled runs gate, missing block, no direct messages, partial messages, tool-call content extraction, empty entries, all-passing, all-failing, mixed, gate disabled, unknown algorithm. |
+
+### Files modified
+
+| File | Change |
+|---|---|
+| `lib/config.ts` | Added `QualityGateConfig` interface + `qualityGate` field on `PluginConfig` + default config + `mergeQualityGate()` + clone support. |
+| `lib/config-validation.ts` | Added 4 VALID_CONFIG_KEYS: `qualityGate`, `qualityGate.enabled`, `qualityGate.algorithm`, `qualityGate.algorithms`. |
+| `lib/compress/pipeline.ts` | `finalizeSession()` now calls `evaluateBatchQuality()` after state save when `entries.length > 0`. Failures → `ctx.logger.warn("Compression quality gate FAILED", ...)`. Non-blocking. |
+| `dcp.schema.json` | Added `qualityGate.*` schema with defaults matching code. |
+| `README.md` | New "Quality gate" section under "How It Works". New default-config block. v1.13.0 changelog entry. |
+| `README.zh-CN.md` | 同步中文翻译。 |
+| `AGENTS.md` | Module map updated with `lib/compress/quality-gate/` subtree. Pipeline dataflow line updated. |
+
+### Algorithm decisions
+
+- **Non-blocking**: Model already moved on by the time the gate runs; rejecting the compression would leave state inconsistent. Failures only `logger.warn`.
+- **Sync signature today**: Future external-API gates need either type widening or internal wait+timeout wrap. Registry/config shape unchanged.
+- **L1 length floor**: 200 chars / 1% retention. Calibrated against 6,913 real-world blocks → 100% recall on catastrophic failures, 0% FPR.
+- **L2 AND-combine**: OR would push FPR to 30%+; AND keeps FPR at ~6.6% while still catching the "long enough but content-empty" failure mode.
+- **Default `enabled: false`**: One release burn-in before flipping default. Users opt in via config.
+- **Hand-rolled tokenizer**: ACP's BPE tokenizer is wrong granularity for ROUGE. English keywords ≥4 chars (filters noise), Chinese unigrams+bigrams (captures meaningful CJK units).
+- **Top-K constant K=20**: Matches calibration.
+- **Path coverage**: Only reported when original has ≥5 distinct paths (otherwise noise).
+
+### Bug found and fixed during implementation
+
+`rouge-recall-v1.evaluate()` originally computed `retentionPct = originalChars > 0 ? ... : 0` then checked `retentionPct < threshold`. When `originalText` is empty, this always failed L1. Fixed: only check retention when `originalChars > 0` (no signal when original is empty).
+
+## Verification
+
+```
+typecheck: PASS
+build: PASS (npm run build)
+tests: 842/842 PASS  (was 768; +74 new tests)
+```
+
+Test breakdown:
+- `quality-gate-tokenizer.test.ts`: 33/33
+- `quality-gate-registry.test.ts`: 8/8
+- `quality-gate-rouge-recall-v1.test.ts`: 21/21
+- `quality-gate-pipeline-integration.test.ts`: 12/12
+- All other 768 existing tests: unchanged, still passing
+
+## TODO (post-merge)
+
+- Dual-agent code review (lib + tests)
+- After one release burn-in, flip `qualityGate.enabled` default to `true`
+- Consider future external-API judge algorithm (LLM-as-judge)
+
+## Notes
+
+- Pre-edit hook fires on every comment/docstring. Strategy: keep only (a) public-API contract docs, (b) algorithm/math rationale, (c) bug-case traceability. Drop section dividers and obvious field descriptions. Each hook trigger acknowledged individually with this priority list.
+- Tests use `TEST_CONFIG` (lowered L1 thresholds) to isolate Layer 2 logic. The DEFAULT config is tested separately in dedicated tests.

--- a/lib/compress/pipeline.ts
+++ b/lib/compress/pipeline.ts
@@ -10,6 +10,7 @@ import type { ToolContext } from "./types"
 import { buildSearchContext, fetchSessionMessages } from "./search"
 import type { SearchContext } from "./types"
 import { applyPendingCompressionDurations } from "./timing"
+import { evaluateBatchQuality } from "./quality-gate"
 
 export interface CompressionSnapshot {
     messages: PruneMessagesState
@@ -110,6 +111,28 @@ export async function finalizeSession(
     ctx.state.manualMode = ctx.state.manualMode ? "active" : false
     applyPendingCompressionDurations(ctx.state)
     await saveSessionState(ctx.state, ctx.logger)
+
+    if (entries.length > 0) {
+        const qualityReport = evaluateBatchQuality(
+            ctx.state,
+            rawMessages,
+            entries,
+            ctx.config,
+            ctx.logger,
+        )
+        for (const failure of qualityReport.failures) {
+            const metrics = Object.fromEntries(
+                failure.result.metrics.map((m) => [m.name, m.value]),
+            )
+            ctx.logger.warn("Compression quality gate FAILED", {
+                blockId: failure.blockId,
+                algorithm: ctx.config.qualityGate.algorithm,
+                layer: failure.result.layer,
+                reason: failure.result.reason,
+                ...metrics,
+            })
+        }
+    }
 
     const params = getCurrentParams(ctx.state, rawMessages, ctx.logger)
     const sessionMessageIds = rawMessages

--- a/lib/compress/quality-gate/algorithms/index.ts
+++ b/lib/compress/quality-gate/algorithms/index.ts
@@ -1,0 +1,12 @@
+import { registerQualityGate } from "../registry"
+import { rougeRecallV1 } from "./rouge-recall-v1"
+
+let initialized = false
+
+export function ensureBuiltinGatesRegistered(): void {
+    if (initialized) return
+    registerQualityGate(rougeRecallV1)
+    initialized = true
+}
+
+export { rougeRecallV1 } from "./rouge-recall-v1"

--- a/lib/compress/quality-gate/algorithms/rouge-recall-v1.ts
+++ b/lib/compress/quality-gate/algorithms/rouge-recall-v1.ts
@@ -1,0 +1,127 @@
+import type { QualityGate, QualityGateContext, QualityGateResult, QualityGateMetric } from "../types"
+import {
+    tokenize,
+    rouge1F1,
+    rouge1Recall,
+    topKRecall,
+    extractFilePaths,
+} from "../tokenizer"
+
+export interface RougeRecallV1Config {
+    layer1MinChars: number
+    layer1MinRetentionPct: number
+    layer2MaxRougeF1: number
+    layer2MaxTop20Recall: number
+}
+
+export const DEFAULT_ROUGE_RECALL_V1_CONFIG: RougeRecallV1Config = {
+    layer1MinChars: 200,
+    layer1MinRetentionPct: 1.0,
+    layer2MaxRougeF1: 0.05,
+    layer2MaxTop20Recall: 0.20,
+}
+
+const TOP_K = 20
+const ORIGINAL_TOKEN_ESTIMATE_CHARS_PER_TOKEN = 4
+
+function resolveConfig(input: unknown): RougeRecallV1Config {
+    if (!input || typeof input !== "object") return DEFAULT_ROUGE_RECALL_V1_CONFIG
+    const c = input as Partial<RougeRecallV1Config>
+    return {
+        layer1MinChars: typeof c.layer1MinChars === "number" && c.layer1MinChars > 0
+            ? c.layer1MinChars : DEFAULT_ROUGE_RECALL_V1_CONFIG.layer1MinChars,
+        layer1MinRetentionPct: typeof c.layer1MinRetentionPct === "number" && c.layer1MinRetentionPct >= 0
+            ? c.layer1MinRetentionPct : DEFAULT_ROUGE_RECALL_V1_CONFIG.layer1MinRetentionPct,
+        layer2MaxRougeF1: typeof c.layer2MaxRougeF1 === "number" && c.layer2MaxRougeF1 >= 0
+            ? c.layer2MaxRougeF1 : DEFAULT_ROUGE_RECALL_V1_CONFIG.layer2MaxRougeF1,
+        layer2MaxTop20Recall: typeof c.layer2MaxTop20Recall === "number" && c.layer2MaxTop20Recall >= 0
+            ? c.layer2MaxTop20Recall : DEFAULT_ROUGE_RECALL_V1_CONFIG.layer2MaxTop20Recall,
+    }
+}
+
+/**
+ * Layer 1 (length gate):
+ * - 100% coverage of catastrophic-retention failures (<1% retention)
+ * - 0% FPR on healthy summaries (≥5% retention) in calibration (n=6913)
+ *
+ * Layer 2 (content coverage AND-combine):
+ * - Only runs on blocks that PASS Layer 1
+ * - Flags if BOTH rougeF1 < threshold AND top20Recall < threshold
+ * - AND-combine keeps FPR ~6.6% on healthy summaries while catching
+ *   the "long enough but content-empty" failure mode (e.g. 996-char summary
+ *   of 5K-token original that captures 0.6% of content words).
+ */
+export const rougeRecallV1: QualityGate = {
+    name: "rouge-recall-v1",
+    version: "1.0.0",
+    description: "Two-layer gate: length floor (L1) then ROUGE-1 F1 AND top-20 keyword recall (L2)",
+
+    evaluate(ctx: QualityGateContext, rawConfig: unknown): QualityGateResult {
+        const cfg = resolveConfig(rawConfig)
+        const summaryLen = ctx.summary.length
+        const originalChars = ctx.originalText.length
+        const retentionPct = originalChars > 0
+            ? (summaryLen / (ctx.block.compressedTokens * ORIGINAL_TOKEN_ESTIMATE_CHARS_PER_TOKEN)) * 100
+            : 0
+
+        const baseMetrics: QualityGateMetric[] = [
+            { name: "summaryLen", value: summaryLen },
+            { name: "retentionPct", value: +retentionPct.toFixed(2), format: "percent" },
+            { name: "originalTokens", value: ctx.block.compressedTokens },
+        ]
+
+        if (
+            summaryLen < cfg.layer1MinChars ||
+            (originalChars > 0 && retentionPct < cfg.layer1MinRetentionPct)
+        ) {
+            return {
+                passed: false,
+                layer: "L1-length",
+                reason: `Summary too short: ${summaryLen} chars, ${retentionPct.toFixed(2)}% retention ` +
+                    `(threshold: ${cfg.layer1MinChars} chars OR ${cfg.layer1MinRetentionPct}% retention)`,
+                metrics: baseMetrics,
+            }
+        }
+
+        if (ctx.originalText.length === 0) {
+            return { passed: true, metrics: baseMetrics }
+        }
+
+        const summaryTokens = tokenize(ctx.summary)
+        const originalTokens = tokenize(ctx.originalText)
+        const rougeF1 = rouge1F1(summaryTokens, originalTokens)
+        const rougeRecall = rouge1Recall(summaryTokens, originalTokens)
+        const top20 = topKRecall(summaryTokens, originalTokens, TOP_K)
+
+        const summaryPaths = extractFilePaths(ctx.summary)
+        const originalPaths = extractFilePaths(ctx.originalText)
+        const pathCoverage = originalPaths.size >= 5
+            ? [...summaryPaths].filter((p) => originalPaths.has(p)).length / originalPaths.size
+            : -1
+
+        const contentMetrics: QualityGateMetric[] = [
+            ...baseMetrics,
+            { name: "rougeF1", value: +rougeF1.toFixed(4), format: "ratio" },
+            { name: "rougeRecall", value: +rougeRecall.toFixed(4), format: "ratio" },
+            { name: "top20Recall", value: +top20.toFixed(4), format: "ratio" },
+            { name: "nOriginalPaths", value: originalPaths.size },
+            { name: "nSummaryPaths", value: summaryPaths.size },
+        ]
+        if (pathCoverage >= 0) {
+            contentMetrics.push({ name: "pathCoverage", value: +pathCoverage.toFixed(3), format: "ratio" })
+        }
+
+        if (rougeF1 < cfg.layer2MaxRougeF1 && top20 < cfg.layer2MaxTop20Recall) {
+            return {
+                passed: false,
+                layer: "L2-recall",
+                reason: `Content coverage too low: rougeF1=${rougeF1.toFixed(3)}, ` +
+                    `top20Recall=${top20.toFixed(3)} ` +
+                    `(threshold: rougeF1<${cfg.layer2MaxRougeF1} AND top20<${cfg.layer2MaxTop20Recall})`,
+                metrics: contentMetrics,
+            }
+        }
+
+        return { passed: true, metrics: contentMetrics }
+    },
+}

--- a/lib/compress/quality-gate/evaluate.ts
+++ b/lib/compress/quality-gate/evaluate.ts
@@ -2,6 +2,7 @@ import type { Logger } from "../../logger"
 import type { PluginConfig } from "../../config"
 import type { SessionState, WithParts } from "../../state/types"
 import type { CompressionBlock } from "../../state/types"
+import type { Part } from "@opencode-ai/sdk/v2"
 import type {
     QualityGateContext,
     QualityGateResult,
@@ -12,25 +13,27 @@ import { ensureBuiltinGatesRegistered } from "./algorithms"
 import { getQualityGate } from "./registry"
 
 const CHARS_PER_TOKEN_ESTIMATE = 4
+const TOOL_OUTPUT_MAX_CHARS = 1500
+const TOOL_INPUT_MAX_CHARS = 500
 
-function extractMessageText(parts: { type: string; text?: string; tool?: string; state?: { input?: unknown; output?: unknown } }[] | undefined): string {
+function extractMessageText(parts: Part[] | undefined): string {
     if (!parts || !Array.isArray(parts)) return ""
     let text = ""
     for (const part of parts) {
         if (!part || typeof part !== "object") continue
-        if (part.type === "text" && typeof part.text === "string") {
+        if (part.type === "text") {
             text += part.text + "\n"
         } else if (part.type === "tool") {
-            const toolName = part.tool ?? ""
-            const input = part.state && typeof part.state.input === "object"
-                ? JSON.stringify(part.state.input).slice(0, 500)
+            const state = part.state
+            const input = state.status === "completed" && typeof state.input === "object"
+                ? JSON.stringify(state.input).slice(0, TOOL_INPUT_MAX_CHARS)
                 : ""
-            const output = part.state && typeof part.state.output === "string"
-                ? part.state.output.slice(0, 1500)
-                : part.state && typeof part.state.output === "object"
-                  ? JSON.stringify(part.state.output).slice(0, 1500)
+            const output = state.status === "completed" && typeof state.output === "string"
+                ? state.output.slice(0, TOOL_OUTPUT_MAX_CHARS)
+                : state.status === "completed" && typeof state.output === "object"
+                  ? JSON.stringify(state.output).slice(0, TOOL_OUTPUT_MAX_CHARS)
                   : ""
-            text += `[tool:${toolName}] ${input}\n${output}\n`
+            text += `[tool:${part.tool}] ${input}\n${output}\n`
         }
     }
     return text
@@ -53,7 +56,7 @@ function buildContext(
     for (const id of directIds) {
         const m = idToMsg.get(id)
         if (!m) continue
-        chunks.push(extractMessageText(m.parts as any))
+        chunks.push(extractMessageText(m.parts))
     }
     if (chunks.length === 0) return null
 
@@ -74,7 +77,7 @@ export function evaluateBlockQuality(
     config: PluginConfig,
     logger: Logger,
 ): QualityGateResult | null {
-    const qg = (config as PluginConfig & { qualityGate?: { enabled?: boolean; algorithm?: string; algorithms?: Record<string, unknown> } }).qualityGate
+    const qg = config.qualityGate
     if (!qg || qg.enabled !== true) return null
 
     ensureBuiltinGatesRegistered()

--- a/lib/compress/quality-gate/evaluate.ts
+++ b/lib/compress/quality-gate/evaluate.ts
@@ -1,0 +1,133 @@
+import type { Logger } from "../../logger"
+import type { PluginConfig } from "../../config"
+import type { SessionState, WithParts } from "../../state/types"
+import type { CompressionBlock } from "../../state/types"
+import type {
+    QualityGateContext,
+    QualityGateResult,
+    QualityReport,
+} from "./types"
+import type { NotificationEntry } from "../pipeline"
+import { ensureBuiltinGatesRegistered } from "./algorithms"
+import { getQualityGate } from "./registry"
+
+const CHARS_PER_TOKEN_ESTIMATE = 4
+
+function extractMessageText(parts: { type: string; text?: string; tool?: string; state?: { input?: unknown; output?: unknown } }[] | undefined): string {
+    if (!parts || !Array.isArray(parts)) return ""
+    let text = ""
+    for (const part of parts) {
+        if (!part || typeof part !== "object") continue
+        if (part.type === "text" && typeof part.text === "string") {
+            text += part.text + "\n"
+        } else if (part.type === "tool") {
+            const toolName = part.tool ?? ""
+            const input = part.state && typeof part.state.input === "object"
+                ? JSON.stringify(part.state.input).slice(0, 500)
+                : ""
+            const output = part.state && typeof part.state.output === "string"
+                ? part.state.output.slice(0, 1500)
+                : part.state && typeof part.state.output === "object"
+                  ? JSON.stringify(part.state.output).slice(0, 1500)
+                  : ""
+            text += `[tool:${toolName}] ${input}\n${output}\n`
+        }
+    }
+    return text
+}
+
+function buildContext(
+    block: CompressionBlock,
+    rawMessages: WithParts[],
+): QualityGateContext | null {
+    const directIds = block.directMessageIds
+    if (!directIds || directIds.length === 0) return null
+
+    const idToMsg = new Map<string, WithParts>()
+    for (const m of rawMessages) {
+        const id = m?.info?.id
+        if (typeof id === "string") idToMsg.set(id, m)
+    }
+
+    const chunks: string[] = []
+    for (const id of directIds) {
+        const m = idToMsg.get(id)
+        if (!m) continue
+        chunks.push(extractMessageText(m.parts as any))
+    }
+    if (chunks.length === 0) return null
+
+    const originalText = chunks.join("\n")
+    return {
+        block,
+        summary: block.summary ?? "",
+        originalChunks: chunks,
+        originalText,
+        originalTokens: Math.ceil(originalText.length / CHARS_PER_TOKEN_ESTIMATE),
+    }
+}
+
+export function evaluateBlockQuality(
+    state: SessionState,
+    rawMessages: WithParts[],
+    entry: NotificationEntry,
+    config: PluginConfig,
+    logger: Logger,
+): QualityGateResult | null {
+    const qg = (config as PluginConfig & { qualityGate?: { enabled?: boolean; algorithm?: string; algorithms?: Record<string, unknown> } }).qualityGate
+    if (!qg || qg.enabled !== true) return null
+
+    ensureBuiltinGatesRegistered()
+    const algoName = qg.algorithm
+    if (!algoName) {
+        logger.warn("Quality gate enabled but no algorithm specified", {})
+        return null
+    }
+    const gate = getQualityGate(algoName)
+    if (!gate) {
+        logger.warn("Quality gate algorithm not found in registry", { algorithm: algoName })
+        return null
+    }
+
+    const block = state.prune.messages.blocksById.get(entry.blockId)
+    if (!block) {
+        logger.warn("Quality gate: block not found", { blockId: entry.blockId })
+        return null
+    }
+
+    const ctx = buildContext(block, rawMessages)
+    if (!ctx) return null
+
+    const algoConfig = (qg.algorithms && qg.algorithms[algoName]) ?? {}
+    try {
+        return gate.evaluate(ctx, algoConfig)
+    } catch (err) {
+        logger.warn("Quality gate threw — treating as pass", {
+            gate: gate.name,
+            blockId: entry.blockId,
+            error: err instanceof Error ? err.message : String(err),
+        })
+        return { passed: true, metrics: [] }
+    }
+}
+
+export function evaluateBatchQuality(
+    state: SessionState,
+    rawMessages: WithParts[],
+    entries: NotificationEntry[],
+    config: PluginConfig,
+    logger: Logger,
+): QualityReport {
+    const failures: QualityReport["failures"] = []
+    for (const entry of entries) {
+        const result = evaluateBlockQuality(state, rawMessages, entry, config, logger)
+        if (result && !result.passed) {
+            failures.push({ blockId: entry.blockId, result })
+        }
+    }
+    return {
+        total: entries.length,
+        passed: entries.length - failures.length,
+        failures,
+    }
+}

--- a/lib/compress/quality-gate/index.ts
+++ b/lib/compress/quality-gate/index.ts
@@ -1,0 +1,21 @@
+export type {
+    QualityGate,
+    QualityGateContext,
+    QualityGateResult,
+    QualityGateMetric,
+    QualityReport,
+} from "./types"
+
+export {
+    registerQualityGate,
+    getQualityGate,
+    listQualityGates,
+    clearQualityGateRegistryForTests,
+} from "./registry"
+
+export { evaluateBlockQuality, evaluateBatchQuality } from "./evaluate"
+export { ensureBuiltinGatesRegistered } from "./algorithms"
+export { rougeRecallV1 } from "./algorithms"
+export type { RougeRecallV1Config } from "./algorithms/rouge-recall-v1"
+export { DEFAULT_ROUGE_RECALL_V1_CONFIG } from "./algorithms/rouge-recall-v1"
+export * from "./tokenizer"

--- a/lib/compress/quality-gate/registry.ts
+++ b/lib/compress/quality-gate/registry.ts
@@ -1,0 +1,27 @@
+import type { QualityGate } from "./types"
+
+const registry = new Map<string, QualityGate>()
+
+export function registerQualityGate(gate: QualityGate): void {
+    if (registry.has(gate.name)) {
+        const existing = registry.get(gate.name)!
+        if (existing !== gate && existing.version !== gate.version) {
+            throw new Error(
+                `Quality gate "${gate.name}" already registered with version ${existing.version} (attempted ${gate.version})`,
+            )
+        }
+    }
+    registry.set(gate.name, gate)
+}
+
+export function getQualityGate(name: string): QualityGate | undefined {
+    return registry.get(name)
+}
+
+export function listQualityGates(): string[] {
+    return [...registry.keys()].sort()
+}
+
+export function clearQualityGateRegistryForTests(): void {
+    registry.clear()
+}

--- a/lib/compress/quality-gate/tokenizer.ts
+++ b/lib/compress/quality-gate/tokenizer.ts
@@ -1,0 +1,192 @@
+/**
+ * Hand-rolled tokenizer for content-coverage metrics.
+ *
+ * Why hand-rolled:
+ * - ACP's @anthropic-ai/tokenizer is BPE — great for cost, bad for word-level recall.
+ * - We need word-level tokens (unigrams) for ROUGE-style matching.
+ * - No new runtime deps.
+ *
+ * Tokenization rules:
+ * - English: `[a-z][a-z0-9_]+` words, length ≥ 4, not in stopword set
+ * - Chinese: every CJK char as a unigram + every adjacent pair as a bigram (excluding stopword pairs)
+ * - Punctuation, whitespace, and other scripts are separators (not tokenized)
+ */
+
+const ENGLISH_WORD_RE = /[a-z][a-z0-9_]+/g
+const CJK_RE = /[\u4e00-\u9fff]/g
+const FILE_PATH_RE = /(?:[a-zA-Z0-9_-]+\/){1,}[a-zA-Z0-9_-]+\.[a-zA-Z]{1,5}/g
+
+const STOPWORDS = new Set<string>([
+    "the","that","this","these","those","there","their","them","then","than","thats",
+    "with","will","would","could","should","from","have","has","had","having","were","what",
+    "which","when","where","while","your","yours","theirs","ours","mine","hers","whose",
+    "they","them","those","these","this","that","such","some","same","other","another","each",
+    "into","onto","upon","over","under","between","through","during","before","after","above",
+    "below","among","across","along","around","about","because","since","unless",
+    "although","though","whereas","whether","either","neither","both","also","only",
+    "just","very","more","most","much","many","less","least","several","enough",
+    "make","made","makes","making","take","took","taken","takes","taking","get","got",
+    "getting","gets","give","gave","given","gives","giving","come","came","comes","coming",
+    "were","been","being","have","make","want","need","using",
+    "true","false","null","undefined","void","return","returns","returning","function",
+    "const","class","interface","type","typeof","instanceof","import","export",
+    "require","module","default","async","await","static","public","private",
+    "protected","readonly","partial","abstract","virtual","override","final","super",
+    "value","values","param","params","name","names",
+    "test","tests","testing","tested","expect","expected","actual","actuals","result",
+    "results","output","outputs","input","inputs","data","record","records","item","items",
+    "like","want","need","used","uses","said","say","says","went","goes",
+    "here","there","where","when","what","who","how","why","which","whose","whom",
+    "yourself","myself","itself","themselves","ourselves","himself","herself",
+    "yeah","okay","ok","yes","no","not","nor","or","and","but","if","then","else","elif",
+    "when","while","for","to","of","in","on","at","by","with","from","into","onto",
+    "的","是","了","在","和","与","或","也","都","就","还","又","才","再","已","将","会",
+    "能","可","可以","要","想","需要","应该","必须","没","没有","不","非","无","莫",
+    "我","你","他","她","它","我们","你们","他们","她们","它们","咱","咱们","自己",
+    "这","那","这个","那个","这些","那些","这样","那样","这里","那里","这么","那么",
+    "什么","怎么","为什么","哪","哪个","哪些","哪里","怎样","多少","几","多","少",
+    "于","从","向","往","到","至","为","对于","关于","至于","由于","因为","所以",
+    "但是","但","不过","然而","可是","只是","只有","除了","除非","无论","不管","尽管",
+    "虽然","虽说","即使","即便","哪怕","一旦","如果","要是","假如","假使","倘若",
+    "之","其","其中","其他","其它","其余","另一","另外","此外","并且","并","且",
+    "着","过","吧","吗","呢","啊","哦","嗯","呀","哇","哈","嘛","咯","哟",
+])
+
+const ZH_STOPWORD_BIGRAMS = new Set<string>([
+    "我们","你们","他们","她们","它们","咱们","这个","那个","这些","那些","什么","怎么",
+    "为什么","如何","可以","应该","但是","因为","所以","如果","虽然","即使","尽管",
+    "为了","由于","不但","而且","并且","或者","还是","以及","以为","于是","然而",
+    "其实","就是","只是","只有","除了","除非","这样","那样","这么","那么","这些",
+    "那些","这里","那里","现在","以后","以前","之后","之前","然后","当然","可能",
+    "一些","许多","非常","十分","比较","更加","最为","也是","还是","就是","不过",
+    "不要","不能","不会","没有","不是","不用","不必","一直","已经","正在","马上",
+])
+
+export interface TokenizeOptions {
+    english?: boolean
+    zhUnigrams?: boolean
+    /** ZH bigrams reduce false positives — single chars like 的/了 are noisy even after stopword removal. */
+    zhBigrams?: boolean
+}
+
+const DEFAULT_OPTS: Required<TokenizeOptions> = {
+    english: true,
+    zhUnigrams: true,
+    zhBigrams: true,
+}
+
+export function tokenize(text: string, opts: TokenizeOptions = {}): string[] {
+    if (!text || typeof text !== "string") return []
+    const options = { ...DEFAULT_OPTS, ...opts }
+    const tokens: string[] = []
+    const lower = text.toLowerCase()
+
+    if (options.english) {
+        const matches = lower.match(ENGLISH_WORD_RE)
+        if (matches) {
+            for (const w of matches) {
+                if (w.length >= 4 && !STOPWORDS.has(w) && !/^\d+$/.test(w)) {
+                    tokens.push(w)
+                }
+            }
+        }
+    }
+
+    if (options.zhUnigrams || options.zhBigrams) {
+        const cjkChars = text.match(CJK_RE)
+        if (cjkChars && cjkChars.length > 0) {
+            const cjkStr = cjkChars.join("")
+            if (options.zhUnigrams) {
+                for (const c of cjkStr) {
+                    if (!STOPWORDS.has(c)) tokens.push(c)
+                }
+            }
+            if (options.zhBigrams) {
+                for (let i = 0; i < cjkStr.length - 1; i++) {
+                    const bg = cjkStr.slice(i, i + 2)
+                    if (!ZH_STOPWORD_BIGRAMS.has(bg) && !STOPWORDS.has(bg[0]!) && !STOPWORDS.has(bg[1]!)) {
+                        tokens.push(bg)
+                    }
+                }
+            }
+        }
+    }
+
+    return tokens
+}
+
+export function termFrequency(tokens: string[]): Map<string, number> {
+    const tf = new Map<string, number>()
+    for (const t of tokens) {
+        tf.set(t, (tf.get(t) ?? 0) + 1)
+    }
+    return tf
+}
+
+export function topKByTf(tokens: string[], k: number): string[] {
+    if (tokens.length === 0 || k <= 0) return []
+    const tf = termFrequency(tokens)
+    const sorted = [...tf.entries()].sort((a, b) => {
+        if (b[1] !== a[1]) return b[1] - a[1]
+        return a[0].localeCompare(b[0])
+    })
+    return sorted.slice(0, k).map((e) => e[0])
+}
+
+export function extractFilePaths(text: string): Set<string> {
+    if (!text) return new Set()
+    const paths = new Set<string>()
+    const matches = text.match(FILE_PATH_RE)
+    if (matches) {
+        for (const m of matches) paths.add(m)
+    }
+    return paths
+}
+
+/**
+ * ROUGE-1 recall: fraction of original unigrams that also appear in summary.
+ * Uses unique-token sets (type-level), not token counts.
+ */
+export function rouge1Recall(summaryTokens: string[], originalTokens: string[]): number {
+    if (originalTokens.length === 0) return 0
+    const summarySet = new Set(summaryTokens)
+    const originalSet = new Set(originalTokens)
+    let hit = 0
+    for (const t of originalSet) if (summarySet.has(t)) hit++
+    return hit / originalSet.size
+}
+
+export function rouge1Precision(summaryTokens: string[], originalTokens: string[]): number {
+    if (summaryTokens.length === 0) return 0
+    const summarySet = new Set(summaryTokens)
+    const originalSet = new Set(originalTokens)
+    let hit = 0
+    for (const t of summarySet) if (originalSet.has(t)) hit++
+    return hit / summarySet.size
+}
+
+export function rouge1F1(summaryTokens: string[], originalTokens: string[]): number {
+    const r = rouge1Recall(summaryTokens, originalTokens)
+    const p = rouge1Precision(summaryTokens, originalTokens)
+    if (r + p === 0) return 0
+    return (2 * r * p) / (r + p)
+}
+
+export function topKRecall(summaryTokens: string[], originalTokens: string[], k: number): number {
+    if (originalTokens.length === 0 || k <= 0) return 0
+    const top = topKByTf(originalTokens, k)
+    if (top.length === 0) return 0
+    const summarySet = new Set(summaryTokens)
+    let hit = 0
+    for (const t of top) if (summarySet.has(t)) hit++
+    return hit / top.length
+}
+
+export function jaccardSimilarity(a: string[], b: string[]): number {
+    const setA = new Set(a)
+    const setB = new Set(b)
+    if (setA.size === 0 && setB.size === 0) return 0
+    let inter = 0
+    for (const t of setA) if (setB.has(t)) inter++
+    return inter / (setA.size + setB.size - inter)
+}

--- a/lib/compress/quality-gate/types.ts
+++ b/lib/compress/quality-gate/types.ts
@@ -1,0 +1,56 @@
+import type { CompressionBlock } from "../../state/types"
+
+/**
+ * Quality gate framework — pluggable post-compression quality checks.
+ *
+ * Gates are non-blocking: failures warn via logger, they never reject the
+ * compression (the model has already moved on). The framework is designed
+ * so that future algorithms (external LLM judges, BERTScore, custom models)
+ * can be added by registering a new `QualityGate` implementation.
+ */
+
+export interface QualityGateContext {
+    block: CompressionBlock
+    summary: string
+    originalChunks: string[]
+    originalText: string
+    originalTokens: number
+}
+
+export interface QualityGateMetric {
+    name: string
+    value: number
+    format?: "raw" | "percent" | "ratio"
+}
+
+export interface QualityGateResult {
+    passed: boolean
+    layer?: string
+    reason?: string
+    metrics: QualityGateMetric[]
+}
+
+/**
+ * Pluggable quality-gate algorithm.
+ *
+ * Contract:
+ * - `name` MUST be globally unique and stable across versions (config refers to it).
+ * - `version` SHOULD bump when thresholds or logic change.
+ * - `evaluate` MUST NOT throw — on internal error, return `{ passed: true, metrics: [] }`.
+ *   Throwing would break the compression pipeline.
+ */
+export interface QualityGate {
+    name: string
+    version: string
+    description: string
+    evaluate(ctx: QualityGateContext, config: unknown): QualityGateResult
+}
+
+export interface QualityReport {
+    total: number
+    passed: number
+    failures: Array<{
+        blockId: number
+        result: QualityGateResult
+    }>
+}

--- a/lib/config-validation.ts
+++ b/lib/config-validation.ts
@@ -67,6 +67,10 @@ export const VALID_CONFIG_KEYS = new Set([
     "strategies.purgeErrors.enabled",
     "strategies.purgeErrors.turns",
     "strategies.purgeErrors.protectedTools",
+    "qualityGate",
+    "qualityGate.enabled",
+    "qualityGate.algorithm",
+    "qualityGate.algorithms",
 ])
 
 function getConfigKeyPaths(obj: Record<string, any>, prefix = ""): string[] {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -83,6 +83,16 @@ export interface GCConfig {
     batchCleanup: BatchCleanupConfig
 }
 
+export interface QualityGateAlgorithmConfigs {
+    [gateName: string]: unknown
+}
+
+export interface QualityGateConfig {
+    enabled: boolean
+    algorithm: string
+    algorithms: QualityGateAlgorithmConfigs
+}
+
 export interface PluginConfig {
     enabled: boolean
     autoUpdate: boolean
@@ -100,6 +110,7 @@ export interface PluginConfig {
         deduplication: Deduplication
         purgeErrors: PurgeErrors
     }
+    qualityGate: QualityGateConfig
 }
 
 type CompressOverride = Partial<CompressConfig>
@@ -234,6 +245,18 @@ const defaultConfig: PluginConfig = {
             lowThreshold: "55%",
             highThreshold: "75%",
             forceThreshold: "90%",
+        },
+    },
+    qualityGate: {
+        enabled: false,
+        algorithm: "rouge-recall-v1",
+        algorithms: {
+            "rouge-recall-v1": {
+                layer1MinChars: 200,
+                layer1MinRetentionPct: 1.0,
+                layer2MaxRougeF1: 0.05,
+                layer2MaxTop20Recall: 0.20,
+            },
         },
     },
 }
@@ -504,6 +527,11 @@ function deepCloneConfig(config: PluginConfig): PluginConfig {
             ...config.gc,
             batchCleanup: { ...config.gc.batchCleanup },
         },
+        qualityGate: {
+            enabled: config.qualityGate.enabled,
+            algorithm: config.qualityGate.algorithm,
+            algorithms: { ...config.qualityGate.algorithms },
+        },
     }
 }
 
@@ -516,6 +544,18 @@ function mergeGC(base: GCConfig, override?: Partial<GCConfig>): GCConfig {
         ...base,
         ...override,
         batchCleanup: { ...base.batchCleanup, ...(override.batchCleanup ?? {}) },
+    }
+}
+
+function mergeQualityGate(
+    base: QualityGateConfig,
+    override?: Partial<QualityGateConfig>,
+): QualityGateConfig {
+    if (!override) return base
+    return {
+        enabled: override.enabled ?? base.enabled,
+        algorithm: override.algorithm ?? base.algorithm,
+        algorithms: { ...base.algorithms, ...(override.algorithms ?? {}) },
     }
 }
 
@@ -539,6 +579,7 @@ function mergeLayer(config: PluginConfig, data: Record<string, any>): PluginConf
         compress: mergeCompress(config.compress, data.compress as CompressOverride),
         gc: mergeGC(config.gc, data.gc as Partial<GCConfig>),
         strategies: mergeStrategies(config.strategies, data.strategies as any),
+        qualityGate: mergeQualityGate(config.qualityGate, data.qualityGate as Partial<QualityGateConfig>),
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.12.11",
+    "version": "1.13.0",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",

--- a/tests/quality-gate-pipeline-integration.test.ts
+++ b/tests/quality-gate-pipeline-integration.test.ts
@@ -1,0 +1,320 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import type { PluginConfig } from "../lib/config"
+import { Logger } from "../lib/logger"
+import { createSessionState, type WithParts, type CompressionBlock } from "../lib/state"
+import { evaluateBatchQuality, evaluateBlockQuality } from "../lib/compress/quality-gate"
+import type { NotificationEntry } from "../lib/compress/pipeline"
+
+function buildConfig(qualityGateEnabled: boolean): PluginConfig {
+    return {
+        enabled: true,
+        autoUpdate: true,
+        debug: false,
+        pruneNotification: "off",
+        pruneNotificationType: "chat",
+        commands: { enabled: true, protectedTools: [] },
+        manualMode: { enabled: false, automaticStrategies: true },
+        turnProtection: { enabled: false, turns: 4 },
+        experimental: { allowSubAgents: false, customPrompts: false },
+        protectedFilePatterns: [],
+        compress: {
+            mode: "range",
+            permission: "allow",
+            showCompression: false,
+            summaryBuffer: true,
+            maxContextLimit: 150000,
+            minContextLimit: 50000,
+            nudgeFrequency: 5,
+            iterationNudgeThreshold: 15,
+            nudgeForce: "soft",
+            protectedTools: [],
+            protectTags: false,
+            protectUserMessages: false,
+        },
+        strategies: {
+            deduplication: { enabled: true, protectedTools: [] },
+            purgeErrors: { enabled: true, turns: 4, protectedTools: [] },
+        },
+        gc: {
+            algorithm: "truncate",
+            promotionThreshold: 5,
+            maxBlockAge: 15,
+            maxOldGenSummaryLength: 3000,
+            majorGcThresholdPercent: "100%",
+            batchCleanup: { lowThreshold: "60%", highThreshold: "75%", forceThreshold: "90%" },
+        },
+        qualityGate: {
+            enabled: qualityGateEnabled,
+            algorithm: "rouge-recall-v1",
+            algorithms: {
+                "rouge-recall-v1": {
+                    layer1MinChars: 200,
+                    layer1MinRetentionPct: 1.0,
+                    layer2MaxRougeF1: 0.05,
+                    layer2MaxTop20Recall: 0.20,
+                },
+            },
+        },
+    }
+}
+
+function makeBlock(blockId: number, summary: string, directMessageIds: string[], compressedTokens = 1000): CompressionBlock {
+    return {
+        blockId,
+        runId: 1,
+        active: true,
+        deactivatedByUser: false,
+        compressedTokens,
+        summaryTokens: Math.ceil(summary.length / 4),
+        durationMs: 0,
+        mode: "range",
+        topic: "test",
+        batchTopic: "",
+        startId: "m001",
+        endId: "m010",
+        anchorMessageId: "anchor",
+        compressMessageId: "compress",
+        compressCallId: `call-${blockId}`,
+        includedBlockIds: [],
+        consumedBlockIds: [],
+        parentBlockIds: [],
+        directMessageIds,
+        directToolIds: [],
+        effectiveMessageIds: directMessageIds,
+        effectiveToolIds: [],
+        createdAt: 0,
+        summary,
+        survivedCount: 0,
+        generation: "young",
+    }
+}
+
+function makeTextMessage(id: string, text: string): WithParts {
+    return {
+        info: { id, role: "user", sessionId: "test" } as any,
+        parts: [{ type: "text", text }],
+    } as any
+}
+
+function installBlock(state: ReturnType<typeof createSessionState>, block: CompressionBlock): void {
+    state.prune.messages.blocksById.set(block.blockId, block)
+    for (const mid of block.directMessageIds) {
+        state.prune.messages.byMessageId.set(mid, {
+            activeBlockIds: [block.blockId],
+            allBlockIds: [block.blockId],
+        })
+    }
+}
+
+const logger = new Logger(false)
+
+test("evaluateBlockQuality returns null when qualityGate disabled", () => {
+    const state = createSessionState()
+    const block = makeBlock(1, "short", ["msg-1"])
+    installBlock(state, block)
+    const rawMessages: WithParts[] = [makeTextMessage("msg-1", "original content")]
+    const entry: NotificationEntry = { blockId: 1, runId: 1, summary: "short", summaryTokens: 2 }
+
+    const result = evaluateBlockQuality(state, rawMessages, entry, buildConfig(false), logger)
+    assert.equal(result, null)
+})
+
+test("evaluateBlockQuality runs gate when enabled", () => {
+    const state = createSessionState()
+    const block = makeBlock(1, "x".repeat(50), ["msg-1"], 10000)
+    installBlock(state, block)
+    const rawMessages: WithParts[] = [makeTextMessage("msg-1", "original content with technical keywords")]
+    const entry: NotificationEntry = { blockId: 1, runId: 1, summary: "x".repeat(50), summaryTokens: 13 }
+
+    const result = evaluateBlockQuality(state, rawMessages, entry, buildConfig(true), logger)
+    assert.ok(result, "should produce a result when enabled")
+    assert.equal(result!.passed, false, "50-char summary of 10K-token original should fail L1")
+    assert.equal(result!.layer, "L1-length")
+})
+
+test("evaluateBlockQuality returns null when block not in state", () => {
+    const state = createSessionState()
+    const rawMessages: WithParts[] = []
+    const entry: NotificationEntry = { blockId: 999, runId: 1, summary: "missing", summaryTokens: 2 }
+
+    const result = evaluateBlockQuality(state, rawMessages, entry, buildConfig(true), logger)
+    assert.equal(result, null)
+})
+
+test("evaluateBlockQuality returns null when block has no direct messages", () => {
+    const state = createSessionState()
+    const block = makeBlock(1, "x".repeat(500), [])
+    installBlock(state, block)
+    const rawMessages: WithParts[] = []
+    const entry: NotificationEntry = { blockId: 1, runId: 1, summary: "x".repeat(500), summaryTokens: 125 }
+
+    const result = evaluateBlockQuality(state, rawMessages, entry, buildConfig(true), logger)
+    assert.equal(result, null, "blocks with no direct messages have no original to compare")
+})
+
+test("evaluateBlockQuality handles missing raw messages gracefully", () => {
+    const state = createSessionState()
+    const summary = "first message available only summary preserved across missing parts".repeat(3)
+    const block = makeBlock(1, summary, ["msg-1", "msg-2"])
+    installBlock(state, block)
+    const rawMessages: WithParts[] = [makeTextMessage("msg-1", "only first message available")]
+    const entry: NotificationEntry = { blockId: 1, runId: 1, summary, summaryTokens: 60 }
+
+    const result = evaluateBlockQuality(state, rawMessages, entry, buildConfig(true), logger)
+    assert.ok(result, "should still evaluate with partial messages")
+    assert.equal(result!.passed, true, "summary covers available content keywords")
+})
+
+test("evaluateBlockQuality extracts tool-call content from messages", () => {
+    const state = createSessionState()
+    const block = makeBlock(1, "x".repeat(500), ["msg-1"])
+    installBlock(state, block)
+    const rawMessages: WithParts[] = [
+        {
+            info: { id: "msg-1", role: "assistant", sessionId: "test" } as any,
+            parts: [
+                { type: "text", text: "Running ls to inspect" },
+                {
+                    type: "tool",
+                    tool: "bash",
+                    state: {
+                        input: { command: "ls -la" },
+                        output: "file1.txt\nfile2.txt\ncompression pipeline algorithm",
+                    },
+                },
+            ],
+        } as any,
+    ]
+    const entry: NotificationEntry = { blockId: 1, runId: 1, summary: "x".repeat(500), summaryTokens: 125 }
+
+    const result = evaluateBlockQuality(state, rawMessages, entry, buildConfig(true), logger)
+    assert.ok(result)
+    const metrics = Object.fromEntries(result!.metrics.map((m) => [m.name, m.value]))
+    assert.ok(metrics.rougeF1 !== undefined, "L2 should have run because originalText is non-empty")
+})
+
+test("evaluateBatchQuality: empty entries → empty report", () => {
+    const state = createSessionState()
+    const report = evaluateBatchQuality(state, [], [], buildConfig(true), logger)
+    assert.equal(report.total, 0)
+    assert.equal(report.passed, 0)
+    assert.equal(report.failures.length, 0)
+})
+
+test("evaluateBatchQuality: all-passing entries → no failures", () => {
+    const state = createSessionState()
+    const longOriginal = "compression pipeline quality gate algorithm threshold detection mechanism ".repeat(20)
+    const summary = (
+        "compression pipeline quality gate algorithm threshold detection mechanism framework module. " +
+        "This summary carefully preserves the technical keywords from the original content. "
+    ).repeat(3)
+    const block1 = makeBlock(1, summary, ["msg-1"], 100)
+    const block2 = makeBlock(2, summary, ["msg-2"], 100)
+    installBlock(state, block1)
+    installBlock(state, block2)
+    const rawMessages: WithParts[] = [
+        makeTextMessage("msg-1", longOriginal),
+        makeTextMessage("msg-2", longOriginal),
+    ]
+    const entries: NotificationEntry[] = [
+        { blockId: 1, runId: 1, summary, summaryTokens: 60 },
+        { blockId: 2, runId: 1, summary, summaryTokens: 60 },
+    ]
+
+    const report = evaluateBatchQuality(state, rawMessages, entries, buildConfig(true), logger)
+    assert.equal(report.total, 2)
+    assert.equal(report.passed, 2)
+    assert.equal(report.failures.length, 0)
+})
+
+test("evaluateBatchQuality: failing entries → reported with blockId", () => {
+    const state = createSessionState()
+    const failingSummary = "x".repeat(50)
+    const block1 = makeBlock(1, failingSummary, ["msg-1"], 50000)
+    const block2 = makeBlock(2, failingSummary, ["msg-2"], 50000)
+    installBlock(state, block1)
+    installBlock(state, block2)
+    const rawMessages: WithParts[] = [
+        makeTextMessage("msg-1", "original technical content with keywords"),
+        makeTextMessage("msg-2", "different original content with other keywords"),
+    ]
+    const entries: NotificationEntry[] = [
+        { blockId: 1, runId: 1, summary: failingSummary, summaryTokens: 13 },
+        { blockId: 2, runId: 1, summary: failingSummary, summaryTokens: 13 },
+    ]
+
+    const report = evaluateBatchQuality(state, rawMessages, entries, buildConfig(true), logger)
+    assert.equal(report.total, 2)
+    assert.equal(report.passed, 0)
+    assert.equal(report.failures.length, 2)
+    assert.deepEqual(
+        report.failures.map((f) => f.blockId).sort((a, b) => a - b),
+        [1, 2],
+    )
+    for (const failure of report.failures) {
+        assert.equal(failure.result.layer, "L1-length")
+        assert.ok(failure.result.reason?.includes("too short"))
+    }
+})
+
+test("evaluateBatchQuality: mixed pass/fail entries → only failures reported", () => {
+    const state = createSessionState()
+    const goodSummary = (
+        "compression pipeline quality gate algorithm threshold detection mechanism framework. " +
+        "Detailed notes on direction, approval, experiment results, and divergence. "
+    ).repeat(3)
+    const badSummary = "x".repeat(50)
+    const block1 = makeBlock(1, goodSummary, ["msg-1"], 100)
+    const block2 = makeBlock(2, badSummary, ["msg-2"], 50000)
+    installBlock(state, block1)
+    installBlock(state, block2)
+    const goodOriginal = "compression pipeline quality gate algorithm threshold detection mechanism ".repeat(10)
+    const rawMessages: WithParts[] = [
+        makeTextMessage("msg-1", goodOriginal),
+        makeTextMessage("msg-2", "unrelated content"),
+    ]
+    const entries: NotificationEntry[] = [
+        { blockId: 1, runId: 1, summary: goodSummary, summaryTokens: 60 },
+        { blockId: 2, runId: 1, summary: badSummary, summaryTokens: 13 },
+    ]
+
+    const report = evaluateBatchQuality(state, rawMessages, entries, buildConfig(true), logger)
+    assert.equal(report.total, 2)
+    assert.equal(report.passed, 1)
+    assert.equal(report.failures.length, 1)
+    assert.equal(report.failures[0].blockId, 2)
+})
+
+test("evaluateBatchQuality: gate disabled → all entries counted as passed, no evaluation", () => {
+    const state = createSessionState()
+    const block = makeBlock(1, "tiny", ["msg-1"])
+    installBlock(state, block)
+    const rawMessages: WithParts[] = [makeTextMessage("msg-1", "content")]
+    const entries: NotificationEntry[] = [
+        { blockId: 1, runId: 1, summary: "tiny", summaryTokens: 1 },
+    ]
+
+    const report = evaluateBatchQuality(state, rawMessages, entries, buildConfig(false), logger)
+    assert.equal(report.total, 1)
+    assert.equal(report.passed, 1)
+    assert.equal(report.failures.length, 0)
+})
+
+test("evaluateBatchQuality: unknown algorithm → entries treated as pass (warned)", () => {
+    const state = createSessionState()
+    const block = makeBlock(1, "tiny", ["msg-1"])
+    installBlock(state, block)
+    const rawMessages: WithParts[] = [makeTextMessage("msg-1", "content")]
+    const entries: NotificationEntry[] = [
+        { blockId: 1, runId: 1, summary: "tiny", summaryTokens: 1 },
+    ]
+    const cfg = buildConfig(true)
+    cfg.qualityGate.algorithm = "nonexistent-algorithm"
+
+    const report = evaluateBatchQuality(state, rawMessages, entries, cfg, logger)
+    assert.equal(report.total, 1)
+    assert.equal(report.passed, 1)
+    assert.equal(report.failures.length, 0)
+})

--- a/tests/quality-gate-registry.test.ts
+++ b/tests/quality-gate-registry.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+    registerQualityGate,
+    getQualityGate,
+    listQualityGates,
+    clearQualityGateRegistryForTests,
+} from "../lib/compress/quality-gate/registry"
+import type { QualityGate, QualityGateContext, QualityGateResult } from "../lib/compress/quality-gate/types"
+
+function makeFakeGate(name: string, version = "1.0.0"): QualityGate {
+    return {
+        name,
+        version,
+        description: `fake gate ${name}`,
+        evaluate: (_ctx: QualityGateContext, _config: unknown): QualityGateResult => ({
+            passed: true,
+            metrics: [],
+        }),
+    }
+}
+
+test("registry: getQualityGate returns undefined for unknown name", () => {
+    clearQualityGateRegistryForTests()
+    assert.equal(getQualityGate("does-not-exist"), undefined)
+})
+
+test("registry: registerQualityGate + getQualityGate roundtrip", () => {
+    clearQualityGateRegistryForTests()
+    const gate = makeFakeGate("test-1")
+    registerQualityGate(gate)
+    assert.equal(getQualityGate("test-1"), gate)
+})
+
+test("registry: re-registering the same gate object is a no-op", () => {
+    clearQualityGateRegistryForTests()
+    const gate = makeFakeGate("test-2")
+    registerQualityGate(gate)
+    registerQualityGate(gate)
+    assert.equal(getQualityGate("test-2"), gate)
+})
+
+test("registry: re-registering same name + same version (different object) is allowed", () => {
+    clearQualityGateRegistryForTests()
+    registerQualityGate(makeFakeGate("test-3", "1.0.0"))
+    assert.doesNotThrow(() => registerQualityGate(makeFakeGate("test-3", "1.0.0")))
+})
+
+test("registry: re-registering same name + different version throws", () => {
+    clearQualityGateRegistryForTests()
+    registerQualityGate(makeFakeGate("test-4", "1.0.0"))
+    assert.throws(
+        () => registerQualityGate(makeFakeGate("test-4", "2.0.0")),
+        /already registered with version 1\.0\.0/,
+    )
+})
+
+test("registry: listQualityGates returns sorted names", () => {
+    clearQualityGateRegistryForTests()
+    registerQualityGate(makeFakeGate("zeta"))
+    registerQualityGate(makeFakeGate("alpha"))
+    registerQualityGate(makeFakeGate("mike"))
+    const names = listQualityGates()
+    assert.deepEqual(names, ["alpha", "mike", "zeta"])
+})
+
+test("registry: listQualityGates returns empty array when registry is empty", () => {
+    clearQualityGateRegistryForTests()
+    assert.deepEqual(listQualityGates(), [])
+})
+
+test("registry: clearQualityGateRegistryForTests resets the registry", () => {
+    registerQualityGate(makeFakeGate("temp"))
+    clearQualityGateRegistryForTests()
+    assert.equal(getQualityGate("temp"), undefined)
+    assert.deepEqual(listQualityGates(), [])
+})

--- a/tests/quality-gate-rouge-recall-v1.test.ts
+++ b/tests/quality-gate-rouge-recall-v1.test.ts
@@ -143,25 +143,38 @@ test("Layer 2: fails when BOTH rougeF1 AND top20Recall are below thresholds (b27
 })
 
 test("Layer 2: passes when rougeF1 low but top20Recall high (b22 pattern)", () => {
-    const originalWords = [
-        "VQ-VAE","direction","approved","experiment","launched",
-        "discontinuity","gradient","blocking","STE","straight-through",
-        "user","confirmed","batch","results","divergence","epoch",
-    ]
-    const original = originalWords.join(" ") + " " + originalWords.join(" ")
-    const summary = "VQ-VAE direction approved, experiment launched, discontinuity gradient blocking, STE straight-through, user confirmed batch"
+    // 20 unique keywords in original; summary covers 4 of them + 200 distractor words.
+    // Yields: rougeF1 ~0.036 (low), top20Recall = 0.20 (at threshold).
+    // Verifies the AND-combine: low rougeF1 alone does NOT trigger failure when top20Recall is high.
+    // An `&&` -> `||` regression in rouge-recall-v1.ts:114 would still pass this test, but
+    // paired with the next test (high rougeF1 + low top20Recall) the two together catch it.
+    const originalKeywords = Array.from({ length: 20 }, (_, i) => `keyword${String(i + 1).padStart(2, "0")}`)
+    const original = originalKeywords.join(" ")
+    const distractors = Array.from({ length: 200 }, (_, i) => `distractor${String(i + 1).padStart(3, "0")}`)
+    const summary = originalKeywords.slice(0, 4).join(" ") + " " + distractors.join(" ")
     const ctx = makeCtx(summary, original, 20000)
     const result = rougeRecallV1.evaluate(ctx, TEST_CONFIG)
     const metrics = Object.fromEntries(result.metrics.map((m) => [m.name, m.value]))
+    assert.ok(metrics.rougeF1 < 0.05, `rougeF1=${metrics.rougeF1} should be < 0.05`)
     assert.ok(metrics.top20Recall >= 0.20, `top20Recall=${metrics.top20Recall} should be >= 0.20`)
     assert.equal(result.passed, true)
 })
 
-test("Layer 2: AND-combine — only one signal low does NOT trigger failure", () => {
-    const original = "compression algorithm pipeline quality gate threshold detection mechanism framework module architecture"
-    const summary = "compression algorithm pipeline quality gate threshold detection mechanism framework"
+test("Layer 2: AND-combine — high rougeF1 + low top20Recall does NOT trigger failure", () => {
+    // 200 unique tokens in original (all freq=1, so top-20 is alphabetical first 20).
+    // Summary covers 30 tokens: only 3 from the top-20 (alphabetically early) + 27 from the tail.
+    // Yields: rougeF1 ~0.26 (high, > 0.05), top20Recall = 0.15 (low, < 0.20).
+    // An `&&` -> `||` regression in rouge-recall-v1.ts:114 would fail this test (OR would
+    // trigger failure on the low top20Recall alone).
+    const allTokens = Array.from({ length: 200 }, (_, i) => `token${String(i + 1).padStart(3, "0")}`)
+    const original = allTokens.join(" ")
+    const summaryTokens = [...allTokens.slice(0, 3), ...allTokens.slice(50, 77)]
+    const summary = summaryTokens.join(" ")
     const ctx = makeCtx(summary, original, 100)
     const result = rougeRecallV1.evaluate(ctx, TEST_CONFIG)
+    const metrics = Object.fromEntries(result.metrics.map((m) => [m.name, m.value]))
+    assert.ok(metrics.rougeF1 >= 0.05, `rougeF1=${metrics.rougeF1} should be >= 0.05`)
+    assert.ok(metrics.top20Recall < 0.20, `top20Recall=${metrics.top20Recall} should be < 0.20`)
     assert.equal(result.passed, true)
 })
 
@@ -246,7 +259,7 @@ test("Mixed EN+ZH content evaluates without error", () => {
     assert.ok(typeof result.passed === "boolean")
 })
 
-test("Reproduces b27 case from issue #20 (0.05% retention)", () => {
+test("Reproduces b27 case from issue #20 (catastrophic retention)", () => {
     const original = "VQ-VAE direction approved ".repeat(2000)
     const summary = "## VQ-VAE direction approved, experiment launched"
     const ctx = makeCtx(summary, original, 72000)

--- a/tests/quality-gate-rouge-recall-v1.test.ts
+++ b/tests/quality-gate-rouge-recall-v1.test.ts
@@ -1,0 +1,258 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { rougeRecallV1, DEFAULT_ROUGE_RECALL_V1_CONFIG } from "../lib/compress/quality-gate/algorithms/rouge-recall-v1"
+import type { QualityGateContext } from "../lib/compress/quality-gate/types"
+import type { CompressionBlock } from "../lib/state/types"
+
+function makeBlock(overrides: Partial<CompressionBlock> = {}): CompressionBlock {
+    return {
+        blockId: 1,
+        runId: 1,
+        active: true,
+        deactivatedByUser: false,
+        compressedTokens: 1000,
+        summaryTokens: 50,
+        durationMs: 0,
+        mode: "range",
+        topic: "test",
+        batchTopic: "",
+        startId: "m001",
+        endId: "m010",
+        anchorMessageId: "anchor",
+        compressMessageId: "compress",
+        compressCallId: "call",
+        includedBlockIds: [],
+        consumedBlockIds: [],
+        parentBlockIds: [],
+        directMessageIds: ["msg-1"],
+        directToolIds: [],
+        effectiveMessageIds: ["msg-1"],
+        effectiveToolIds: [],
+        createdAt: 0,
+        summary: "",
+        survivedCount: 0,
+        generation: "young",
+        ...overrides,
+    }
+}
+
+function makeCtx(
+    summary: string,
+    originalText: string,
+    compressedTokens = 1000,
+): QualityGateContext {
+    return {
+        block: makeBlock({ summary, compressedTokens }),
+        summary,
+        originalChunks: [originalText],
+        originalText,
+        originalTokens: Math.ceil(originalText.length / 4),
+    }
+}
+
+const TEST_CONFIG = {
+    layer1MinChars: 1,
+    layer1MinRetentionPct: 0,
+    layer2MaxRougeF1: 0.05,
+    layer2MaxTop20Recall: 0.20,
+}
+
+test("rouge-recall-v1: name and version are stable", () => {
+    assert.equal(rougeRecallV1.name, "rouge-recall-v1")
+    assert.equal(typeof rougeRecallV1.version, "string")
+    assert.ok(rougeRecallV1.version.length > 0)
+})
+
+test("rouge-recall-v1: description is non-empty", () => {
+    assert.ok(rougeRecallV1.description.length > 0)
+})
+
+test("DEFAULT_ROUGE_RECALL_V1_CONFIG has expected defaults", () => {
+    assert.equal(DEFAULT_ROUGE_RECALL_V1_CONFIG.layer1MinChars, 200)
+    assert.equal(DEFAULT_ROUGE_RECALL_V1_CONFIG.layer1MinRetentionPct, 1.0)
+    assert.equal(DEFAULT_ROUGE_RECALL_V1_CONFIG.layer2MaxRougeF1, 0.05)
+    assert.equal(DEFAULT_ROUGE_RECALL_V1_CONFIG.layer2MaxTop20Recall, 0.20)
+})
+
+test("Layer 1 fails on summary shorter than minChars", () => {
+    const ctx = makeCtx("short summary", "some longer original content here for testing")
+    const result = rougeRecallV1.evaluate(ctx, DEFAULT_ROUGE_RECALL_V1_CONFIG)
+    assert.equal(result.passed, false)
+    assert.equal(result.layer, "L1-length")
+    assert.ok(result.reason?.includes("too short"))
+})
+
+test("Layer 1 fails on retention below threshold", () => {
+    const summary = "x".repeat(250)
+    const ctx = makeCtx(summary, "irrelevant text", 100000)
+    const result = rougeRecallV1.evaluate(ctx, DEFAULT_ROUGE_RECALL_V1_CONFIG)
+    assert.equal(result.passed, false)
+    assert.equal(result.layer, "L1-length")
+    assert.ok(result.reason?.includes("retention"))
+})
+
+test("Layer 1 passes with summary length >= minChars AND retention >= threshold", () => {
+    const summary = "x".repeat(500)
+    const ctx = makeCtx(summary, "irrelevant", 1000)
+    const result = rougeRecallV1.evaluate(ctx, DEFAULT_ROUGE_RECALL_V1_CONFIG)
+    assert.notEqual(result.layer, "L1-length")
+})
+
+test("Layer 1 boundary: summary at exactly minChars with high retention passes", () => {
+    const summary = "x".repeat(200)
+    const ctx = makeCtx(summary, "y", 100)
+    const result = rougeRecallV1.evaluate(ctx, DEFAULT_ROUGE_RECALL_V1_CONFIG)
+    assert.notEqual(result.layer, "L1-length")
+})
+
+test("Layer 2 does not run when Layer 1 fails", () => {
+    const ctx = makeCtx("tiny", "original content here for testing")
+    const result = rougeRecallV1.evaluate(ctx, DEFAULT_ROUGE_RECALL_V1_CONFIG)
+    assert.equal(result.layer, "L1-length")
+    const metricNames = result.metrics.map((m) => m.name)
+    assert.ok(!metricNames.includes("rougeF1"))
+})
+
+test("Layer 2: passes when rougeF1 high enough", () => {
+    const original = "compression pipeline quality gate threshold detection algorithm".repeat(5)
+    const summary = "compression pipeline quality gate threshold detection algorithm"
+    const ctx = makeCtx(summary, original, 100)
+    const result = rougeRecallV1.evaluate(ctx, TEST_CONFIG)
+    assert.equal(result.passed, true)
+})
+
+test("Layer 2: fails when BOTH rougeF1 AND top20Recall are below thresholds (b27 pattern)", () => {
+    // b27 from issue #20: 37 messages about VQ-VAE compressed to a summary
+    // that captured none of the technical keywords.
+    const original = [
+        "VQ-VAE direction approved and experiment launched",
+        "hard-NN discontinuity causes gradient blocking",
+        "STE training with straight-through estimator",
+        "user confirmed direction and approved batch",
+        "experiment results show divergence after epoch 50",
+    ].join(" ")
+    const summary = "## Status\nWork continues. Updates pending further review."
+    const ctx = makeCtx(summary, original, 18000)
+    const result = rougeRecallV1.evaluate(ctx, TEST_CONFIG)
+    assert.equal(result.passed, false)
+    assert.equal(result.layer, "L2-recall")
+    const metrics = Object.fromEntries(result.metrics.map((m) => [m.name, m.value]))
+    assert.ok(metrics.rougeF1 < 0.05, `rougeF1=${metrics.rougeF1}`)
+    assert.ok(metrics.top20Recall < 0.20, `top20Recall=${metrics.top20Recall}`)
+})
+
+test("Layer 2: passes when rougeF1 low but top20Recall high (b22 pattern)", () => {
+    const originalWords = [
+        "VQ-VAE","direction","approved","experiment","launched",
+        "discontinuity","gradient","blocking","STE","straight-through",
+        "user","confirmed","batch","results","divergence","epoch",
+    ]
+    const original = originalWords.join(" ") + " " + originalWords.join(" ")
+    const summary = "VQ-VAE direction approved, experiment launched, discontinuity gradient blocking, STE straight-through, user confirmed batch"
+    const ctx = makeCtx(summary, original, 20000)
+    const result = rougeRecallV1.evaluate(ctx, TEST_CONFIG)
+    const metrics = Object.fromEntries(result.metrics.map((m) => [m.name, m.value]))
+    assert.ok(metrics.top20Recall >= 0.20, `top20Recall=${metrics.top20Recall} should be >= 0.20`)
+    assert.equal(result.passed, true)
+})
+
+test("Layer 2: AND-combine — only one signal low does NOT trigger failure", () => {
+    const original = "compression algorithm pipeline quality gate threshold detection mechanism framework module architecture"
+    const summary = "compression algorithm pipeline quality gate threshold detection mechanism framework"
+    const ctx = makeCtx(summary, original, 100)
+    const result = rougeRecallV1.evaluate(ctx, TEST_CONFIG)
+    assert.equal(result.passed, true)
+})
+
+test("Layer 2 metrics include required fields", () => {
+    const summary = "x".repeat(500)
+    const ctx = makeCtx(summary, "compression pipeline quality gate", 100)
+    const result = rougeRecallV1.evaluate(ctx, DEFAULT_ROUGE_RECALL_V1_CONFIG)
+    const names = result.metrics.map((m) => m.name)
+    assert.ok(names.includes("summaryLen"))
+    assert.ok(names.includes("retentionPct"))
+    assert.ok(names.includes("originalTokens"))
+    assert.ok(names.includes("rougeF1"))
+    assert.ok(names.includes("rougeRecall"))
+    assert.ok(names.includes("top20Recall"))
+    assert.ok(names.includes("nOriginalPaths"))
+    assert.ok(names.includes("nSummaryPaths"))
+})
+
+test("Layer 2 does not include pathCoverage when original has < 5 paths", () => {
+    const summary = "x".repeat(500)
+    const ctx = makeCtx(summary, "compression pipeline quality gate", 100)
+    const result = rougeRecallV1.evaluate(ctx, DEFAULT_ROUGE_RECALL_V1_CONFIG)
+    const names = result.metrics.map((m) => m.name)
+    assert.ok(!names.includes("pathCoverage"))
+})
+
+test("Layer 2 includes pathCoverage when original has >= 5 paths", () => {
+    const summary = "x".repeat(500)
+    const original = [
+        "see lib/foo.ts", "and lib/bar.ts", "plus lib/baz.ts",
+        "with src/qux.ts", "and src/quux.ts",
+    ].join(" ")
+    const ctx = makeCtx(summary, original, 100)
+    const result = rougeRecallV1.evaluate(ctx, DEFAULT_ROUGE_RECALL_V1_CONFIG)
+    const names = result.metrics.map((m) => m.name)
+    assert.ok(names.includes("pathCoverage"))
+    const pathCoverage = result.metrics.find((m) => m.name === "pathCoverage")!
+    assert.equal(pathCoverage.value, 0, "summary had no paths, original had 5 -> coverage 0")
+})
+
+test("Empty original text passes Layer 1 but skips Layer 2", () => {
+    const summary = "x".repeat(500)
+    const ctx = makeCtx(summary, "", 100)
+    const result = rougeRecallV1.evaluate(ctx, DEFAULT_ROUGE_RECALL_V1_CONFIG)
+    assert.equal(result.passed, true)
+    const names = result.metrics.map((m) => m.name)
+    assert.ok(!names.includes("rougeF1"), "Layer 2 should be skipped when original is empty")
+})
+
+test("Custom config overrides defaults", () => {
+    const ctx = makeCtx("short summary", "some original text here", 100)
+    const result = rougeRecallV1.evaluate(ctx, {
+        ...DEFAULT_ROUGE_RECALL_V1_CONFIG,
+        layer1MinChars: 5,
+        layer1MinRetentionPct: 0,
+    })
+    assert.notEqual(result.layer, "L1-length")
+})
+
+test("Custom config: invalid layer1MinChars falls back to default", () => {
+    const ctx = makeCtx("short", "original", 1000)
+    const result = rougeRecallV1.evaluate(ctx, {
+        ...DEFAULT_ROUGE_RECALL_V1_CONFIG,
+        layer1MinChars: -1,
+    })
+    assert.equal(result.layer, "L1-length")
+})
+
+test("Custom config: undefined config uses all defaults", () => {
+    const summary = "x".repeat(500)
+    const ctx = makeCtx(summary, "compression pipeline quality gate", 100)
+    const result = rougeRecallV1.evaluate(ctx, undefined)
+    assert.ok(typeof result.passed === "boolean")
+    assert.ok(Array.isArray(result.metrics))
+})
+
+test("Mixed EN+ZH content evaluates without error", () => {
+    const original = "Compression 压缩 quality 质量 gate 门 detection 检测 algorithm 算法"
+    const summary = "压缩压缩压缩质量门检测算法 compression quality gate detection algorithm"
+    const ctx = makeCtx(summary, original, 200)
+    const result = rougeRecallV1.evaluate(ctx, DEFAULT_ROUGE_RECALL_V1_CONFIG)
+    assert.ok(typeof result.passed === "boolean")
+})
+
+test("Reproduces b27 case from issue #20 (0.05% retention)", () => {
+    const original = "VQ-VAE direction approved ".repeat(2000)
+    const summary = "## VQ-VAE direction approved, experiment launched"
+    const ctx = makeCtx(summary, original, 72000)
+    const result = rougeRecallV1.evaluate(ctx, DEFAULT_ROUGE_RECALL_V1_CONFIG)
+    assert.equal(result.passed, false)
+    assert.equal(result.layer, "L1-length")
+    const metrics = Object.fromEntries(result.metrics.map((m) => [m.name, m.value]))
+    assert.ok(metrics.retentionPct < 1.0)
+})

--- a/tests/quality-gate-tokenizer.test.ts
+++ b/tests/quality-gate-tokenizer.test.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+    tokenize,
+    termFrequency,
+    topKByTf,
+    extractFilePaths,
+    rouge1Recall,
+    rouge1Precision,
+    rouge1F1,
+    topKRecall,
+    jaccardSimilarity,
+} from "../lib/compress/quality-gate/tokenizer"
+
+test("tokenize returns empty for empty input", () => {
+    assert.deepEqual(tokenize(""), [])
+    assert.deepEqual(tokenize(undefined as unknown as string), [])
+})
+
+test("tokenize extracts English words of length >= 4", () => {
+    const tokens = tokenize("the quick brown fox jumps swiftly past lazy dogs running")
+    const set = new Set(tokens)
+    assert.ok(set.has("quick"), "quick (5 chars) should be kept")
+    assert.ok(set.has("brown"), "brown (5 chars) should be kept")
+    assert.ok(set.has("jumps"), "jumps (5 chars) should be kept")
+    assert.ok(set.has("swiftly"), "swiftly (7 chars) should be kept")
+    assert.ok(set.has("lazy"), "lazy (4 chars) should be kept")
+    assert.ok(set.has("dogs"), "dogs (4 chars) should be kept")
+    assert.ok(set.has("running"), "running (7 chars) should be kept")
+    assert.ok(!set.has("the"), "'the' should be stopworded")
+    assert.ok(!set.has("fox"), "'fox' (3 chars) should be too short")
+})
+
+test("tokenize lowercases input", () => {
+    const tokens = new Set(tokenize("Compression Pipeline Framework"))
+    assert.ok(tokens.has("compression"))
+    assert.ok(tokens.has("pipeline"))
+    assert.ok(tokens.has("framework"))
+})
+
+test("tokenize filters pure-digit tokens", () => {
+    const tokens = new Set(tokenize("version 12345 and 9999"))
+    assert.ok(!tokens.has("12345"))
+    assert.ok(!tokens.has("9999"))
+})
+
+test("tokenize keeps alphanumeric words like 'utf8' and 'b32encoder'", () => {
+    const tokens = new Set(tokenize("utf8 b32encoder file5"))
+    assert.ok(tokens.has("utf8"))
+    assert.ok(tokens.has("b32encoder"))
+    assert.ok(tokens.has("file5"))
+})
+
+test("tokenize extracts Chinese unigrams and bigrams", () => {
+    const tokens = tokenize("模型压缩质量门")
+    const set = new Set(tokens)
+    const unigrams = ["模", "型", "压", "缩", "质", "量", "门"]
+    for (const c of unigrams) assert.ok(set.has(c), `unigram ${c} should be present`)
+    const bigrams = ["模型", "型压", "压缩", "缩质", "质量", "量门"]
+    for (const bg of bigrams) assert.ok(set.has(bg), `bigram ${bg} should be present`)
+})
+
+test("tokenize filters Chinese stopwords", () => {
+    const tokens = new Set(tokenize("我们的压缩"));
+    assert.ok(!tokens.has("我"), "'我' is a stopword");
+    assert.ok(tokens.has("压"), "'压' is content");
+    assert.ok(tokens.has("缩"), "'缩' is content");
+    assert.ok(!tokens.has("我们"), "'我们' is a stopword bigram");
+    assert.ok(tokens.has("压缩"), "'压缩' is content bigram");
+})
+
+test("tokenize handles mixed EN+ZH input", () => {
+    const tokens = new Set(tokenize("Compression 压缩 quality 质量 gate"))
+    assert.ok(tokens.has("compression"))
+    assert.ok(tokens.has("quality"))
+    assert.ok(tokens.has("压"))
+    assert.ok(tokens.has("缩"))
+    assert.ok(tokens.has("质"))
+})
+
+test("tokenize english=false skips english words", () => {
+    const tokens = new Set(tokenize("compression 压缩", { english: false }))
+    assert.ok(!tokens.has("compression"))
+    assert.ok(tokens.has("压"))
+})
+
+test("tokenize zhBigrams=false disables bigram extraction", () => {
+    const tokens = new Set(tokenize("压缩", { zhBigrams: false }))
+    assert.ok(tokens.has("压"))
+    assert.ok(tokens.has("缩"))
+    assert.ok(!tokens.has("压缩"))
+})
+
+test("termFrequency counts occurrences", () => {
+    const tf = termFrequency(tokenize("quality quality quality compression compression"))
+    assert.equal(tf.get("quality"), 3)
+    assert.equal(tf.get("compression"), 2)
+})
+
+test("topKByTf returns top K by frequency, ties broken alphabetically", () => {
+    const tokens = tokenize("alpha alpha beta beta gamma delta delta delta epsilon")
+    const top3 = topKByTf(tokens, 3)
+    assert.ok(top3.includes("delta"), "delta (3 occurrences) should be in top 3")
+    assert.ok(top3.includes("alpha"), "alpha (2) should be in top 3")
+    assert.ok(top3.includes("beta"), "beta (2) should be in top 3 (alphabetical tiebreak)")
+})
+
+test("topKByTf with k=0 returns empty", () => {
+    assert.deepEqual(topKByTf(["a", "b", "c"], 0), [])
+})
+
+test("topKByTf with empty input returns empty", () => {
+    assert.deepEqual(topKByTf([], 5), [])
+})
+
+test("extractFilePaths captures lib/foo.ts style paths", () => {
+    const paths = extractFilePaths("see lib/hooks.ts and src/index.ts:12 and deep/dir/file.py")
+    assert.ok(paths.has("lib/hooks.ts"))
+    assert.ok(paths.has("src/index.ts"))
+    assert.ok(paths.has("deep/dir/file.py"))
+})
+
+test("extractFilePaths ignores bare filenames without slash", () => {
+    const paths = extractFilePaths("foo.ts and bar.py without path")
+    assert.equal(paths.size, 0, "bare filenames should not match (need at least one slash)")
+})
+
+test("extractFilePaths returns empty for input without paths", () => {
+    assert.equal(extractFilePaths("just plain text").size, 0)
+    assert.equal(extractFilePaths("").size, 0)
+})
+
+test("rouge1Recall: identical token sets -> 1.0", () => {
+    const tokens = ["quality", "gate", "compression"]
+    assert.equal(rouge1Recall(tokens, tokens), 1.0)
+})
+
+test("rouge1Recall: disjoint token sets -> 0.0", () => {
+    assert.equal(rouge1Recall(["alpha"], ["beta", "gamma"]), 0.0)
+})
+
+test("rouge1Recall: summary covers half of original unique tokens -> 0.5", () => {
+    const summary = ["compression", "gate"]
+    const original = ["compression", "gate", "quality", "threshold"]
+    assert.equal(rouge1Recall(summary, original), 0.5)
+})
+
+test("rouge1Recall: empty original -> 0", () => {
+    assert.equal(rouge1Recall(["alpha"], []), 0)
+})
+
+test("rouge1Precision: identical token sets -> 1.0", () => {
+    const tokens = ["quality", "gate"]
+    assert.equal(rouge1Precision(tokens, tokens), 1.0)
+})
+
+test("rouge1Precision: empty summary -> 0", () => {
+    assert.equal(rouge1Precision([], ["alpha", "beta"]), 0)
+})
+
+test("rouge1F1: identical sets -> 1.0", () => {
+    const tokens = ["alpha", "beta"]
+    assert.equal(rouge1F1(tokens, tokens), 1.0)
+})
+
+test("rouge1F1: disjoint sets -> 0", () => {
+    assert.equal(rouge1F1(["alpha"], ["beta"]), 0)
+})
+
+test("rouge1F1: partial overlap yields intermediate value", () => {
+    // summary={a,b}, original={b,c,d} -> recall=1/3, precision=1/2, F1=0.4
+    const r = rouge1F1(["a", "b"], ["b", "c", "d"])
+    assert.ok(r > 0 && r < 1)
+    assert.ok(Math.abs(r - 0.4) < 0.01, `expected ~0.4, got ${r}`)
+})
+
+test("topKRecall: summary covers all top-K -> 1.0", () => {
+    const summary = ["alpha", "beta", "gamma"]
+    const original = ["alpha", "alpha", "beta", "beta", "gamma", "gamma", "delta"]
+    assert.equal(topKRecall(summary, original, 3), 1.0)
+})
+
+test("topKRecall: summary covers none -> 0.0", () => {
+    assert.equal(topKRecall(["delta"], ["alpha", "beta", "gamma"], 3), 0.0)
+})
+
+test("topKRecall: K larger than original unique count", () => {
+    const summary = ["alpha"]
+    const original = ["alpha", "beta"]
+    assert.equal(topKRecall(summary, original, 10), 0.5)
+})
+
+test("jaccardSimilarity: identical sets -> 1.0", () => {
+    const tokens = ["a", "b", "c"]
+    assert.equal(jaccardSimilarity(tokens, tokens), 1.0)
+})
+
+test("jaccardSimilarity: disjoint sets -> 0.0", () => {
+    assert.equal(jaccardSimilarity(["a"], ["b"]), 0.0)
+})
+
+test("jaccardSimilarity: half overlap -> 1/3", () => {
+    const j = jaccardSimilarity(["a", "b"], ["b", "c"])
+    assert.ok(Math.abs(j - 1 / 3) < 0.01)
+})
+
+test("jaccardSimilarity: both empty -> 0", () => {
+    assert.equal(jaccardSimilarity([], []), 0)
+})


### PR DESCRIPTION
## Summary

Adds a pluggable post-compression quality gate under `lib/compress/quality-gate/` that detects summaries which catastrophically lost content. Default `rouge-recall-v1` algorithm calibrated against 6,913 real-world blocks. **Non-blocking**: failures only `logger.warn`; the compression result is already committed.

Closes #20.

## Algorithm: rouge-recall-v1

Two-layer gate:

- **L1 (length floor)** — Catches catastrophic retention failures. Summary < 200 chars OR <1% retention vs original. 100% recall, 0% FPR.
- **L2 (content coverage)** — Only runs on blocks that pass L1. Flags when **both** ROUGE-1 F1 < 0.05 **and** top-20 keyword recall < 0.20 (AND-combine keeps FPR at ~6.6%).

Hand-rolled word-level tokenizer (English keywords ≥4 chars + Chinese unigrams/bigrams) — separate from ACP's BPE tokenizer, which is too coarse for ROUGE matching.

## Interface

\`\`\`typescript
interface QualityGate {
  name: string
  version: string
  description: string
  evaluate(ctx: QualityGateContext, config: unknown): QualityGateResult
}
\`\`\`

Pluggable via \`registerQualityGate()\`. Future algorithms (including external API judges) can be added without touching pipeline wiring. Sync signature today; future async gates need either type widening or internal wait+timeout wrap, registry/config unchanged.

## Config

\`\`\`jsonc
{
  \"qualityGate\": {
    \"enabled\": false,  // off by default for one release burn-in
    \"algorithm\": \"rouge-recall-v1\",
    \"algorithms\": {
      \"rouge-recall-v1\": {
        \"layer1MinChars\": 200,
        \"layer1MinRetentionPct\": 1.0,
        \"layer2MaxRougeF1\": 0.05,
        \"layer2MaxTop20Recall\": 0.20
      }
    }
  }
}
\`\`\`

## Pipeline wiring

\`finalizeSession()\` in \`lib/compress/pipeline.ts\` calls \`evaluateBatchQuality()\` after state save when \`entries.length > 0\`. Each failure emits \`logger.warn(\"Compression quality gate FAILED\", { blockId, algorithm, layer, reason, ...metrics })\`. Non-blocking: runs AFTER state save so a thrown error in the gate cannot corrupt compression state.

## Commits

1. \`feat: add qualityGate config schema and defaults\` — lib/config.ts, lib/config-validation.ts, dcp.schema.json
2. \`feat: pluggable post-compression quality gate subsystem\` — lib/compress/quality-gate/* + 4 test files (74 tests)
3. \`feat: wire quality gate into finalizeSession pipeline\` — lib/compress/pipeline.ts
4. \`docs: quality gate section in README, README.zh-CN, AGENTS module map\`
5. \`chore: bump version to 1.13.0 + devlog for quality gate\`

## Verification

- \`npm run typecheck\`: PASS
- \`npm run build\`: PASS
- \`npm test\`: **842/842 PASS** (was 768; +74 new tests)
- \`scripts/ci/check-pr.sh\`: PASS (branch name, devlog, changelog)

## Test breakdown

| File | Tests | Coverage |
|---|---|---|
| \`tests/quality-gate-tokenizer.test.ts\` | 33 | Empty inputs, EN length filter, ZH uni/bigrams, ZH stopword filter, mixed EN+ZH, ROUGE recall/precision/F1, topK recall, jaccard |
| \`tests/quality-gate-registry.test.ts\` | 8 | Singleton Map, same-object re-register, version conflict detection, sorted list, clear-for-tests |
| \`tests/quality-gate-rouge-recall-v1.test.ts\` | 21 | L1/L2 boundary cases, b27 retention regression, custom/invalid/undefined config, metrics field coverage, pathCoverage |
| \`tests/quality-gate-pipeline-integration.test.ts\` | 12 | Disabled returns null, enabled runs gate, missing block, partial messages, tool-call content extraction, batch evaluation |

## Notes

- Pre-edit hook fired on every comment/docstring during implementation. Strategy: keep only (a) public-API contract docs (\"MUST NOT throw\"), (b) algorithm/math rationale (calibration thresholds), (c) bug-case traceability refs (\"b27 from issue #20\"). Acknowledged each trigger with the priority-list justification.
- Default \`enabled: false\` for one release of burn-in. After v1.13.0 stabilizes, flip default to \`true\` in v1.14.0.

## Post-merge TODO

- [ ] Dual-agent code review (lib + tests per AGENTS.md §5.3, §5.6)
- [ ] After one release burn-in, flip \`qualityGate.enabled\` default to \`true\`
- [ ] Consider future external-API judge algorithm (LLM-as-judge)