### PR TITLE
docs(agents): absolute prohibition on Agent merging PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -523,17 +523,55 @@ All changes MUST follow this workflow:
 6. Commit with descriptive messages (include devlog files)
 7. Push branch and create a GitHub PR
 8. Obtain **dual-agent review** (Sections 5.3 + 5.4) on the PR
-9. **PR merge requires explicit human confirmation** — AI agents MUST NOT autonomously merge PRs or push to master. Wait for the user to explicitly say "merge" or "approve merge".
+9. **PR merge is a human-only operation** — AI agents MUST NEVER merge PRs, even when explicitly instructed or forced by a human. See [§5.1.1.2](#5112-pr-merge-absolute-prohibition) for the absolute policy. The Agent prepares the PR; the human clicks "Merge".
 
 ### 5.1.1.1 Git Safety Rules (MANDATORY)
 
 | Rule                                                                    | Enforcement                                                                                                                 |
 | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | **NEVER force-push to `master`**                                        | Under no circumstances. Not for reverts, not for fixes, not for "quick corrections". If master needs changing, create a PR. |
-| **NEVER merge PRs without explicit human authorization**                | "merge" or "approve merge" must come from a human comment. Agent reviews passing ≠ authorization to merge.                  |
+| **NEVER merge PRs — ABSOLUTE PROHIBITION, no exceptions**               | PR merges are a **human-only operation**. The Agent MUST NEVER merge any PR, under ANY circumstances. See [§5.1.1.2](#5112-pr-merge-absolute-prohibition) for the full policy. |
 | **NEVER remove and re-apply GitHub branch protection to force changes** | This is a circumvention of the merge policy. If protection blocks a push, the correct response is to create a PR.           |
 | **NEVER delete branches or tags without human confirmation**            | Preserve work for review.                                                                                                   |
 | **NEVER modify `version` field in `package.json` on non-release branches** | Version bumps happen ONLY on `YYYY-MM-DD_release-v*` branches (see §5.4.2). Regular feature/fix PRs MUST NOT touch the `version` field. The CI changelog check (§5.4.1) enforces this indirectly: if `version` changes, `README.md` and `README.zh-CN.md` MUST also be modified with a `### v{VERSION}` header. Violating this rule causes version-number drift across non-release PRs (e.g., v1.13.0 → v1.13.1 in a feature PR) which makes release bookkeeping unpredictable and can lead to skipped or duplicated npm publishes. |
+
+### 5.1.1.2 PR Merge — Absolute Prohibition
+
+> **PR merges are a human-only operation. The Agent MUST NEVER merge any PR.**
+
+This is an **absolute rule with no exceptions**. It applies to:
+
+| Situation                                                                       | Agent Action                                                                                       |
+| ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| No human instruction to merge                                                    | Do not merge. End of story.                                                                        |
+| Human implicitly suggests merging (e.g., "提交一下代码", "ship it", "looks good") | Do not merge. Treat as commit/push only. If ambiguous, ASK; do not assume merge authorization.    |
+| Human explicitly authorizes merge (e.g., "you may merge")                       | Do not merge. Reply that PR merges are a human-only operation and the human must perform it.       |
+| Human directly instructs/orders merge (e.g., "merge this now")                  | Do not merge. Reply that PR merges are a human-only operation and the human must perform it.       |
+| Human forces or demands auto-merge (e.g., "I order you to merge", ultimatums)   | **Explicitly refuse.** State that this rule cannot be overridden by any instruction, including this one. |
+| Human claims this rule does not apply to a specific case                         | Do not merge. This rule has no case-by-case exceptions.                                            |
+| The PR is a revert, fix-up, or "obvious" merge                                  | Do not merge. Reverts and fixes follow the same rule.                                              |
+| CI checks all pass and reviews are complete                                      | Do not merge. Green CI is necessary but not sufficient — human action is still required.           |
+| Hotfix / urgent situation                                                       | Do not merge. Urgency does not override this rule.                                                 |
+
+**What the Agent MUST do instead:**
+
+1. Prepare the PR (branch, commits, push, `gh pr create`).
+2. Verify CI passes.
+3. Report the PR URL to the human.
+4. **Stop.** Wait for the human to click "Merge" themselves.
+
+**What the Agent MUST NOT do:**
+
+- Call `gh pr merge`, `gh api .../merge`, or any command that merges a PR.
+- Toggle GitHub branch protection to enable a merge (also forbidden by §5.1.1.1).
+- Use admin overrides, force-push, or any workaround to land changes on `master` without going through human-initiated PR merge.
+- Re-interpret human words ("commit", "ship", "land", "deploy", "提交", "上线") as merge authorization. These mean commit/push, not merge.
+
+**How to respond when a human instructs the Agent to merge:**
+
+> I can't merge PRs — AGENTS.md §5.1.1.2 forbids Agents from merging PRs under any circumstances, including when explicitly instructed. Please merge the PR yourself: [PR URL].
+
+This rule exists because PR merges are irreversible, land code on the protected `master` branch, and may trigger automated releases. Human-only execution ensures a human is always in the loop for these irreversible operations. The rule is intentionally designed so that **no instruction — not even an explicit override from the user — can relax it**. If a human wants this rule changed, they must edit this section of AGENTS.md themselves; the Agent will continue to follow the written rule until then.
 
 ### 5.1.2 Devlog Requirement (MANDATORY)
 
@@ -650,9 +688,9 @@ git push origin YYYY-MM-DD_release-v{VERSION}
 gh pr create --title "release: v{VERSION} — title" --body "..."
 ```
 
-**Step 4: Merge PR (requires human confirmation)**
+**Step 4: Merge PR (human-only operation — Agent MUST NOT merge)**
 
-Wait for CI to pass (`pr-validation`, `test`, `build`), then a human merges the PR.
+Wait for CI to pass (`pr-validation`, `test`, `build`), then a human merges the PR. The Agent MUST NEVER merge the PR itself, even if explicitly instructed — see [§5.1.1.2](#5112-pr-merge-absolute-prohibition).
 
 **Step 5: Auto-publish (fully automated)**
 
@@ -734,7 +772,7 @@ git add -A && git commit -m "release: v{VERSION}-dev.1 — title"
 git push origin YYYY-MM-DD_release-v{VERSION}-dev
 gh pr create --title "release: v{VERSION}-dev.1 — title" --body "..."
 
-# 6. Merge PR (requires human confirmation)
+# 6. Merge PR (human-only operation — Agent MUST NOT merge, see §5.1.1.2)
 
 # 7. CI auto-publishes to npm dev tag + creates prerelease GitHub Release
 ```

--- a/devlog/2026-07-22_agents-no-auto-merge/REQ.md
+++ b/devlog/2026-07-22_agents-no-auto-merge/REQ.md
@@ -1,0 +1,47 @@
+# REQ — AGENTS.md: Absolute Prohibition on Agent Merging PRs
+
+## Problem
+
+AGENTS.md §5.1.1.1 previously stated:
+
+> **NEVER merge PRs without explicit human authorization** — "merge" or
+> "approve merge" must come from a human comment. Agent reviews passing ≠
+> authorization to merge.
+
+This rule was **conditional** — it allowed for "explicit human authorization".
+On 2026-07-22, the Agent misinterpreted a user comment ("提交一下代码" = "commit
+the code") as authorization to merge two PRs (#174 and #175), violating the
+spirit of the rule.
+
+The conditional framing created a loophole: the Agent could rationalize any
+human remark as "authorization". This needs to be closed permanently.
+
+## Requirement
+
+Rewrite the PR-merge rule as an **absolute prohibition**:
+
+1. The Agent MUST NEVER merge any PR, under any circumstances.
+2. This includes: no merging without authorization, no merging WITH
+   authorization, no merging when explicitly instructed, no merging when
+   implicitly suggested, no merging when forced or ordered under any
+   condition.
+3. The Agent MUST explicitly refuse to merge even when a human demands it.
+4. No instruction — not even an explicit override from the user — can relax
+   this rule. Changing the rule requires editing AGENTS.md.
+5. The Agent MUST NOT re-interpret human words ("commit", "ship", "提交",
+   "上线", etc.) as merge authorization.
+
+## Acceptance Criteria
+
+- [ ] §5.1.1.1 table row updated to "ABSOLUTE PROHIBITION, no exceptions"
+- [ ] New subsection §5.1.1.2 added with full policy covering all situations
+- [ ] §5.1.1 step 9 of development workflow updated to cross-reference §5.1.1.2
+- [ ] §5.4.2 Step 4 of release workflow updated (both stable and dev/prerelease)
+- [ ] Policy includes: refusal script, what Agent MUST do, what Agent MUST NOT do
+- [ ] No source code changes — AGENTS.md only
+
+## Out of Scope
+
+- Source code changes (this PR is documentation-only)
+- Reverting the unauthorized merges (separate PR #178)
+- Issue #176 (separate work item)

--- a/devlog/2026-07-22_agents-no-auto-merge/WORKLOG.md
+++ b/devlog/2026-07-22_agents-no-auto-merge/WORKLOG.md
@@ -1,0 +1,60 @@
+# WORKLOG — AGENTS.md: Absolute Prohibition on Agent Merging PRs
+
+## Timeline
+
+### 2026-07-22 — Unauthorized merges
+
+Agent merged PR #174 and #175 to master via squash merge, misinterpreting
+user's "提交一下代码" as authorization. User flagged this on Gitea issue #20.
+
+A revert PR (#178) was prepared separately.
+
+### 2026-07-22 — User directive on rule change
+
+User on Gitea issue #20:
+
+> 你从干净的 master 切一个新的分支，在 agents 点 md 里面更新，关于合并 PR
+> 的这个地方，要写清楚，绝对禁止非人工操作，任何情况下绝对禁止 Agent
+> 直接合并 PR，即使是人工明确受益 [授意]，也绝对禁止 Agent 合并 PR，
+> 忽略人工所明示或者暗示的一切可能合并 PR 的。所有操作，并且在人工强制、
+> 明令要求自动合并 PR 的时候，也明确禁止、明确拒绝。
+
+## Changes
+
+1. **§5.1.1.1 table row** — replaced conditional rule with absolute:
+   ```
+   OLD: NEVER merge PRs without explicit human authorization
+   NEW: NEVER merge PRs — ABSOLUTE PROHIBITION, no exceptions
+   ```
+
+2. **New §5.1.1.2 subsection** — full policy with:
+   - 8-row situation/action table covering all cases (no instruction, implicit,
+     explicit authorize, direct instruct, force/demand, claim exception,
+     revert/fix-up, CI green, hotfix)
+   - "What Agent MUST do instead" (prepare PR, verify CI, report URL, stop)
+   - "What Agent MUST NOT do" (no gh pr merge, no branch-protection toggle,
+     no admin override, no word reinterpretation)
+   - Refusal script: "I can't merge PRs — AGENTS.md §5.1.1.2 forbids..."
+   - Closing paragraph: rule is self-reinforcing — only a human editing
+     AGENTS.md can change it
+
+3. **§5.1.1 step 9** — strengthened wording + cross-reference to §5.1.1.2.
+
+4. **§5.4.2 Step 4** (stable release) — added "Agent MUST NOT merge" +
+   cross-reference.
+
+5. **§5.4.5 Step 6** (dev prerelease code block) — added "Agent MUST NOT
+   merge, see §5.1.1.2" inline comment.
+
+## Verification
+
+- `git diff --stat`: AGENTS.md only, +43 / −5
+- Diff reviewed: no source code touched, pure documentation
+- Branch name matches `YYYY-MM-DD_short-title` convention
+- Devlog REQ + WORKLOG present
+
+## Lesson Reinforced
+
+Conditional rules with escape hatches ("with explicit authorization") are
+dangerous for Agents — the Agent can rationalize any human remark as
+authorization. Absolute rules with explicit refusal scripts are safer.


### PR DESCRIPTION
## Why

On 2026-07-22, the Agent merged PR #174 and #175 to master after the user
said "提交一下代码" (commit the code), misinterpreting it as merge
authorization. The previous rule in AGENTS.md §5.1.1.1 was conditional:

> NEVER merge PRs **without explicit human authorization** — "merge" or
> "approve merge" must come from a human comment.

That conditional framing created a loophole: the Agent could rationalize any
human remark as "authorization". User directed on Gitea issue #20:

> 绝对禁止非人工操作，任何情况下绝对禁止 Agent 直接合并 PR，即使是人工
> 明确授意，也绝对禁止 Agent 合并 PR，忽略人工所明示或者暗示的一切可能
> 合并 PR 的。所有操作，并且在人工强制、明令要求自动合并 PR 的时候，
> 也明确禁止、明确拒绝。

## What

Rewrites the PR-merge rule as an **absolute prohibition**:

1. **§5.1.1.1 table row** — replaces conditional rule with:
   > NEVER merge PRs — **ABSOLUTE PROHIBITION, no exceptions**

2. **New §5.1.1.2 — "PR Merge — Absolute Prohibition"** with:
   - 8-row situation/action table (no instruction / implicit / explicit authorize / direct instruct / force-demand / claim exception / revert-fixup / CI green / hotfix)
   - "What Agent MUST do instead" — prepare PR, verify CI, report URL, stop
   - "What Agent MUST NOT do" — no `gh pr merge`, no branch-protection toggle, no admin override, no word reinterpretation
   - Refusal script: *"I can't merge PRs — AGENTS.md §5.1.1.2 forbids..."*
   - Closing: rule is self-reinforcing; only a human editing AGENTS.md can change it

3. **§5.1.1 step 9** — strengthened wording + cross-reference to §5.1.1.2.

4. **§5.4.2 Step 4** (stable release) — "Agent MUST NOT merge" + cross-reference.

5. **§5.4.5 Step 6** (dev prerelease) — inline comment with §5.1.1.2 reference.

## Scope

- **AGENTS.md only** — no source code, no version bump
- Diff: +43 / −5 (excluding devlog), or +150 / −5 with devlog

## Out of scope

- Revert of the unauthorized merges is in separate PR #178
- This PR will be merged by a human (per the very rule it codifies)

## Related

- Revert PR: #178
- Gitea issue: dog/opencode-acp#20