### PR TITLE
feat: blocking quality gate enforcement with acknowledgeRisk parameter

### DIFF
--- a/devlog/2026-07-22_quality-gate-enforcement/REQ.md
+++ b/devlog/2026-07-22_quality-gate-enforcement/REQ.md
@@ -1,0 +1,55 @@
+# REQ: Quality Gate Enforcement — Blocking Pre-Commit Check
+
+## Problem
+
+The quality gate is non-blocking: it logs warnings but never rejects bad compressions.
+This allowed block b7 in session `ses_07fa6ea18ffe7FVkta5UpKd2Jr` to compress 7598 tokens
+into 353 chars (94 tokens, 81:1 ratio) — a meta-reference summary with zero standalone value.
+
+Three-layer failure:
+1. L1 retention threshold too low (1.0% allows 99:1 ratio)
+2. L2 AND logic (both rougeF1 AND top20Recall must fail — keyword overlap passes)
+3. Non-blocking (quality gate only logs, never rejects)
+
+## Solution
+
+### 1. Pre-commit blocking quality gate
+Move quality evaluation from post-commit (in `finalizeSession`) to pre-commit
+(before `applyCompressionState`). Reject the compression if quality fails.
+
+### 2. `acknowledgeRisk` parameter
+Add `acknowledgeRisk: boolean` to compress tool schema (both range + message mode).
+- NOT documented in schema description — model discovers it only via rejection error
+- Only valid after a prior rejection for this range (tracked via `state.qualityGateRetryPending`)
+- Preemptive use (no prior rejection) → error "remove this parameter"
+- One-shot: consumed on use, next call goes through quality gate normally
+
+### 3. Severe error message
+Rejection error includes:
+- Stats (original tokens → summary chars, ratio, retention%)
+- Severe warning about data loss and context chain collapse
+- Full HOW TO COMPRESS rules (same as system prompt)
+- Instructions to add `acknowledgeRisk: true` on retry
+
+### 4. Threshold adjustment
+Raise `layer1MinRetentionPct` default from 1.0% to 5.0% (max ~20:1 ratio).
+
+## Scope
+
+Files to change:
+- `lib/state/types.ts` — add `qualityGateRetryPending: boolean` to SessionState
+- `lib/state/state.ts` — initialize flag in `createSessionState` + `resetSessionState`
+- `lib/config.ts` — raise `layer1MinRetentionPct` default 1.0 → 5.0
+- `lib/compress/quality-gate/evaluate.ts` — add `evaluatePreCommitQuality`
+- `lib/compress/quality-gate/rejection.ts` — new: build severe rejection error
+- `lib/compress/quality-gate/index.ts` — export new function
+- `lib/compress/range.ts` — add `acknowledgeRisk` to schema + pre-commit check
+- `lib/compress/message.ts` — add `acknowledgeRisk` to schema + pre-commit check
+- `lib/compress/types.ts` — add `acknowledgeRisk` to tool args types
+- `tests/quality-gate-enforcement.test.ts` — new test file
+
+## Non-persisted state
+
+`qualityGateRetryPending` is a transient runtime flag — NOT persisted to disk.
+Resets to `false` on session restart. This is correct because the model's context
+also resets on restart, so there's no pending rejection to retry.

--- a/devlog/2026-07-22_quality-gate-enforcement/WORKLOG.md
+++ b/devlog/2026-07-22_quality-gate-enforcement/WORKLOG.md
@@ -42,4 +42,40 @@
 
 ## Verification
 - `tsc --noEmit`: clean
-- `node --import tsx --test tests/*.test.ts`: 813 pass, 0 fail
+- `node --import tsx --test tests/*.test.ts`: 817 pass, 0 fail
+
+## Dual-Agent Review Fixes
+
+Two independent oracle agents reviewed the PR. Both converged on the same issues:
+
+### Fix 1: Tautological test (BLOCKER)
+Test "qualityGateRetryPending resets to false on resetSessionState" never called
+`resetSessionState()` — manually set the flag to false then asserted false.
+Fixed: now calls `resetSessionState(state)` directly and imports it.
+
+### Fix 2: State-leak — flag never cleared on successful quality pass (WARNING)
+If flag was `true` (from prior rejection) and model made a normal call (no
+acknowledgeRisk) that passed quality, the flag stayed `true`. Model could then
+"bank" the flag and use acknowledgeRisk on a totally different range to bypass
+quality. Fixed: clear flag to `false` at the start of the quality-check else
+branch in both range.ts and message.ts.
+
+### Fix 3: Rollback bug — flag not restored on mutation failure (WARNING)
+If acknowledgeRisk was consumed (flag→false) and then mutation failed inside
+the try block, `restoreCompressionState` didn't restore the flag. Model was
+stuck — couldn't retry with acknowledgeRisk (flag=false → preemptive error).
+Fixed: save `qualityGateRetryPendingBefore` before quality processing, restore
+it in the catch block alongside `restoreCompressionState`.
+
+### Fix 4: Integration tests through createCompressRangeTool (WARNING)
+Added 4 integration tests:
+- Quality gate rejects bad summary through the full tool pipeline
+- acknowledgeRisk bypasses quality after rejection (end-to-end retry flow)
+- Preemptive acknowledgeRisk rejected without prior rejection
+- Flag cleared on successful non-acknowledgeRisk compression (state-leak fix verification)
+
+### Fix 5: buildConfig() missing required fields (WARNING)
+Added all required CompressConfig fields: `autoUpdate`, `summaryBuffer`,
+`minNudgeContextPercent`, `maxSummaryLengthHard`, `minCompressRange`,
+`minNudgeGrowthRatio`, `minNudgeGrowthFloor`, `emergencyThresholdPercent`,
+`maxVisibleSegments`, `keepEmbedMaxChars`.

--- a/devlog/2026-07-22_quality-gate-enforcement/WORKLOG.md
+++ b/devlog/2026-07-22_quality-gate-enforcement/WORKLOG.md
@@ -1,0 +1,45 @@
+# WORKLOG: Quality Gate Enforcement
+
+## Implementation
+
+### 1. State: `qualityGateRetryPending` flag
+- `lib/state/types.ts`: Added `qualityGateRetryPending: boolean` to `SessionState`
+- `lib/state/state.ts`: Initialize `false` in `createSessionState()` + reset `false` in `resetSessionState()`
+- NOT persisted to disk — transient runtime flag. Resets on session restart (correct: model context also resets)
+
+### 2. Config: threshold adjustment
+- `lib/config.ts:259`: `layer1MinRetentionPct` default 1.0 → 5.0 (max ~20:1 ratio)
+
+### 3. Pre-commit quality evaluation
+- `lib/compress/quality-gate/evaluate.ts`: Added `evaluatePreCommitQuality()` function
+  - Takes rawMessages, messageIds, messageTokenById, summary, config
+  - Builds pseudo-block snapshot (compressedTokens estimated as sum of messageTokenById)
+  - Overestimates compressedTokens → conservative (stricter) for blocking check
+  - Returns null if quality gate disabled or no chunks extractable
+
+### 4. Rejection error builder
+- `lib/compress/quality-gate/rejection.ts`: New file
+  - `buildQualityRejectionError()`: Severe error with stats + HOW_TO_COMPRESS rules + acknowledgeRisk instructions
+  - `buildPreemptiveAcknowledgeError()`: Error for when acknowledgeRisk is used without pending rejection
+  - Imports `HOW_TO_COMPRESS_RULES` from `context-compress-algorithms/prompts` (same as system prompt)
+
+### 5. Range tool integration (`lib/compress/range.ts`)
+- Added `acknowledgeRisk: boolean` to schema (no description — model discovers via rejection)
+- Pre-commit check after `checkPhantomBlock`, before `snapshotCompressionState`:
+  1. `acknowledgeRisk:true` + `!qualityGateRetryPending` → throw preemptive error
+  2. `acknowledgeRisk:true` + `qualityGateRetryPending` → reset flag, skip quality
+  3. No acknowledgeRisk → evaluate each plan, throw rejection on first failure
+
+### 6. Message tool integration (`lib/compress/message.ts`)
+- Same pattern as range tool
+
+### 7. Types (`lib/compress/types.ts`)
+- Added `acknowledgeRisk?: boolean` to `CompressRangeToolArgs` and `CompressMessageToolArgs`
+
+### 8. Tests (`tests/quality-gate-enforcement.test.ts`)
+- 10 tests: evaluatePreCommitQuality (5), buildQualityRejectionError (2), buildPreemptiveAcknowledgeError (1), state flag lifecycle (2)
+- All 813 tests pass (803 existing + 10 new)
+
+## Verification
+- `tsc --noEmit`: clean
+- `node --import tsx --test tests/*.test.ts`: 813 pass, 0 fail

--- a/lib/compress/message.ts
+++ b/lib/compress/message.ts
@@ -21,6 +21,11 @@ import {
 } from "./state"
 import { resolveKeepMarkers } from "./keep-markers"
 import type { CompressMessageToolArgs } from "./types"
+import {
+    buildPreemptiveAcknowledgeError,
+    buildQualityRejectionError,
+    evaluatePreCommitQuality,
+} from "./quality-gate"
 
 function buildSchema(maxSummaryLengthHard: number) {
     return {
@@ -58,6 +63,7 @@ function buildSchema(maxSummaryLengthHard: number) {
             .describe(
                 "Set to true ONLY when you are certain the most recent message(s) must be compressed. Required when a range includes the tail of the conversation.",
             ),
+        acknowledgeRisk: tool.schema.boolean().optional(),
     }
 }
 
@@ -180,6 +186,40 @@ export function createCompressMessageTool(ctx: ToolContext): ReturnType<typeof t
                 })),
             )
             if (phantomError) throw phantomError
+
+            const acknowledgeRisk =
+                (args as { acknowledgeRisk?: boolean }).acknowledgeRisk === true
+
+            if (acknowledgeRisk && !ctx.state.qualityGateRetryPending) {
+                throw buildPreemptiveAcknowledgeError()
+            }
+            if (acknowledgeRisk) {
+                ctx.state.qualityGateRetryPending = false
+            } else {
+                for (const { plan, summaryWithTools } of preparedPlans) {
+                    const result = evaluatePreCommitQuality(
+                        rawMessages,
+                        plan.selection.messageIds,
+                        plan.selection.messageTokenById,
+                        summaryWithTools,
+                        ctx.config,
+                        ctx.logger,
+                    )
+                    if (result && !result.passed) {
+                        ctx.state.qualityGateRetryPending = true
+                        throw buildQualityRejectionError(
+                            {
+                                startId: plan.entry.messageId,
+                                endId: plan.entry.messageId,
+                                summary: summaryWithTools,
+                                messageIds: plan.selection.messageIds,
+                                messageTokenById: plan.selection.messageTokenById,
+                            },
+                            result,
+                        )
+                    }
+                }
+            }
 
             const snapshot = snapshotCompressionState(ctx.state)
             const runId = allocateRunId(ctx.state)

--- a/lib/compress/message.ts
+++ b/lib/compress/message.ts
@@ -190,12 +190,15 @@ export function createCompressMessageTool(ctx: ToolContext): ReturnType<typeof t
             const acknowledgeRisk =
                 (args as { acknowledgeRisk?: boolean }).acknowledgeRisk === true
 
+            const qualityGateRetryPendingBefore = ctx.state.qualityGateRetryPending
+
             if (acknowledgeRisk && !ctx.state.qualityGateRetryPending) {
                 throw buildPreemptiveAcknowledgeError()
             }
             if (acknowledgeRisk) {
                 ctx.state.qualityGateRetryPending = false
             } else {
+                ctx.state.qualityGateRetryPending = false
                 for (const { plan, summaryWithTools } of preparedPlans) {
                     const result = evaluatePreCommitQuality(
                         rawMessages,
@@ -269,6 +272,7 @@ export function createCompressMessageTool(ctx: ToolContext): ReturnType<typeof t
                 await finalizeSession(ctx, toolCtx, rawMessages, notifications, input.topic)
             } catch (error) {
                 restoreCompressionState(ctx.state, snapshot)
+                ctx.state.qualityGateRetryPending = qualityGateRetryPendingBefore
                 throw error
             }
 

--- a/lib/compress/quality-gate/evaluate.ts
+++ b/lib/compress/quality-gate/evaluate.ts
@@ -134,3 +134,84 @@ export function evaluateBatchQuality(
         failures,
     }
 }
+
+/**
+ * Pre-commit quality evaluation: check summary quality BEFORE the block is
+ * committed to state. Builds a pseudo-block snapshot from the plan data.
+ *
+ * Returns null if quality gate is disabled or evaluation cannot run.
+ * Returns QualityGateResult (passed: true/false) otherwise.
+ *
+ * `compressedTokens` is estimated as the sum of messageTokenById for all
+ * direct message IDs. This overestimates when some messages were already
+ * active under consumed blocks, making the gate more conservative (stricter)
+ * — which is the safe direction for a blocking check.
+ */
+export function evaluatePreCommitQuality(
+    rawMessages: WithParts[],
+    messageIds: string[],
+    messageTokenById: Map<string, number>,
+    summary: string,
+    config: PluginConfig,
+    logger: Logger,
+): QualityGateResult | null {
+    const qg = config.qualityGate
+    if (!qg || qg.enabled !== true) return null
+
+    ensureBuiltinGatesRegistered()
+    const algoName = qg.algorithm
+    if (!algoName) {
+        logger.warn("Quality gate enabled but no algorithm specified", {})
+        return null
+    }
+    const gate = getQualityGate(algoName)
+    if (!gate) {
+        logger.warn("Quality gate algorithm not found in registry", { algorithm: algoName })
+        return null
+    }
+
+    if (messageIds.length === 0) return null
+
+    const idToMsg = new Map<string, WithParts>()
+    for (const m of rawMessages) {
+        const id = m?.info?.id
+        if (typeof id === "string") idToMsg.set(id, m)
+    }
+
+    const chunks: string[] = []
+    let compressedTokens = 0
+    for (const id of messageIds) {
+        const m = idToMsg.get(id)
+        if (m) chunks.push(extractMessageText(m.parts))
+        compressedTokens += messageTokenById.get(id) || 0
+    }
+    if (chunks.length === 0) return null
+
+    const originalText = chunks.join("\n")
+    const pseudoBlock = {
+        blockId: -1,
+        summary,
+        compressedTokens,
+        directMessageIds: messageIds,
+        effectiveMessageIds: messageIds,
+    }
+
+    const ctx: QualityGateContext = {
+        block: pseudoBlock as CompressionBlock,
+        summary,
+        originalChunks: chunks,
+        originalText,
+        originalTokens: Math.ceil(originalText.length / CHARS_PER_TOKEN_ESTIMATE),
+    }
+
+    const algoConfig = (qg.algorithms && qg.algorithms[algoName]) ?? {}
+    try {
+        return gate.evaluate(ctx, algoConfig)
+    } catch (err) {
+        logger.warn("Pre-commit quality gate threw — treating as pass", {
+            gate: gate.name,
+            error: err instanceof Error ? err.message : String(err),
+        })
+        return { passed: true, metrics: [] }
+    }
+}

--- a/lib/compress/quality-gate/index.ts
+++ b/lib/compress/quality-gate/index.ts
@@ -13,5 +13,7 @@ export {
     clearQualityGateRegistryForTests,
 } from "./registry"
 
-export { evaluateBlockQuality, evaluateBatchQuality } from "./evaluate"
+export { evaluateBlockQuality, evaluateBatchQuality, evaluatePreCommitQuality } from "./evaluate"
+export { buildQualityRejectionError, buildPreemptiveAcknowledgeError } from "./rejection"
+export type { RejectionPlanInfo } from "./rejection"
 export { ensureBuiltinGatesRegistered } from "./algorithms"

--- a/lib/compress/quality-gate/rejection.ts
+++ b/lib/compress/quality-gate/rejection.ts
@@ -1,0 +1,83 @@
+import { HOW_TO_COMPRESS_RULES } from "context-compress-algorithms/prompts"
+import type { QualityGateResult } from "./types"
+
+export interface RejectionPlanInfo {
+    startId: string
+    endId: string
+    summary: string
+    messageIds: string[]
+    messageTokenById: Map<string, number>
+}
+
+function formatMetric(result: QualityGateResult, name: string): string {
+    const m = result.metrics.find((x) => x.name === name)
+    if (!m) return "?"
+    switch (m.format) {
+        case "percent":
+            return `${m.value.toFixed(2)}%`
+        case "ratio":
+            return m.value.toFixed(4)
+        default:
+            return String(m.value)
+    }
+}
+
+function computeStats(plan: RejectionPlanInfo): {
+    originalTokens: number
+    summaryChars: number
+    ratio: string
+    retentionPct: string
+} {
+    let originalTokens = 0
+    for (const id of plan.messageIds) {
+        originalTokens += plan.messageTokenById.get(id) || 0
+    }
+    const summaryChars = plan.summary.length
+    const ratio = originalTokens > 0 ? (originalTokens / Math.max(summaryChars / 4, 1)).toFixed(1) : "?"
+    const retentionPct =
+        originalTokens > 0 ? ((summaryChars / (originalTokens * 4)) * 100).toFixed(2) : "?"
+    return { originalTokens, summaryChars, ratio, retentionPct }
+}
+
+export function buildQualityRejectionError(
+    plan: RejectionPlanInfo,
+    result: QualityGateResult,
+): Error {
+    const stats = computeStats(plan)
+    const metrics = [
+        `Original: ~${stats.originalTokens} tokens`,
+        `Summary: ${stats.summaryChars} chars`,
+        `Ratio: ${stats.ratio}:1`,
+        `Retention: ${stats.retentionPct}%`,
+        `Gate layer: ${result.layer ?? "unknown"}`,
+        `rougeF1: ${formatMetric(result, "rougeF1")}`,
+        `top20Recall: ${formatMetric(result, "top20Recall")}`,
+    ]
+
+    const message = `⚠️ COMPRESSION REJECTED — QUALITY GATE FAILURE
+
+Range: ${plan.startId}–${plan.endId}
+${metrics.join("\n")}
+
+⚠️ CRITICAL: Compression is the ONLY mechanism for preserving historical context in this session.
+Once a compression is accepted, the original messages are permanently removed from visible context.
+Your summary becomes the SOLE record. If it fails, subsequent work is built on a broken foundation —
+memory loss → wrong assumptions → entire reasoning chain collapse.
+Treat every compression with maximum care.
+
+${HOW_TO_COMPRESS_RULES}
+
+To retry: rewrite a more complete summary that preserves critical details (file paths, decisions,
+exact values, errors). Then add "acknowledgeRisk": true to the compress tool call parameters.
+Without acknowledgeRisk: true, the compression will be rejected again.`
+
+    return new Error(message)
+}
+
+export function buildPreemptiveAcknowledgeError(): Error {
+    return new Error(
+        'Parameter "acknowledgeRisk": true was provided, but no quality gate rejection is pending. ' +
+            "This parameter is only valid immediately after a compression was rejected by the quality gate. " +
+            "Remove it and try again.",
+    )
+}

--- a/lib/compress/range.ts
+++ b/lib/compress/range.ts
@@ -35,6 +35,11 @@ import {
 } from "./state"
 import type { CompressRangeToolArgs } from "./types"
 import { resolveKeepMarkers } from "./keep-markers"
+import {
+    buildPreemptiveAcknowledgeError,
+    buildQualityRejectionError,
+    evaluatePreCommitQuality,
+} from "./quality-gate"
 
 function buildSchema(maxSummaryLengthHard: number) {
     return {
@@ -83,6 +88,7 @@ function buildSchema(maxSummaryLengthHard: number) {
             .describe(
                 "Set to true ONLY when you are certain the most recent message(s) must be compressed. Required when a range includes the tail of the conversation.",
             ),
+        acknowledgeRisk: tool.schema.boolean().optional(),
     }
 }
 
@@ -271,6 +277,40 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
                 })),
             )
             if (phantomError) throw phantomError
+
+            const acknowledgeRisk =
+                (args as { acknowledgeRisk?: boolean }).acknowledgeRisk === true
+
+            if (acknowledgeRisk && !ctx.state.qualityGateRetryPending) {
+                throw buildPreemptiveAcknowledgeError()
+            }
+            if (acknowledgeRisk) {
+                ctx.state.qualityGateRetryPending = false
+            } else {
+                for (const plan of preparedPlans) {
+                    const result = evaluatePreCommitQuality(
+                        rawMessages,
+                        plan.selection.messageIds,
+                        plan.selection.messageTokenById,
+                        plan.finalSummary,
+                        ctx.config,
+                        ctx.logger,
+                    )
+                    if (result && !result.passed) {
+                        ctx.state.qualityGateRetryPending = true
+                        throw buildQualityRejectionError(
+                            {
+                                startId: plan.entry.startId,
+                                endId: plan.entry.endId,
+                                summary: plan.finalSummary,
+                                messageIds: plan.selection.messageIds,
+                                messageTokenById: plan.selection.messageTokenById,
+                            },
+                            result,
+                        )
+                    }
+                }
+            }
 
             const snapshot = snapshotCompressionState(ctx.state)
             const runId = allocateRunId(ctx.state)

--- a/lib/compress/range.ts
+++ b/lib/compress/range.ts
@@ -281,12 +281,15 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
             const acknowledgeRisk =
                 (args as { acknowledgeRisk?: boolean }).acknowledgeRisk === true
 
+            const qualityGateRetryPendingBefore = ctx.state.qualityGateRetryPending
+
             if (acknowledgeRisk && !ctx.state.qualityGateRetryPending) {
                 throw buildPreemptiveAcknowledgeError()
             }
             if (acknowledgeRisk) {
                 ctx.state.qualityGateRetryPending = false
             } else {
+                ctx.state.qualityGateRetryPending = false
                 for (const plan of preparedPlans) {
                     const result = evaluatePreCommitQuality(
                         rawMessages,
@@ -368,6 +371,7 @@ export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof too
                 )
             } catch (error) {
                 restoreCompressionState(ctx.state, snapshot)
+                ctx.state.qualityGateRetryPending = qualityGateRetryPendingBefore
                 throw error
             }
 

--- a/lib/compress/types.ts
+++ b/lib/compress/types.ts
@@ -23,6 +23,9 @@ export interface CompressRangeToolArgs {
     /** Fallback topic for entries without their own. Optional if every entry has one. */
     topic?: string
     content: CompressRangeEntry[]
+    summaryMaxChars?: number
+    dangerous?: boolean
+    acknowledgeRisk?: boolean
 }
 
 export interface CompressMessageEntry {
@@ -34,6 +37,9 @@ export interface CompressMessageEntry {
 export interface CompressMessageToolArgs {
     topic: string
     content: CompressMessageEntry[]
+    summaryMaxChars?: number
+    dangerous?: boolean
+    acknowledgeRisk?: boolean
 }
 
 export interface BoundaryReference {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -256,7 +256,7 @@ const defaultConfig: PluginConfig = {
         algorithms: {
             "rouge-recall-v1": {
                 layer1MinChars: 200,
-                layer1MinRetentionPct: 1.0,
+                layer1MinRetentionPct: 5.0,
                 layer2MaxRougeF1: 0.05,
                 layer2MaxTop20Recall: 0.20,
             },

--- a/lib/state/state.ts
+++ b/lib/state/state.ts
@@ -109,6 +109,7 @@ export function createSessionState(): SessionState {
         currentTurn: 0,
         modelContextLimit: undefined,
         systemPromptTokens: undefined,
+        qualityGateRetryPending: false,
     }
 }
 
@@ -149,6 +150,7 @@ export function resetSessionState(state: SessionState): void {
     state.currentTurn = 0
     state.modelContextLimit = undefined
     state.systemPromptTokens = undefined
+    state.qualityGateRetryPending = false
 }
 
 export async function ensureSessionInitialized(

--- a/lib/state/types.ts
+++ b/lib/state/types.ts
@@ -128,4 +128,16 @@ export interface SessionState {
     currentTurn: number
     modelContextLimit: number | undefined
     systemPromptTokens: number | undefined
+    /**
+     * Transient flag (NOT persisted): set to true when a compress call is rejected
+     * by the pre-commit quality gate. The model must retry with `acknowledgeRisk: true`
+     * to bypass quality on the retry. Consumed (reset to false) on use.
+     *
+     * Lifecycle:
+     * - Quality fails → flag = true → rejection error returned
+     * - Retry with acknowledgeRisk:true + flag=true → accepted, flag = false
+     * - acknowledgeRisk:true + flag=false → error "no rejection pending, remove parameter"
+     * - Normal call (no acknowledgeRisk) → quality runs normally
+     */
+    qualityGateRetryPending: boolean
 }

--- a/tests/quality-gate-enforcement.test.ts
+++ b/tests/quality-gate-enforcement.test.ts
@@ -1,0 +1,311 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { mkdirSync } from "node:fs"
+import {
+    evaluatePreCommitQuality,
+    buildQualityRejectionError,
+    buildPreemptiveAcknowledgeError,
+} from "../lib/compress/quality-gate"
+import { createSessionState, type WithParts } from "../lib/state"
+import type { PluginConfig } from "../lib/config"
+import type { QualityGateResult } from "../lib/compress/quality-gate/types"
+import { Logger } from "../lib/logger"
+
+const testDataHome = join(tmpdir(), `opencode-acp-qg-tests-${process.pid}`)
+const testConfigHome = join(tmpdir(), `opencode-acp-qg-config-tests-${process.pid}`)
+
+process.env.XDG_DATA_HOME = testDataHome
+process.env.XDG_CONFIG_HOME = testConfigHome
+
+mkdirSync(testDataHome, { recursive: true })
+mkdirSync(testConfigHome, { recursive: true })
+
+function buildConfig(qualityGateEnabled: boolean): PluginConfig {
+    return {
+        enabled: true,
+        debug: false,
+        pruneNotification: "off",
+        pruneNotificationType: "chat",
+        commands: { enabled: true, protectedTools: [] },
+        manualMode: { enabled: false, automaticStrategies: true },
+        turnProtection: { enabled: false, turns: 4 },
+        experimental: { allowSubAgents: true, customPrompts: false },
+        protectedFilePatterns: [],
+        compress: {
+            mode: "range",
+            permission: "allow",
+            showCompression: false,
+            maxContextLimit: 150000,
+            minContextLimit: 50000,
+            nudgeFrequency: 5,
+            iterationNudgeThreshold: 15,
+            nudgeForce: "soft",
+            protectedTools: [],
+            protectTags: false,
+            protectUserMessages: false,
+            lastSegmentSoftBlock: false,
+        },
+        strategies: {
+            deduplication: { enabled: true, protectedTools: [] },
+            purgeErrors: { enabled: true, turns: 4, protectedTools: [] },
+        },
+        gc: {
+            algorithm: "truncate",
+            promotionThreshold: 5,
+            maxBlockAge: 15,
+            maxOldGenSummaryLength: 3000,
+            majorGcThresholdPercent: "100%",
+            batchCleanup: { lowThreshold: "60%", highThreshold: "75%", forceThreshold: "90%" },
+        },
+        qualityGate: qualityGateEnabled
+            ? {
+                  enabled: true,
+                  algorithm: "rouge-recall-v1",
+                  algorithms: {
+                      "rouge-recall-v1": {
+                          layer1MinChars: 200,
+                          layer1MinRetentionPct: 5.0,
+                          layer2MaxRougeF1: 0.05,
+                          layer2MaxTop20Recall: 0.20,
+                      },
+                  },
+              }
+            : { enabled: false, algorithm: "rouge-recall-v1" },
+    }
+}
+
+function textPart(messageID: string, sessionID: string, id: string, text: string) {
+    return { id, messageID, sessionID, type: "text" as const, text }
+}
+
+function buildLargeMessages(sessionID: string): WithParts[] {
+    const messages: WithParts[] = []
+    for (let i = 0; i < 5; i++) {
+        const msgId = `msg-large-${i}`
+        messages.push({
+            info: {
+                id: msgId,
+                role: i % 2 === 0 ? "user" : "assistant",
+                sessionID,
+                time: { created: i + 1 },
+            } as WithParts["info"],
+            parts: [
+                textPart(
+                    msgId,
+                    sessionID,
+                    `part-${i}`,
+                    `This is a detailed message about authentication system design. ` +
+                        `The file path is lib/auth.ts at line ${i * 10}. ` +
+                        `We found a critical bug where the token refresh logic was broken. ` +
+                        `The fix involved adding a retry mechanism with exponential backoff. ` +
+                        `Key decision: use JWT over session cookies for stateless architecture.`,
+                ),
+            ],
+        })
+    }
+    return messages
+}
+
+function buildTokenMap(messageIds: string[], tokensPerMessage: number): Map<string, number> {
+    const map = new Map<string, number>()
+    for (const id of messageIds) map.set(id, tokensPerMessage)
+    return map
+}
+
+const logger = new Logger(false)
+
+test("evaluatePreCommitQuality returns null when quality gate disabled", () => {
+    const config = buildConfig(false)
+    const result = evaluatePreCommitQuality(
+        [],
+        ["msg-1"],
+        buildTokenMap(["msg-1"], 100),
+        "short",
+        config,
+        logger,
+    )
+    assert.equal(result, null)
+})
+
+test("evaluatePreCommitQuality rejects summary with extremely low retention (L1)", () => {
+    const sessionID = "ses-test-l1"
+    const rawMessages = buildLargeMessages(sessionID)
+    const messageIds = rawMessages.map((m) => m.info.id)
+    const messageTokenById = buildTokenMap(messageIds, 300)
+
+    const result = evaluatePreCommitQuality(
+        rawMessages,
+        messageIds,
+        messageTokenById,
+        "Too short.",
+        buildConfig(true),
+        logger,
+    )
+
+    assert.ok(result, "should return a result")
+    assert.equal(result!.passed, false)
+    assert.equal(result!.layer, "L1-length")
+})
+
+test("evaluatePreCommitQuality passes summary with adequate retention and keyword overlap", () => {
+    const sessionID = "ses-test-pass"
+    const rawMessages = buildLargeMessages(sessionID)
+    const messageIds = rawMessages.map((m) => m.info.id)
+    const messageTokenById = buildTokenMap(messageIds, 50)
+
+    const goodSummary =
+        `Authentication system design analysis. ` +
+        `File: lib/auth.ts. Found critical bug in token refresh logic. ` +
+        `Fix: retry mechanism with exponential backoff. ` +
+        `Decision: JWT over session cookies for stateless architecture. ` +
+        `Key details preserved for downstream work.`
+
+    const result = evaluatePreCommitQuality(
+        rawMessages,
+        messageIds,
+        messageTokenById,
+        goodSummary,
+        buildConfig(true),
+        logger,
+    )
+
+    assert.ok(result, "should return a result")
+    assert.equal(result!.passed, true)
+})
+
+test("evaluatePreCommitQuality returns null for empty messageIds", () => {
+    const result = evaluatePreCommitQuality(
+        buildLargeMessages("ses"),
+        [],
+        new Map(),
+        "summary",
+        buildConfig(true),
+        logger,
+    )
+    assert.equal(result, null)
+})
+
+test("evaluatePreCommitQuality returns null when no chunks can be extracted", () => {
+    const result = evaluatePreCommitQuality(
+        [],
+        ["msg-nonexistent"],
+        buildTokenMap(["msg-nonexistent"], 100),
+        "summary",
+        buildConfig(true),
+        logger,
+    )
+    assert.equal(result, null)
+})
+
+// === buildQualityRejectionError ===
+
+test("buildQualityRejectionError includes range, stats, and acknowledgeRisk instructions", () => {
+    const messageIds = ["msg-1", "msg-2"]
+    const plan = {
+        startId: "m00001",
+        endId: "m00005",
+        summary: "Too short summary.",
+        messageIds,
+        messageTokenById: buildTokenMap(messageIds, 500),
+    }
+    const result: QualityGateResult = {
+        passed: false,
+        layer: "L1-length",
+        reason: "Summary too short",
+        metrics: [
+            { name: "summaryLen", value: 18 },
+            { name: "retentionPct", value: 0.9, format: "percent" },
+            { name: "originalTokens", value: 1000 },
+            { name: "rougeF1", value: 0.01, format: "ratio" },
+            { name: "top20Recall", value: 0.05, format: "ratio" },
+        ],
+    }
+
+    const error = buildQualityRejectionError(plan, result)
+    const msg = error.message
+
+    assert.ok(msg.includes("COMPRESSION REJECTED"), "should have rejection header")
+    assert.ok(msg.includes("m00001–m00005"), "should include range")
+    assert.ok(msg.includes("1000 tokens"), "should include original token count")
+    assert.ok(msg.includes("acknowledgeRisk"), "should mention acknowledgeRisk")
+    assert.ok(msg.includes("HOW TO COMPRESS") || msg.includes("KEEP VERBATIM"), "should include compress rules")
+})
+
+test("buildQualityRejectionError computes ratio and retention from plan data", () => {
+    const messageIds = ["msg-1"]
+    const plan = {
+        startId: "m00001",
+        endId: "m00002",
+        summary: "x".repeat(100),
+        messageIds,
+        messageTokenById: buildTokenMap(messageIds, 1000),
+    }
+    const result: QualityGateResult = {
+        passed: false,
+        layer: "L1-length",
+        reason: "test",
+        metrics: [],
+    }
+
+    const error = buildQualityRejectionError(plan, result)
+    assert.ok(error.message.includes("1000 tokens"), "should show original tokens")
+    assert.ok(error.message.includes("100 chars"), "should show summary chars")
+})
+
+test("buildPreemptiveAcknowledgeError explains the parameter is invalid without pending rejection", () => {
+    const error = buildPreemptiveAcknowledgeError()
+    assert.ok(error.message.includes("acknowledgeRisk"), "should mention the parameter name")
+    assert.ok(
+        error.message.includes("no quality gate rejection is pending"),
+        "should explain why it's invalid",
+    )
+    assert.ok(error.message.includes("Remove it"), "should tell model to remove it")
+})
+
+test("qualityGateRetryPending defaults to false", () => {
+    const state = createSessionState()
+    assert.equal(state.qualityGateRetryPending, false)
+})
+
+test("qualityGateRetryPending resets to false on resetSessionState", () => {
+    const state = createSessionState()
+    state.qualityGateRetryPending = true
+    state.sessionId = null
+    state.prune = {
+        tools: new Map(),
+        messages: {
+            byMessageId: new Map(),
+            blocksById: new Map(),
+            activeBlockIds: new Set(),
+            activeByAnchorMessageId: new Map(),
+            nextBlockId: 1,
+            nextRunId: 1,
+            markedForCleanup: new Set(),
+        },
+    }
+    state.nudges = {
+        contextLimitAnchors: new Set(),
+        turnNudgeAnchors: new Set(),
+        iterationNudgeAnchors: new Set(),
+        lastPerMessageNudgeTurn: 0,
+        lastPerMessageNudgeTokens: undefined,
+        lastNudgeShownTokens: undefined,
+        lastToolOutputNudgeTokens: undefined,
+        shouldInjectThisTurn: undefined,
+        compressBaselineSet: false,
+    }
+    state.stats = { pruneTokenCounter: 0, totalPruneTokens: 0 }
+    state.toolParameters.clear()
+    state.subAgentResultCache.clear()
+    state.toolIdList = []
+    state.messageIds = { byRawId: new Map(), byRef: new Map(), nextRef: 1 }
+    state.lastCompaction = 0
+    state.currentTurn = 0
+    state.modelContextLimit = undefined
+    state.systemPromptTokens = undefined
+    state.qualityGateRetryPending = false
+
+    assert.equal(state.qualityGateRetryPending, false)
+})

--- a/tests/quality-gate-enforcement.test.ts
+++ b/tests/quality-gate-enforcement.test.ts
@@ -8,7 +8,8 @@ import {
     buildQualityRejectionError,
     buildPreemptiveAcknowledgeError,
 } from "../lib/compress/quality-gate"
-import { createSessionState, type WithParts } from "../lib/state"
+import { createCompressRangeTool } from "../lib/compress/range"
+import { createSessionState, resetSessionState, type WithParts } from "../lib/state"
 import type { PluginConfig } from "../lib/config"
 import type { QualityGateResult } from "../lib/compress/quality-gate/types"
 import { Logger } from "../lib/logger"
@@ -25,6 +26,7 @@ mkdirSync(testConfigHome, { recursive: true })
 function buildConfig(qualityGateEnabled: boolean): PluginConfig {
     return {
         enabled: true,
+        autoUpdate: true,
         debug: false,
         pruneNotification: "off",
         pruneNotificationType: "chat",
@@ -37,14 +39,23 @@ function buildConfig(qualityGateEnabled: boolean): PluginConfig {
             mode: "range",
             permission: "allow",
             showCompression: false,
+            summaryBuffer: true,
             maxContextLimit: 150000,
             minContextLimit: 50000,
             nudgeFrequency: 5,
+            minNudgeContextPercent: 15,
             iterationNudgeThreshold: 15,
             nudgeForce: "soft",
             protectedTools: [],
             protectTags: false,
             protectUserMessages: false,
+            maxSummaryLengthHard: 20000,
+            minCompressRange: 0,
+            minNudgeGrowthRatio: 0.45,
+            minNudgeGrowthFloor: 5000,
+            emergencyThresholdPercent: "98%",
+            maxVisibleSegments: 50,
+            keepEmbedMaxChars: 2000,
             lastSegmentSoftBlock: false,
         },
         strategies: {
@@ -272,40 +283,171 @@ test("qualityGateRetryPending defaults to false", () => {
 test("qualityGateRetryPending resets to false on resetSessionState", () => {
     const state = createSessionState()
     state.qualityGateRetryPending = true
-    state.sessionId = null
-    state.prune = {
-        tools: new Map(),
-        messages: {
-            byMessageId: new Map(),
-            blocksById: new Map(),
-            activeBlockIds: new Set(),
-            activeByAnchorMessageId: new Map(),
-            nextBlockId: 1,
-            nextRunId: 1,
-            markedForCleanup: new Set(),
-        },
-    }
-    state.nudges = {
-        contextLimitAnchors: new Set(),
-        turnNudgeAnchors: new Set(),
-        iterationNudgeAnchors: new Set(),
-        lastPerMessageNudgeTurn: 0,
-        lastPerMessageNudgeTokens: undefined,
-        lastNudgeShownTokens: undefined,
-        lastToolOutputNudgeTokens: undefined,
-        shouldInjectThisTurn: undefined,
-        compressBaselineSet: false,
-    }
-    state.stats = { pruneTokenCounter: 0, totalPruneTokens: 0 }
-    state.toolParameters.clear()
-    state.subAgentResultCache.clear()
-    state.toolIdList = []
-    state.messageIds = { byRawId: new Map(), byRef: new Map(), nextRef: 1 }
-    state.lastCompaction = 0
-    state.currentTurn = 0
-    state.modelContextLimit = undefined
-    state.systemPromptTokens = undefined
-    state.qualityGateRetryPending = false
-
+    resetSessionState(state)
     assert.equal(state.qualityGateRetryPending, false)
+})
+
+function buildIntegrationMessages(sessionID: string): WithParts[] {
+    const messages: WithParts[] = []
+    const longText =
+        "This is a detailed technical analysis of the authentication system. " +
+        "File: lib/auth.ts:142 contains the token refresh logic. " +
+        "Decision: JWT over session cookies for stateless architecture. " +
+        "Critical bug found: retry mechanism missing exponential backoff. " +
+        "Fix applied: added backoff with base=1000ms, max=30000ms. " +
+        "Test coverage: lib/auth.test.ts now covers refresh edge cases. " +
+        "Performance: 3ms overhead per refresh attempt, acceptable. "
+    for (let i = 0; i < 6; i++) {
+        const msgId = `msg-int-${i}`
+        messages.push({
+            info: {
+                id: msgId,
+                role: i % 2 === 0 ? "user" : "assistant",
+                sessionID,
+                model: { providerID: "anthropic", modelID: "claude-test" },
+                time: { created: i + 1 },
+            } as WithParts["info"],
+            parts: [textPart(msgId, sessionID, `int-part-${i}`, longText + `Iteration ${i}. `)],
+        })
+    }
+    return messages
+}
+
+function buildToolContext(state: ReturnType<typeof createSessionState>, config: PluginConfig, rawMessages: WithParts[]) {
+    return createCompressRangeTool({
+        client: {
+            session: {
+                messages: async () => ({ data: rawMessages }),
+                get: async () => ({ data: { parentID: null } }),
+            },
+        },
+        state,
+        logger: new Logger(false),
+        config,
+        prompts: {
+            reload() {},
+            getRuntimePrompts() {
+                return { compressRange: "", compressMessage: "" }
+            },
+        },
+    } as any)
+}
+
+const toolCtx = {
+    ask: async () => {},
+    metadata: () => {},
+    sessionID: "",
+    messageID: "msg-compress",
+}
+
+test("integration: quality gate rejects bad summary through createCompressRangeTool", async () => {
+    const sessionID = `ses-int-reject-${Date.now()}`
+    const rawMessages = buildIntegrationMessages(sessionID)
+    const state = createSessionState()
+    const config = buildConfig(true)
+    const tool = buildToolContext(state, config, rawMessages)
+
+    await assert.rejects(
+        tool.execute(
+            {
+                topic: "Auth analysis",
+                content: [
+                    {
+                        startId: "m00001",
+                        endId: "m00004",
+                        summary: "Stuff happened.",
+                    },
+                ],
+            },
+            { ...toolCtx, sessionID },
+        ),
+        (err: Error) => {
+            assert.ok(err.message.includes("COMPRESSION REJECTED"), `should be quality rejection, got: ${err.message}`)
+            return true
+        },
+    )
+    assert.equal(state.qualityGateRetryPending, true, "flag should be set after rejection")
+    assert.equal(state.prune.messages.blocksById.size, 0, "no blocks should be committed")
+})
+
+test("integration: acknowledgeRisk bypasses quality after rejection", async () => {
+    const sessionID = `ses-int-ack-${Date.now()}`
+    const rawMessages = buildIntegrationMessages(sessionID)
+    const state = createSessionState()
+    const config = buildConfig(true)
+    const tool = buildToolContext(state, config, rawMessages)
+
+    await assert.rejects(
+        tool.execute(
+            {
+                topic: "Auth analysis",
+                content: [{ startId: "m00001", endId: "m00004", summary: "Bad." }],
+            },
+            { ...toolCtx, sessionID },
+        ),
+    )
+    assert.equal(state.qualityGateRetryPending, true)
+
+    const result = await tool.execute(
+        {
+            topic: "Auth analysis",
+            content: [{ startId: "m00001", endId: "m00004", summary: "Bad summary bypassed." }],
+            acknowledgeRisk: true,
+        } as any,
+        { ...toolCtx, sessionID },
+    )
+    assert.ok(result.includes("Compressed"), "retry with acknowledgeRisk should succeed")
+    assert.equal(state.qualityGateRetryPending, false, "flag should be consumed after successful retry")
+    assert.equal(state.prune.messages.blocksById.size, 1, "one block should be committed")
+})
+
+test("integration: preemptive acknowledgeRisk without prior rejection is rejected", async () => {
+    const sessionID = `ses-int-preempt-${Date.now()}`
+    const rawMessages = buildIntegrationMessages(sessionID)
+    const state = createSessionState()
+    const config = buildConfig(true)
+    const tool = buildToolContext(state, config, rawMessages)
+
+    await assert.rejects(
+        tool.execute(
+            {
+                topic: "Auth analysis",
+                content: [{ startId: "m00001", endId: "m00004", summary: "Good enough summary with keywords." }],
+                acknowledgeRisk: true,
+            } as any,
+            { ...toolCtx, sessionID },
+        ),
+        (err: Error) => {
+            assert.ok(err.message.includes("no quality gate rejection is pending"), `should be preemptive error, got: ${err.message}`)
+            return true
+        },
+    )
+    assert.equal(state.qualityGateRetryPending, false, "flag should stay false")
+    assert.equal(state.prune.messages.blocksById.size, 0, "no blocks committed")
+})
+
+test("integration: flag cleared on successful non-acknowledgeRisk compression", async () => {
+    const sessionID = `ses-int-clear-${Date.now()}`
+    const rawMessages = buildIntegrationMessages(sessionID)
+    const state = createSessionState()
+    const config = buildConfig(true)
+    const tool = buildToolContext(state, config, rawMessages)
+
+    state.qualityGateRetryPending = true
+
+    const goodSummary =
+        "Authentication system analysis. File: lib/auth.ts:142 token refresh logic. " +
+        "Decision: JWT over session cookies for stateless architecture. " +
+        "Critical bug: retry mechanism missing exponential backoff. Fix: base=1000ms, max=30000ms. " +
+        "Test: lib/auth.test.ts covers refresh edge cases. Performance: 3ms overhead per refresh."
+
+    const result = await tool.execute(
+        {
+            topic: "Auth analysis",
+            content: [{ startId: "m00001", endId: "m00004", summary: goodSummary }],
+        },
+        { ...toolCtx, sessionID },
+    )
+    assert.ok(result.includes("Compressed"), "good summary should pass quality and compress")
+    assert.equal(state.qualityGateRetryPending, false, "flag should be cleared on successful quality pass")
 })


### PR DESCRIPTION
## Summary

- **Pre-commit quality gate**: Summary quality is now evaluated BEFORE the compression block is committed. If the summary fails the gate (e.g., 81:1 token ratio), the entire compression is rejected with a severe error message.
- **`acknowledgeRisk` parameter**: Undocumented in the schema — the model discovers it only via the rejection error. Enforced via a transient `qualityGateRetryPending` flag: preemptive use without a prior rejection → error.
- **L1 threshold raised**: `layer1MinRetentionPct` default 1.0% → 5.0% (caps compression ratio at ~20:1).

## Problem

Block b7 in session `ses_07fa6ea18ffe7FVkta5UpKd2Jr` compressed 7598 tokens into 353 chars (81:1 ratio) — a meta-reference summary with zero standalone value. The quality gate was non-blocking (only logged warnings), and the L1 threshold (1.0%) allowed catastrophic retention failures to pass.

## Solution

### Lifecycle
```
Quality fails → flag=true → rejection error returned
Retry with acknowledgeRisk:true + flag=true → accepted, flag=false
acknowledgeRisk:true + flag=false → error "remove this parameter"
Normal call (no acknowledgeRisk) → quality runs normally
```

### Rejection error
Includes stats (original tokens, summary chars, ratio, retention%), severe warning about permanent data loss, full HOW TO COMPRESS rules, and instructions to add `acknowledgeRisk: true` on retry.

## Files changed
- `lib/state/types.ts`, `lib/state/state.ts` — transient `qualityGateRetryPending` flag
- `lib/config.ts` — L1 threshold 1.0 → 5.0
- `lib/compress/quality-gate/evaluate.ts` — `evaluatePreCommitQuality()` function
- `lib/compress/quality-gate/rejection.ts` — new: rejection error builder
- `lib/compress/range.ts`, `lib/compress/message.ts` — schema + pre-commit check
- `tests/quality-gate-enforcement.test.ts` — 10 new tests

## Test plan
- [x] `tsc --noEmit` clean
- [x] All 813 tests pass (803 existing + 10 new)
- [x] `npm run build` succeeds