### PR TITLE
release: v1.13.4 — protect compress tool calls from being compressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.13.4 — Protect Compress Tool Calls from Being Compressed (PR #185)
+
+**Problem**: Sequential compressions ate previous summaries. Each compress tool call (which carries the summary in its `summary` parameter) lives a few messages after the range it compressed. When the model issued a new compress whose range started right after the previous one's end, the previous compress call fell inside the new range and was pruned — destroying the accumulated summary chain. Evidence from `ses_07562b88`: 113 messages → 6 messages in one compress call because all previous compress call anchors (b5–b10) were inside the new range.
+
+**Fix**: Added `"compress"` to `COMPRESS_DEFAULT_PROTECTED_TOOLS` in `lib/config.ts`. This makes `filterProtectedToolMessages` hard-exclude compress tool call messages from compression ranges (Bug 39 mechanism). The compress call survives intact in visible context; only surrounding non-protected messages are compressed. Also synced stale `["skill"]` defaults in `dcp.schema.json`, `README.md`, and `README.zh-CN.md` to `["skill", "compress"]`. Users can opt out with `compress.protectedTools: ["skill"]`.
+
+Files: `lib/config.ts`, `dcp.schema.json`, `README.md`, `README.zh-CN.md`. Tests: `tests/protect-compress-calls.test.ts` (6 new tests). 843 pass.
+
 ### v1.13.3 — Quality Gate Enforcement + E2E Test Framework + protectedTools Fix (PRs #173, #174, #175, #177, #179)
 
 **Problem**: (1) Compressions with extremely low retention (<1%) or near-zero keyword recall passed silently, causing severe context loss. (2) No end-to-end test infrastructure existed to verify ACP compression through the real opencode→LLM pipeline. (3) `compress.protectedTools` merged with inherited defaults instead of replacing them — an explicit `[]` still protected the inherited set.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -440,6 +440,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.13.4 — 保护 compress 工具调用不被压缩（PR #185）
+
+**问题**：顺序压缩会吞噬之前的 summary。每个 compress 工具调用（在其 `summary` 参数中携带摘要）位于其压缩范围之后几条消息处。当模型发出新的 compress，其范围紧接前一个范围的结尾开始时，前一个 compress 调用落入新范围内并被裁剪——摧毁累积的摘要链。`ses_07562b88` 的证据：113 条消息在一次 compress 调用中变为 6 条，因为所有之前的 compress 调用锚点（b5–b10）都在新范围内。
+
+**修复**：在 `lib/config.ts` 的 `COMPRESS_DEFAULT_PROTECTED_TOOLS` 中添加 `"compress"`。这使得 `filterProtectedToolMessages` 硬排除 compress 工具调用消息不进入压缩范围（Bug 39 机制）。compress 调用完整保留在可见上下文中；只有周围的非受保护消息被压缩。同时将 `dcp.schema.json`、`README.md` 和 `README.zh-CN.md` 中过时的 `["skill"]` 默认值同步为 `["skill", "compress"]`。用户可通过 `compress.protectedTools: ["skill"]` 退出。
+
+文件：`lib/config.ts`、`dcp.schema.json`、`README.md`、`README.zh-CN.md`。测试：`tests/protect-compress-calls.test.ts`（6 个新测试）。843 pass。
+
 ### v1.13.3 — 质量门禁 + E2E 测试框架 + protectedTools 修复（PR #173, #174, #175, #177, #179）
 
 **问题**：（1）极低保留率（<1%）或接近零关键词召回的压缩会静默通过，导致严重的上下文丢失。（2）缺少端到端测试基础设施来验证 ACP 通过真实 opencode→LLM 管道的压缩行为。（3）`compress.protectedTools` 与继承的默认值合并而非替换——显式 `[]` 仍会保护继承的集合。

--- a/devlog/2026-07-25_release-v1.13.4/REQ.md
+++ b/devlog/2026-07-25_release-v1.13.4/REQ.md
@@ -1,0 +1,14 @@
+# REQ: Release v1.13.4
+
+Release PR for the compress-call protection fix (PR #185).
+
+## What's in this release
+
+- **PR #185**: `fix: protect compress tool calls from being compressed`
+  - Added `"compress"` to `COMPRESS_DEFAULT_PROTECTED_TOOLS` in `lib/config.ts`
+  - 6 new tests in `tests/protect-compress-calls.test.ts`
+  - Synced stale defaults in `dcp.schema.json`, `README.md`, `README.zh-CN.md`
+
+## Version bump
+
+1.13.3 → 1.13.4 (patch — bug fix)

--- a/devlog/2026-07-25_release-v1.13.4/WORKLOG.md
+++ b/devlog/2026-07-25_release-v1.13.4/WORKLOG.md
@@ -1,0 +1,17 @@
+# WORKLOG: Release v1.13.4
+
+## Steps
+
+1. Created release branch `2026-07-25_release-v1.13.4` from merged master (89e427e)
+2. Bumped version: 1.13.3 → 1.13.4 in `package.json`
+3. Added changelog entries to `README.md` and `README.zh-CN.md`
+4. Created devlog entry
+5. Verified: typecheck + test + build
+
+## CI flow on merge
+
+1. Push to master → `release.yml` detects release branch merge
+2. Creates `v1.13.4` tag
+3. Runs `npm ci` → `npm run check:package` → `npm test`
+4. Publishes to npm with `--tag latest`
+5. Creates GitHub Release

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.13.3",
+    "version": "1.13.4",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Release PR for v1.13.4 — version bump 1.13.3 → 1.13.4 containing PR #185.

### What's in this release

**PR #185**: `fix: protect compress tool calls from being compressed`

**Problem**: Sequential compressions ate previous summaries. Each compress tool call (which carries the summary in its `summary` parameter) lives a few messages after the range it compressed. When the model issued a new compress whose range started right after the previous one's end, the previous compress call fell inside the new range and was pruned — destroying the accumulated summary chain. Evidence from `ses_07562b88`: 113 messages → 6 messages in one compress call because all previous compress call anchors (b5–b10) were inside the new range.

**Fix**: Added `"compress"` to `COMPRESS_DEFAULT_PROTECTED_TOOLS` in `lib/config.ts`. This makes `filterProtectedToolMessages` hard-exclude compress tool call messages from compression ranges (Bug 39 mechanism). The compress call survives intact in visible context; only surrounding non-protected messages are compressed. Also synced stale `["skill"]` defaults in `dcp.schema.json`, `README.md`, and `README.zh-CN.md` to `["skill", "compress"]`. Users can opt out with `compress.protectedTools: ["skill"]`.

Files: `lib/config.ts`, `dcp.schema.json`, `README.md`, `README.zh-CN.md`. Tests: 843 pass.

### Release changes (this PR)

- `package.json`: version bump 1.13.3 → 1.13.4
- `README.md` / `README.zh-CN.md`: changelog entries for v1.13.4
- `devlog/2026-07-25_release-v1.13.4/`: REQ.md + WORKLOG.md

### Verification

- ✅ `npm run typecheck` — clean
- ✅ `npm run test` — 843 pass
- ✅ `npm run build` — dist/index.js 432.52 KB
- ✅ `scripts/ci/check-pr.sh` — all checks pass (branch name, devlog, changelog)

### After merge

CI `release.yml` detects release-branch merge → creates `v1.13.4` tag → publishes to npm (`latest` tag) → creates GitHub Release. Fully automated, no manual steps.