### PR TITLE
release: v1.13.2 — preserve last user msg + config defaults tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,12 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.13.2 — Preserve Last User Msg + Config Defaults Tuning (PR #169)
+
+**Problem**: Two issues remained after v1.13.1's notification freeze fix. (1) When the model compressed a range that covered all visible user messages, the next API call had zero user-role messages — zhipuai-lb rejected this with the same HTTP 400 code 1214 (`isRetryable: false`), freezing the session. This was the second path to the same freeze that v1.13.1's empty-notification fix addressed. (2) The default `pruneNotification: "detailed"` fired a toast on every compress call (10–30 per session is typical), which was over-intrusive for a routine background operation. Additionally, `compress.maxSummaryLengthHard: 10000` rejected ~25% of information-dense useful summaries in real sessions.
+
+**Fix**: (1) `lib/messages/prune.ts` — `filterCompressedRanges` rewritten as a two-pass filter: pass 1 computes survivors, pass 2 builds the result; if no user-role message would survive, the most recent pruned user message is restored to keep the API request shape valid. The restore is transform-time only — `byMessageId` still records the message as compressed. (2) `lib/config.ts` — default `pruneNotification` changed `"detailed"` → `"off"`; compression events still log to `~/.config/opencode/logs/acp/` via a new always-log path in `lib/ui/notification.ts` (lossless observability without UI noise). (3) `lib/config.ts` — default `compress.maxSummaryLengthHard` raised `10000` → `20000` (aligns with observed good-summary lengths). (4) `dcp.schema.json` — 4 stale defaults synced. Files: `lib/messages/prune.ts`, `lib/config.ts`, `lib/ui/notification.ts`, `dcp.schema.json`, `README.md`. Tests: 803 pass (5 new regression tests for the preserve-last-user fix).
+
 ### v1.13.1 — cc-alg Extraction + Compress Notification Freeze Fix (PRs #167, #168)
 
 **Problem (compress notification freeze, #167)**: After every successful `compress` tool call, ACP injected a user-role notification message with a single `ignored: true` text part. opencode strips `ignored` parts before sending to the LLM, leaving an empty user message. The provider (zhipuai-lb / glm-5.2) rejects this with HTTP 400 code 1214 (`"messages 参数非法"`), `isRetryable: false` — opencode does not retry, and the session freezes until external recovery. 113 total occurrences across active sessions (8 in a single 3,156-message session).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -439,6 +439,12 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.13.2 — 保留最近用户消息 + 配置默认值调优（PR #169）
+
+**问题**：v1.13.1 的通知冻结修复之后还剩两个问题。（1）当模型压缩的范围覆盖了所有可见的 user 消息时，下一次 API 调用中 user 角色消息数量为零——zhipuai-lb 以同样的 HTTP 400 code 1214（`isRetryable: false`）拒绝，会话冻结。这是 v1.13.1 修复的空通知路径之外，通往同一冻结 bug 的第二条路径。（2）默认 `pruneNotification: "detailed"` 每次压缩都弹 toast（典型会话 10–30 次），对例行后台操作来说过于打扰。另外 `compress.maxSummaryLengthHard: 10000` 在真实会话中拒绝了约 25% 信息密度高的有用摘要。
+
+**修复**：（1）`lib/messages/prune.ts`——`filterCompressedRanges` 重写为两段过滤：第一段计算存活消息，第二段构建结果；如果没有 user 角色消息存活，恢复最近一条被压缩的 user 消息以保证 API 请求格式合法。恢复仅发生在 transform 阶段——`byMessageId` 仍记录该消息为已压缩。（2）`lib/config.ts`——默认 `pruneNotification` 改为 `"off"`；压缩事件仍通过 `lib/ui/notification.ts` 新增的 always-log 路径记录到 `~/.config/opencode/logs/acp/`（无损失可观测性，无 UI 噪音）。（3）`lib/config.ts`——默认 `compress.maxSummaryLengthHard` 从 `10000` 提升到 `20000`（与真实会话中观察到的优质摘要长度对齐）。（4）`dcp.schema.json`——同步 4 个过时默认值。文件：`lib/messages/prune.ts`、`lib/config.ts`、`lib/ui/notification.ts`、`dcp.schema.json`、`README.md`。测试：803 pass（5 个新的 preserve-last-user 回归测试）。
+
 ### v1.13.1 — cc-alg 抽取 + 压缩通知冻结修复（PR #167, #168）
 
 **问题（压缩通知冻结，#167）**：每次 `compress` 工具调用成功后，ACP 会注入一条 user 角色通知消息，其中只包含一个带 `ignored: true` 标记的 text part。opencode 在发送给 LLM 前会剥离 ignored parts，于是这条消息变成空 user 消息。Provider（zhipuai-lb / glm-5.2）会以 HTTP 400 code 1214（`"messages 参数非法"`）拒绝，且 `isRetryable: false`——opencode 不会重试，会话冻结，直到外部恢复。所有活跃会话累计发生 113 次（单个 3,156 条消息的会话出现 8 次）。

--- a/devlog/2026-07-21_release-v1.13.2/REQ.md
+++ b/devlog/2026-07-21_release-v1.13.2/REQ.md
@@ -1,0 +1,39 @@
+# REQ - Release v1.13.2
+
+- Task ID: `2026-07-21_release-v1.13.2`
+- Home Repo: `opencode-acp`
+- Status: Done
+- Updated: 2026-07-21
+
+## Goal
+
+Ship PR #169 (preserve-last-user-msg + config defaults tuning) as v1.13.2.
+
+## Scope
+
+Patch release bundling:
+1. **preserve-last-user fix** — `filterCompressedRanges` restores the most
+   recent pruned user message when all visible user messages fall in compressed
+   ranges. Prevents zhipuai-lb code 1214 freeze (second path after v1.13.1).
+2. **pruneNotification default `"off"`** — toast on every compress was
+   over-intrusive; events still logged via always-log path.
+3. **maxSummaryLengthHard default 20000** (was 10000) — old cap rejected ~25%
+   of useful dense summaries.
+4. **dcp.schema.json sync** — 4 stale defaults aligned with code.
+
+## Compatibility
+
+- Persisted state format: unchanged.
+- Config: 3 default values change. Users with explicit config unaffected.
+  - `pruneNotification`: `"detailed"` → `"off"`
+  - `pruneNotificationType`: `"chat"` → `"toast"` (old debt)
+  - `compress.maxSummaryLengthHard`: `10000` → `20000`
+
+## Exit Criteria
+
+- [x] Version bumped in package.json
+- [x] Changelog entries in README.md + README.zh-CN.md
+- [x] Devlog created
+- [x] CI checks pass (branch name, devlog, changelog)
+- [ ] PR merged (human confirmation)
+- [ ] npm published (automated via release.yml)

--- a/devlog/2026-07-21_release-v1.13.2/WORKLOG.md
+++ b/devlog/2026-07-21_release-v1.13.2/WORKLOG.md
@@ -1,0 +1,75 @@
+# WORKLOG - Release v1.13.2
+
+- Task ID: `2026-07-21_release-v1.13.2`
+- Home Repo: `opencode-acp`
+- Status: Done
+- Updated: 2026-07-21
+
+## 1. Summary
+
+Patch release shipping PR #169 (preserve-last-user-msg + config defaults tuning).
+
+## 2. Change Log
+
+### Commits
+
+| Commit | Description |
+|--------|-------------|
+| PR #169 | fix: preserve most recent user msg when compress range covers all user msgs |
+| PR #169 | fix(config): silence compression toast by default, raise summary cap to 20K |
+| PR #169 | refactor(test): simplify prune setupBlock helper |
+| PR #169 | docs(devlog): document config defaults rationale and fix test count |
+| (this release) | release: v1.13.2 |
+
+### Version bump
+
+- 1.13.1 → 1.13.2
+
+### Changelog
+
+- README.md: v1.13.2 entry added
+- README.zh-CN.md: v1.13.2 entry added
+
+## 3. What's in this release
+
+### preserve-last-user (lib/messages/prune.ts)
+
+Two-pass `filterCompressedRanges`:
+1. Pass 1: compute which messages survive compression.
+2. If no user-role message survives, un-prune the most recent pruned user msg.
+3. Pass 2: build the result array.
+
+The restore is transform-time only. `byMessageId` still records the message as
+compressed — future compress calls see the correct state.
+
+This closes the second path to the zhipuai-lb code 1214 freeze. The first path
+(empty notification user message) was closed in v1.13.1.
+
+### Config defaults tuning (lib/config.ts, lib/ui/notification.ts)
+
+- `pruneNotification: "detailed"` → `"off"`. Compression events now log to
+  `~/.config/opencode/logs/acp/daily/<date>.log` via a new always-log block
+  in `sendCompressNotification`. No toast by default. Users can opt in via
+  `"minimal"` or `"detailed"`.
+- `compress.maxSummaryLengthHard: 10000` → `20000`. The old cap rejected
+  ~25% of information-dense summaries in real sessions.
+
+### Schema sync (dcp.schema.json)
+
+4 stale defaults aligned with code:
+- `pruneNotification`: `"detailed"` → `"off"`
+- `pruneNotificationType`: `"chat"` → `"toast"`
+- `maxSummaryLengthHard` (property default): `4000` → `20000`
+- `maxSummaryLengthHard` (compress.default block): `3000` → `20000`
+
+## 4. Validation
+
+- `npm run typecheck` — clean.
+- `npm test` — 803 tests pass.
+- `npm run build` — success (dist/index.js 425 KB).
+- CI `check-pr.sh` — branch name, devlog, changelog all pass.
+
+## 5. Follow-up
+
+- After merge, CI auto-tags `v1.13.2` and publishes to npm `latest`.
+- Verify: `npm view opencode-acp version` shows `1.13.2`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.13.1",
+    "version": "1.13.2",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Patch release bundling PR #169 (preserve-last-user-msg + config defaults tuning).

### Changes

- **preserve-last-user fix** (`lib/messages/prune.ts`): Two-pass `filterCompressedRanges` that restores the most recent pruned user message when all visible user messages fall in compressed ranges. Closes the second path to the zhipuai-lb code 1214 freeze (first path closed in v1.13.1).
- **pruneNotification default `"off"`** (`lib/config.ts`): Toast on every compress was over-intrusive. Compression events now always-log to `~/.config/opencode/logs/acp/` — lossless observability without UI noise.
- **maxSummaryLengthHard default 20000** (`lib/config.ts`): Old 10K cap rejected ~25% of information-dense useful summaries. 20K aligns with observed good-summary lengths.
- **dcp.schema.json sync**: 4 stale defaults aligned with code.
- **5 regression tests**: Cover restore-when-all-pruned, no-over-restore, multi-user-picks-most-recent, no-user-no-op, restored-content-byte-identical.

### Compatibility

- Persisted state format: unchanged
- Config defaults change (3 values) — users with explicit config unaffected

### Validation

- `npm run typecheck` — clean
- `npm test` — 803 tests pass (798 pre-existing + 5 new)
- `npm run build` — success
- `./scripts/ci/check-pr.sh` — all checks pass
- Dual-agent review: APPROVE (both reviewers)

### After merge

CI (`release.yml`) auto-tags `v1.13.2`, builds, tests, publishes to npm `latest`, creates GitHub Release. Fully automated.