### PR TITLE
fix: let compress.protectedTools replace inherited defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,7 +292,7 @@ Auto-migration: if `acp.jsonc` doesn't exist but `dcp.jsonc` does, automatically
         nudgeFrequency: 5,               // nudges every N turns
         iterationNudgeThreshold: 15,     // nudge after N messages since last user message
         nudgeForce: "soft",              // "strong" | "soft"
-        protectedTools: ["task", "skill", "todowrite", "todoread"],
+        protectedTools: ["skill"],       // root default; an explicit array replaces inherited policy (use [] to protect nothing)
         protectTags: false,
         protectUserMessages: false,
     },

--- a/README.md
+++ b/README.md
@@ -309,8 +309,9 @@ Each level overrides the previous, so project settings take priority over global
         // Controls how likely compression is after user messages
         // ("strong" = more likely, "soft" = less likely)
         "nudgeForce": "soft",
-        // Tool names whose completed outputs are appended to the compression
-        "protectedTools": [],
+        // Hard-excluded tool names. The root default is ["skill"]; an explicit
+        // array replaces the inherited policy. Use [] to compress all tool outputs.
+        "protectedTools": ["skill"],
         // Preserve text wrapped in <protect>...</protect> when compressed
         "protectTags": false,
         // Preserve your messages during compression.
@@ -399,7 +400,7 @@ By default, these tools are always protected from pruning:
 
 The `protectedTools` arrays in `commands` and `strategies` add to this default list.
 
-For the `compress` tool, `compress.protectedTools` ensures specific tool outputs are **hard-excluded** from compression ranges (v1.10.0+). When the model compresses a range that includes a protected tool message, that message survives intact in visible context — only the surrounding non-protected messages are compressed. By default `compress.protectedTools` includes only `skill` — this is sufficient in practice, as skill outputs are the one tool type whose content must never be lost to compression.
+For the `compress` tool, `compress.protectedTools` ensures specific tool outputs are **hard-excluded** from compression ranges (v1.10.0+). When the model compresses a range that includes a protected tool message, that message survives intact in visible context — only the surrounding non-protected messages are compressed. The root default is `["skill"]`; an explicit array replaces the inherited policy. Use `[]` to allow all completed tool outputs to compress.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -278,8 +278,9 @@ ACP 使用自己的配置文件，按以下顺序搜索：
         // Controls how likely compression is after user messages
         // ("strong" = more likely, "soft" = less likely)
         "nudgeForce": "soft",
-        // Tool names whose completed outputs are appended to the compression
-        "protectedTools": [],
+        // Hard-excluded tool names. The root default is ["skill"]; an explicit
+        // array replaces the inherited policy. Use [] to compress all tool outputs.
+        "protectedTools": ["skill"],
         // Preserve text wrapped in <protect>...</protect> when compressed
         "protectTags": false,
         // Preserve your messages during compression.
@@ -367,7 +368,7 @@ ACP 暴露六个可编辑的 prompt：
 
 `commands` 和 `strategies` 中的 `protectedTools` 数组会添加到此默认列表。
 
-对于 `compress` 工具，`compress.protectedTools` 确保特定工具的输出被**硬排除**在压缩范围之外（v1.10.0+）。当模型压缩包含受保护工具消息的范围时，该消息完整保留在可见上下文中 — 只有周围的非受保护消息被压缩。默认仅包含 `skill` —— 实践中这一个就够了，因为 skill 输出是唯一绝不能被压缩丢失的工具类型。
+对于 `compress` 工具，`compress.protectedTools` 确保特定工具的输出被**硬排除**在压缩范围之外（v1.10.0+）。当模型压缩包含受保护工具消息的范围时，该消息完整保留在可见上下文中 — 只有周围的非受保护消息被压缩。根默认值为 `["skill"]`；显式数组会替换继承的策略。使用 `[]` 可允许所有已完成工具的输出被压缩。
 
 ---
 

--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -251,8 +251,8 @@
                     "items": {
                         "type": "string"
                     },
-                    "default": [],
-                    "description": "Tool names or wildcard patterns whose completed outputs should be appended to the compression summary. Supports glob wildcards: * matches any characters, ? matches a single character (e.g., \"mcp_*\", \"my_tool_?\")"
+                    "default": ["skill"],
+                    "description": "Tool names or wildcard patterns to hard-exclude from compression ranges. The root default is [\"skill\"]; an explicit array replaces the inherited policy. Use [] to allow all tool outputs to compress. Supports glob wildcards: * matches any characters, ? matches a single character (e.g., \"mcp_*\", \"my_tool_?\")"
                 },
                 "protectTags": {
                     "type": "boolean",
@@ -325,7 +325,7 @@
                 "nudgeFrequency": 5,
                 "iterationNudgeThreshold": 15,
                 "nudgeForce": "soft",
-                "protectedTools": [],
+                "protectedTools": ["skill"],
                 "protectTags": false,
                 "protectUserMessages": false,
                 "minNudgeContextPercent": 15,

--- a/devlog/2026-07-22_replace-compress-protected-tools/REQ.md
+++ b/devlog/2026-07-22_replace-compress-protected-tools/REQ.md
@@ -1,0 +1,13 @@
+# REQ - Replace Compress Protected Tools
+
+- Task ID: `2026-07-22_replace-compress-protected-tools`
+- Status: Done
+
+## Problem
+
+`compress.protectedTools` is additive, so users cannot override the default `skill` protection.
+
+## Acceptance Criteria
+
+- Omission retains the root default of `["skill"]`.
+- An explicit array, including `[]`, replaces inherited protection.

--- a/devlog/2026-07-22_replace-compress-protected-tools/REQ.md
+++ b/devlog/2026-07-22_replace-compress-protected-tools/REQ.md
@@ -11,3 +11,17 @@
 
 - Omission retains the root default of `["skill"]`.
 - An explicit array, including `[]`, replaces inherited protection.
+
+## Behavioral Change (breaking)
+
+Merge semantics for `compress.protectedTools` change from **additive** to
+**replacement**. A config that previously set `compress.protectedTools: ["task"]`
+produced `["skill", "task"]` (inheriting the root `skill`); after this change it
+produces `["task"]` only, dropping `skill` protection.
+
+This is intentional — `compress.protectedTools` is a standalone complete policy,
+not an extension of a hardcoded base (unlike `commands.protectedTools` /
+`strategies.*.protectedTools`, which remain additive over the 11-tool
+`DEFAULT_PROTECTED_TOOLS`). The release changelog MUST flag this as a breaking
+change so users who customized this field know to add `"skill"` back explicitly
+if they want to keep it.

--- a/devlog/2026-07-22_replace-compress-protected-tools/WORKLOG.md
+++ b/devlog/2026-07-22_replace-compress-protected-tools/WORKLOG.md
@@ -1,0 +1,6 @@
+# WORKLOG - Replace Compress Protected Tools
+
+- Task ID: `2026-07-22_replace-compress-protected-tools`
+- Status: Done
+
+Changed `compress.protectedTools` to replacement semantics, updated docs/schema, and added a regression test.

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -421,7 +421,7 @@ function mergeStrategies(
     }
 }
 
-function mergeCompress(
+export function mergeCompress(
     base: PluginConfig["compress"],
     override?: CompressOverride,
 ): PluginConfig["compress"] {
@@ -444,7 +444,9 @@ function mergeCompress(
         toolOutputNudgeThreshold: override.toolOutputNudgeThreshold,
         iterationNudgeThreshold: override.iterationNudgeThreshold ?? base.iterationNudgeThreshold,
         nudgeForce: override.nudgeForce ?? base.nudgeForce,
-        protectedTools: [...new Set([...base.protectedTools, ...(override.protectedTools ?? [])])],
+        protectedTools: Array.isArray(override.protectedTools)
+            ? [...new Set(override.protectedTools)]
+            : base.protectedTools,
         protectTags: override.protectTags ?? base.protectTags,
         protectUserMessages: override.protectUserMessages ?? base.protectUserMessages,
         maxSummaryLengthHard: override.maxSummaryLengthHard ?? base.maxSummaryLengthHard,

--- a/tests/config-protected-tools.test.ts
+++ b/tests/config-protected-tools.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { mergeCompress, type CompressConfig } from "../lib/config"
+
+const base: CompressConfig = {
+    mode: "range",
+    permission: "allow",
+    showCompression: true,
+    summaryBuffer: true,
+    maxContextLimit: "55%",
+    minContextLimit: "45%",
+    nudgeFrequency: 5,
+    minNudgeContextPercent: 15,
+    iterationNudgeThreshold: 15,
+    nudgeForce: "soft",
+    protectedTools: ["skill"],
+    protectTags: false,
+    protectUserMessages: false,
+    maxSummaryLengthHard: 20000,
+    minCompressRange: 5000,
+    minNudgeGrowthRatio: 0.45,
+    minNudgeGrowthFloor: 5000,
+    emergencyThresholdPercent: "98%",
+    maxVisibleSegments: 50,
+    keepEmbedMaxChars: 2000,
+}
+
+test("explicit compress protected tools replace the inherited policy", () => {
+    assert.deepEqual(mergeCompress(base, {}).protectedTools, ["skill"])
+    assert.deepEqual(mergeCompress(base, { protectedTools: ["task"] }).protectedTools, ["task"])
+    assert.deepEqual(mergeCompress(base, { protectedTools: [] }).protectedTools, [])
+})

--- a/tests/config-protected-tools.test.ts
+++ b/tests/config-protected-tools.test.ts
@@ -30,3 +30,21 @@ test("explicit compress protected tools replace the inherited policy", () => {
     assert.deepEqual(mergeCompress(base, { protectedTools: ["task"] }).protectedTools, ["task"])
     assert.deepEqual(mergeCompress(base, { protectedTools: [] }).protectedTools, [])
 })
+
+// Chaining mergeCompress calls mirrors how mergeLayer chains them inside
+// getConfig() across the global → configDir → project layers.
+test("replacement survives across multiple config merge layers", () => {
+    const afterGlobal = mergeCompress(base, { protectedTools: ["my_tool"] })
+    assert.deepEqual(afterGlobal.protectedTools, ["my_tool"])
+
+    const afterConfigDir = mergeCompress(afterGlobal, {})
+    assert.deepEqual(afterConfigDir.protectedTools, ["my_tool"])
+
+    const afterProject = mergeCompress(afterConfigDir, { protectedTools: [] })
+    assert.deepEqual(afterProject.protectedTools, [])
+
+    const emptyGlobal = mergeCompress(base, { protectedTools: [] })
+    assert.deepEqual(emptyGlobal.protectedTools, [])
+    const taskProject = mergeCompress(emptyGlobal, { protectedTools: ["task"] })
+    assert.deepEqual(taskProject.protectedTools, ["task"])
+})


### PR DESCRIPTION
## Problem

`compress.protectedTools` is merged additively, so `[]` cannot disable the
default `skill` protection. A completed skill invocation therefore remains
uncompressible even when it is no longer relevant.

## Change

- Retain `["skill"]` as the root default.
- Treat an explicit `compress.protectedTools` array as the complete policy.
  `[]` protects no tool outputs.
- Update the schema and READMEs.
- Add regression coverage for omitted, explicit, and empty policies.

## Verification

- `node --import tsx --test tests/config-protected-tools.test.ts`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- `jq empty dcp.schema.json`