### PR TITLE
fix: protect compress tool calls from being compressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,9 +309,9 @@ Each level overrides the previous, so project settings take priority over global
         // Controls how likely compression is after user messages
         // ("strong" = more likely, "soft" = less likely)
         "nudgeForce": "soft",
-        // Hard-excluded tool names. The root default is ["skill"]; an explicit
+        // Hard-excluded tool names. The root default is ["skill", "compress"]; an explicit
         // array replaces the inherited policy. Use [] to compress all tool outputs.
-        "protectedTools": ["skill"],
+        "protectedTools": ["skill", "compress"],
         // Preserve text wrapped in <protect>...</protect> when compressed
         "protectTags": false,
         // Preserve your messages during compression.
@@ -400,7 +400,7 @@ By default, these tools are always protected from pruning:
 
 The `protectedTools` arrays in `commands` and `strategies` add to this default list.
 
-For the `compress` tool, `compress.protectedTools` ensures specific tool outputs are **hard-excluded** from compression ranges (v1.10.0+). When the model compresses a range that includes a protected tool message, that message survives intact in visible context — only the surrounding non-protected messages are compressed. The root default is `["skill"]`; an explicit array replaces the inherited policy. Use `[]` to allow all completed tool outputs to compress.
+For the `compress` tool, `compress.protectedTools` ensures specific tool outputs are **hard-excluded** from compression ranges (v1.10.0+). When the model compresses a range that includes a protected tool message, that message survives intact in visible context — only the surrounding non-protected messages are compressed. The root default is `["skill", "compress"]` (the `compress` entry protects compress tool calls — which carry summaries — from being eaten by subsequent sequential compressions); an explicit array replaces the inherited policy. Use `[]` to allow all completed tool outputs to compress.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -278,9 +278,9 @@ ACP 使用自己的配置文件，按以下顺序搜索：
         // Controls how likely compression is after user messages
         // ("strong" = more likely, "soft" = less likely)
         "nudgeForce": "soft",
-        // Hard-excluded tool names. The root default is ["skill"]; an explicit
+        // Hard-excluded tool names. The root default is ["skill", "compress"]; an explicit
         // array replaces the inherited policy. Use [] to compress all tool outputs.
-        "protectedTools": ["skill"],
+        "protectedTools": ["skill", "compress"],
         // Preserve text wrapped in <protect>...</protect> when compressed
         "protectTags": false,
         // Preserve your messages during compression.
@@ -368,7 +368,7 @@ ACP 暴露六个可编辑的 prompt：
 
 `commands` 和 `strategies` 中的 `protectedTools` 数组会添加到此默认列表。
 
-对于 `compress` 工具，`compress.protectedTools` 确保特定工具的输出被**硬排除**在压缩范围之外（v1.10.0+）。当模型压缩包含受保护工具消息的范围时，该消息完整保留在可见上下文中 — 只有周围的非受保护消息被压缩。根默认值为 `["skill"]`；显式数组会替换继承的策略。使用 `[]` 可允许所有已完成工具的输出被压缩。
+对于 `compress` 工具，`compress.protectedTools` 确保特定工具的输出被**硬排除**在压缩范围之外（v1.10.0+）。当模型压缩包含受保护工具消息的范围时，该消息完整保留在可见上下文中 — 只有周围的非受保护消息被压缩。根默认值为 `["skill", "compress"]`（`compress` 条目保护携带 summary 的 compress 工具调用，防止被后续顺序压缩吞噬）；显式数组会替换继承的策略。使用 `[]` 可允许所有已完成工具的输出被压缩。
 
 ---
 

--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -251,8 +251,8 @@
                     "items": {
                         "type": "string"
                     },
-                    "default": ["skill"],
-                    "description": "Tool names or wildcard patterns to hard-exclude from compression ranges. The root default is [\"skill\"]; an explicit array replaces the inherited policy. Use [] to allow all tool outputs to compress. Supports glob wildcards: * matches any characters, ? matches a single character (e.g., \"mcp_*\", \"my_tool_?\")"
+                    "default": ["skill", "compress"],
+                    "description": "Tool names or wildcard patterns to hard-exclude from compression ranges. The root default is [\"skill\", \"compress\"]; an explicit array replaces the inherited policy. Use [] to allow all tool outputs to compress. Supports glob wildcards: * matches any characters, ? matches a single character (e.g., \"mcp_*\", \"my_tool_?\")"
                 },
                 "protectTags": {
                     "type": "boolean",
@@ -325,7 +325,7 @@
                 "nudgeFrequency": 5,
                 "iterationNudgeThreshold": 15,
                 "nudgeForce": "soft",
-                "protectedTools": ["skill"],
+                "protectedTools": ["skill", "compress"],
                 "protectTags": false,
                 "protectUserMessages": false,
                 "minNudgeContextPercent": 15,

--- a/devlog/2026-07-25_protect-compress-calls/REQ.md
+++ b/devlog/2026-07-25_protect-compress-calls/REQ.md
@@ -1,0 +1,62 @@
+# REQ: Protect compress tool calls from being compressed
+
+## Problem
+
+When the model issues sequential compressions, each compress tool call (which
+carries the summary) lives a few messages after the range it compressed. The
+next sequential compress's range typically starts right after the previous one's
+end, so the previous compress call falls INSIDE the new range and gets pruned.
+
+This creates a "summary-eating chain": each new compression destroys the
+previous compression's summary. Over multiple sequential compressions, all
+accumulated summaries vanish, causing catastrophic context loss.
+
+Evidence from `ses_07562b88`: 113 messages compressed to 6 in one call because
+all previous compress call anchors (b5–b10) were inside the new range and got
+pruned along with their summaries.
+
+## Root Cause
+
+Design gap (not a bug in existing logic). `COMPRESS_DEFAULT_PROTECTED_TOOLS`
+was `["skill"]` — the `compress` tool was NOT in the list. The hard-exclusion
+mechanism (Bug 39, `filterProtectedToolMessages` in `protected-content.ts`)
+checks `part.tool` against the `protectedTools` list, so compress tool calls
+were never excluded from compression ranges.
+
+Inconsistency: `DEFAULT_PROTECTED_TOOLS` (commands level, for dedup/purgeErrors)
+DID include `"compress"`, but `COMPRESS_DEFAULT_PROTECTED_TOOLS` (compress
+level, for range/message compression) did NOT.
+
+## Fix
+
+Add `"compress"` to `COMPRESS_DEFAULT_PROTECTED_TOOLS` in `lib/config.ts`.
+
+```typescript
+// Before
+const COMPRESS_DEFAULT_PROTECTED_TOOLS = ["skill"]
+
+// After
+const COMPRESS_DEFAULT_PROTECTED_TOOLS = ["skill", "compress"]
+```
+
+This makes `filterProtectedToolMessages` hard-exclude compress tool call
+messages from compression ranges (Bug 39 mechanism). The compress call
+survives intact in visible context; only the surrounding non-protected
+messages are compressed.
+
+## Scope
+
+Emergency fix — one-line config default change. Long-term solution (e.g.,
+capping visible compress call count, or GC-level message summary truncation)
+deferred to a follow-up.
+
+## Files
+
+- `lib/config.ts` — one-line default change
+- `tests/protect-compress-calls.test.ts` — 6 tests covering the hard-exclusion
+
+## Backward Compatibility
+
+Users who set an explicit `compress.protectedTools` array are unaffected (the
+default only applies when no override is set). Users who relied on compress
+calls being compressible can opt out with `compress.protectedTools: ["skill"]`.

--- a/devlog/2026-07-25_protect-compress-calls/WORKLOG.md
+++ b/devlog/2026-07-25_protect-compress-calls/WORKLOG.md
@@ -1,0 +1,42 @@
+# WORKLOG: Protect compress tool calls from being compressed
+
+## Investigation (Gitea #20)
+
+Investigated `ses_07562b88` compression deviation. Found the root cause:
+sequential compressions eat previous summaries because compress tool calls
+fall inside the next compress range and get pruned.
+
+Verified in code: `COMPRESS_DEFAULT_PROTECTED_TOOLS = ["skill"]` — `compress`
+not in the list. No compress-call-specific protection logic exists anywhere
+in `lib/compress/` or `lib/messages/`. The inconsistency between
+`DEFAULT_PROTECTED_TOOLS` (has `compress`) and `COMPRESS_DEFAULT_PROTECTED_TOOLS`
+(lacks `compress`) is the gap.
+
+GC truncation was already gated behind `majorGcThresholdPercent: "100%"`
+(PR #161) and does not fire in normal operation — so relying on GC to trim
+accumulated compress calls is not viable.
+
+## Implementation
+
+### 1. Config fix (`lib/config.ts:132`)
+
+```diff
+- const COMPRESS_DEFAULT_PROTECTED_TOOLS = ["skill"]
++ const COMPRESS_DEFAULT_PROTECTED_TOOLS = ["skill", "compress"]
+```
+
+### 2. Tests (`tests/protect-compress-calls.test.ts`)
+
+6 tests covering:
+- `messageContainsProtectedTool` detects compress tool calls as protected
+- `messageContainsProtectedTool` does NOT protect when `compress` is absent (opt-out)
+- `messageContainsProtectedTool` does NOT protect plain text messages
+- `filterProtectedToolMessages` removes compress-call messages, keeps surrounding
+- `filterProtectedToolMessages` is a no-op when `compress` is not protected (old behavior)
+- `filterProtectedToolMessages` handles all-compress-call selections (empty result)
+
+## Verification
+
+- `npm run typecheck` — pass
+- `npm run test` — all tests pass including 6 new tests
+- `npm run build` — pass

--- a/devlog/2026-07-25_protect-compress-calls/WORKLOG.md
+++ b/devlog/2026-07-25_protect-compress-calls/WORKLOG.md
@@ -35,6 +35,15 @@ accumulated compress calls is not viable.
 - `filterProtectedToolMessages` is a no-op when `compress` is not protected (old behavior)
 - `filterProtectedToolMessages` handles all-compress-call selections (empty result)
 
+### 3. Documentation sync (schema + READMEs)
+
+Updated stale `["skill"]` defaults to `["skill", "compress"]` in:
+- `dcp.schema.json` — property default (line 254), description text, and default object (line 328)
+- `README.md` — Default Configuration section (line 312-314) and Protected Tools explanation (line 403)
+- `README.zh-CN.md` — same two sections
+
+Historical changelog entries were NOT modified (they record what was true at that time).
+
 ## Verification
 
 - `npm run typecheck` — pass

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -129,7 +129,7 @@ const DEFAULT_PROTECTED_TOOLS = [
     "edit",
 ]
 
-const COMPRESS_DEFAULT_PROTECTED_TOOLS = ["skill"]
+const COMPRESS_DEFAULT_PROTECTED_TOOLS = ["skill", "compress"]
 
 export { VALID_CONFIG_KEYS, getInvalidConfigKeys, validateConfigTypes, type ValidationError } from "./config-validation"
 

--- a/tests/protect-compress-calls.test.ts
+++ b/tests/protect-compress-calls.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for protecting compress tool calls (which carry summaries) from being
+ * included in subsequent compression ranges.
+ *
+ * Background: compress tool calls live inside assistant messages a few positions
+ * after the range they compressed. When the model issues a new sequential
+ * compress whose range starts right after the previous one's end, the previous
+ * compress call falls inside the new range and gets pruned — destroying the
+ * accumulated summary chain. Adding "compress" to the default protectedTools
+ * (COMPRESS_DEFAULT_PROTECTED_TOOLS) makes filterProtectedToolMessages
+ * hard-exclude those messages (Bug 39 mechanism), so summaries survive.
+ */
+import assert from "node:assert/strict"
+import test from "node:test"
+import { messageContainsProtectedTool, filterProtectedToolMessages } from "../lib/compress/protected-content"
+import type { SelectionResolution, SearchContext } from "../lib/compress/types"
+import type { WithParts } from "../lib/state"
+
+const DEFAULT_PROTECTED = ["skill", "compress"]
+
+function makeCompressCallPart(callID: string, summary: string) {
+    return {
+        type: "tool" as const,
+        callID,
+        tool: "compress",
+        state: {
+            status: "completed" as const,
+            input: { content: [{ startId: "m00001", endId: "m00010", summary }] },
+            output: "compressed",
+        },
+    }
+}
+
+function makeTextPart(id: string, text: string) {
+    return { type: "text" as const, id, text }
+}
+
+function makeMessage(id: string, role: "user" | "assistant", parts: any[]): WithParts {
+    return {
+        info: { id, role, sessionID: "ses-test", time: { created: 1 } } as any,
+        parts,
+    }
+}
+
+function makeSearchContext(messages: WithParts[]): SearchContext {
+    const rawMessagesById = new Map<string, WithParts>()
+    const rawIndexById = new Map<string, number>()
+    messages.forEach((m, i) => {
+        rawMessagesById.set(m.info.id, m)
+        rawIndexById.set(m.info.id, i)
+    })
+    return {
+        rawMessages: messages,
+        rawMessagesById,
+        rawIndexById,
+        summaryByBlockId: new Map(),
+    }
+}
+
+function makeSelection(messageIds: string[]): SelectionResolution {
+    return {
+        startReference: { kind: "message", rawIndex: 0, messageId: messageIds[0] },
+        endReference: { kind: "message", rawIndex: messageIds.length - 1, messageId: messageIds[messageIds.length - 1] },
+        messageIds,
+        messageTokenById: new Map(messageIds.map((id) => [id, 100])),
+        toolIds: [],
+        requiredBlockIds: [],
+    }
+}
+
+test("messageContainsProtectedTool: compress tool call is protected when 'compress' is in the list", () => {
+    const msg = makeMessage("msg-compress-call", "assistant", [
+        makeTextPart("p1", "Let me compress the earlier findings."),
+        makeCompressCallPart("call-1", "Summary of earlier work..."),
+    ])
+    assert.equal(messageContainsProtectedTool(msg, DEFAULT_PROTECTED, []), true)
+})
+
+test("messageContainsProtectedTool: compress tool call is NOT protected when 'compress' is absent (opt-out)", () => {
+    const msg = makeMessage("msg-compress-call", "assistant", [
+        makeCompressCallPart("call-1", "Summary of earlier work..."),
+    ])
+    assert.equal(messageContainsProtectedTool(msg, ["skill"], []), false)
+    assert.equal(messageContainsProtectedTool(msg, [], []), false)
+})
+
+test("messageContainsProtectedTool: plain text message is never protected", () => {
+    const msg = makeMessage("msg-text", "user", [makeTextPart("p1", "Hello world")])
+    assert.equal(messageContainsProtectedTool(msg, DEFAULT_PROTECTED, []), false)
+})
+
+test("filterProtectedToolMessages: removes compress-call message from selection, keeps surrounding messages", () => {
+    const compressMsg = makeMessage("msg-compress", "assistant", [
+        makeTextPart("p1", "Compressing now."),
+        makeCompressCallPart("call-compress", "Previous summary content..."),
+    ])
+    const plainMsg1 = makeMessage("msg-plain-1", "user", [makeTextPart("p2", "User question")])
+    const plainMsg2 = makeMessage("msg-plain-2", "assistant", [makeTextPart("p3", "Assistant answer")])
+
+    const ctx = makeSearchContext([plainMsg1, compressMsg, plainMsg2])
+    const selection = makeSelection(["msg-plain-1", "msg-compress", "msg-plain-2"])
+
+    const result = filterProtectedToolMessages(selection, ctx, DEFAULT_PROTECTED, [])
+
+    assert.deepEqual(result.messageIds, ["msg-plain-1", "msg-plain-2"])
+    assert.equal(result.messageTokenById.size, 2)
+    assert.ok(result.messageTokenById.has("msg-plain-1"))
+    assert.ok(result.messageTokenById.has("msg-plain-2"))
+    assert.ok(!result.messageTokenById.has("msg-compress"))
+})
+
+test("filterProtectedToolMessages: no-op when 'compress' is not in protectedTools (old behavior)", () => {
+    const compressMsg = makeMessage("msg-compress", "assistant", [
+        makeCompressCallPart("call-1", "Summary..."),
+    ])
+    const ctx = makeSearchContext([compressMsg])
+    const selection = makeSelection(["msg-compress"])
+
+    const result = filterProtectedToolMessages(selection, ctx, ["skill"], [])
+    assert.deepEqual(result.messageIds, ["msg-compress"])
+})
+
+test("filterProtectedToolMessages: all-compress-call selection becomes empty (all excluded)", () => {
+    const msg1 = makeMessage("msg-c1", "assistant", [makeCompressCallPart("c1", "Summary A")])
+    const msg2 = makeMessage("msg-c2", "assistant", [makeCompressCallPart("c2", "Summary B")])
+
+    const ctx = makeSearchContext([msg1, msg2])
+    const selection = makeSelection(["msg-c1", "msg-c2"])
+
+    const result = filterProtectedToolMessages(selection, ctx, DEFAULT_PROTECTED, [])
+    assert.equal(result.messageIds.length, 0)
+    assert.equal(result.messageTokenById.size, 0)
+})


### PR DESCRIPTION
Emergency fix for the summary-eating chain problem (Gitea #20). Sequential compressions destroy previous summaries because compress tool calls fall inside the next compress range and get pruned. One-line fix: add "compress" to COMPRESS_DEFAULT_PROTECTED_TOOLS so filterProtectedToolMessages hard-excludes them (Bug 39 mechanism). 6 new tests, all 843 pass. Users can opt out with compress.protectedTools: ["skill"].