### PR TITLE
release: v1.13.5 — fix release CI for squash merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,14 +24,22 @@ jobs:
               id: check
               run: |
                   MERGE_MSG=$(git log -1 --pretty=%B)
-                  echo "Commit message: $MERGE_MSG"
+                  MERGE_TITLE=$(echo "$MERGE_MSG" | head -1)
+                  echo "Commit title: $MERGE_TITLE"
 
                   FORCE="${{ github.event.inputs.force }}"
                   IS_RELEASE="false"
 
-                  if echo "$MERGE_MSG" | grep -qE 'Merge pull request #[0-9]+ from .*[0-9]{4}-[0-9]{2}-[0-9]{2}_release-v'; then
+                  # Pattern 1: Standard merge commit
+                  #   "Merge pull request #171 from ranxianglei/2026-07-21_release-v1.13.2"
+                  if echo "$MERGE_TITLE" | grep -qE 'Merge pull request #[0-9]+ from .*[0-9]{4}-[0-9]{2}-[0-9]{2}_release-v'; then
                       IS_RELEASE="true"
-                      echo "Release branch detected"
+                      echo "Release branch detected (standard merge)"
+                  # Pattern 2: Squash merge of a release PR
+                  #   "release: v1.13.4 — ... (#186)"
+                  elif echo "$MERGE_TITLE" | grep -qE '^release: v[0-9]+\.[0-9]+\.[0-9]+'; then
+                      IS_RELEASE="true"
+                      echo "Release branch detected (squash merge)"
                   elif [ "$FORCE" = "true" ]; then
                       IS_RELEASE="true"
                       echo "Force publish requested"

--- a/README.md
+++ b/README.md
@@ -472,6 +472,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.13.5 — Fix Release CI for Squash Merges (PR #187)
+
+**Problem**: The release detection regex in `.github/workflows/release.yml` only matched standard merge commits (`Merge pull request #N from .../YYYY-MM-DD_release-v...`), not squash merges. PRs #182 (v1.13.3) and #186 (v1.13.4) were squash-merged, so the release workflow silently skipped — no tag, no npm publish, no GitHub Release. npm was stuck at 1.13.2 while master had already moved to 1.13.4.
+
+**Fix**: Added a second pattern to the detection logic: `^release: v[0-9]+\.[0-9]+\.[0-9]+` matches squash merge commit titles that start with the release PR title convention (`release: vVERSION ...`). Both standard and squash merges are now detected. Also bumps version to 1.13.5 to publish all accumulated changes (v1.13.3 quality gate + v1.13.4 compress protection + this CI fix).
+
+Files: `.github/workflows/release.yml`, `package.json`, `README.md`, `README.zh-CN.md`. 843 tests pass (no source code changes).
+
 ### v1.13.4 — Protect Compress Tool Calls from Being Compressed (PR #185)
 
 **Problem**: Sequential compressions ate previous summaries. Each compress tool call (which carries the summary in its `summary` parameter) lives a few messages after the range it compressed. When the model issued a new compress whose range started right after the previous one's end, the previous compress call fell inside the new range and was pruned — destroying the accumulated summary chain. Evidence from `ses_07562b88`: 113 messages → 6 messages in one compress call because all previous compress call anchors (b5–b10) were inside the new range.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -440,6 +440,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.13.5 — 修复 Release CI 对 Squash Merge 的检测（PR #187）
+
+**问题**：`.github/workflows/release.yml` 的发布检测正则只认标准 merge commit（`Merge pull request #N from .../YYYY-MM-DD_release-v...`），不认 squash merge。PR #182（v1.13.3）和 #186（v1.13.4）都是 squash 合并，导致 release workflow 静默跳过 — 没有 tag、没有 npm 发布、没有 GitHub Release。npm 卡在 1.13.2，而 master 已经到了 1.13.4。
+
+**修复**：在检测逻辑中添加第二个模式：`^release: v[0-9]+\.[0-9]+\.[0-9]+` 匹配以 release PR 标题开头的 squash merge commit（`release: vVERSION ...`）。现在标准 merge 和 squash merge 都能被检测到。同时将版本号升到 1.13.5，以发布所有累积的变更（v1.13.3 质量门禁 + v1.13.4 compress 保护 + 本次 CI 修复）。
+
+文件：`.github/workflows/release.yml`、`package.json`、`README.md`、`README.zh-CN.md`。843 测试通过（无源码变更）。
+
 ### v1.13.4 — 保护 compress 工具调用不被压缩（PR #185）
 
 **问题**：顺序压缩会吞噬之前的 summary。每个 compress 工具调用（在其 `summary` 参数中携带摘要）位于其压缩范围之后几条消息处。当模型发出新的 compress，其范围紧接前一个范围的结尾开始时，前一个 compress 调用落入新范围内并被裁剪——摧毁累积的摘要链。`ses_07562b88` 的证据：113 条消息在一次 compress 调用中变为 6 条，因为所有之前的 compress 调用锚点（b5–b10）都在新范围内。

--- a/devlog/2026-07-25_release-v1.13.5/REQ.md
+++ b/devlog/2026-07-25_release-v1.13.5/REQ.md
@@ -1,0 +1,32 @@
+# REQ: Release v1.13.5
+
+Release PR to fix the release CI regex and publish all accumulated changes (v1.13.3 + v1.13.4 + CI fix).
+
+## Root cause of skipped releases
+
+`.github/workflows/release.yml` detection regex only matched standard merge commits:
+```
+Merge pull request #[0-9]+ from .*[0-9]{4}-[0-9]{2}-[0-9]{2}_release-v
+```
+
+PRs #182 (v1.13.3) and #186 (v1.13.4) were **squash-merged**, producing commit titles like:
+```
+release: v1.13.3 — quality gate enforcement... (#182)
+```
+
+These don't match the regex → `is_release=false` → all publish steps skipped → npm stuck at 1.13.2.
+
+## Fix
+
+Added second detection pattern for squash merge titles:
+```
+^release: v[0-9]+\.[0-9]+\.[0-9]+
+```
+
+Matches any squash-merged commit whose title starts with `release: vVERSION`.
+
+## What this release includes (accumulated since v1.13.2)
+
+- v1.13.3: Quality Gate Enforcement + E2E Test Framework + protectedTools Fix (PRs #173-#179)
+- v1.13.4: Protect Compress Tool Calls from Being Compressed (PR #185)
+- v1.13.5: Fix Release CI for Squash Merges (this PR)

--- a/devlog/2026-07-25_release-v1.13.5/WORKLOG.md
+++ b/devlog/2026-07-25_release-v1.13.5/WORKLOG.md
@@ -1,0 +1,32 @@
+# WORKLOG: Release v1.13.5
+
+## Steps
+
+1. Diagnosed why npm was stuck at 1.13.2:
+   - Checked npm: `latest: 1.13.2`
+   - Checked GitHub releases: Latest = v1.13.2 (no v1.13.3 or v1.13.4)
+   - Checked release.yml workflow runs: v1.13.3 run took only 8s (skipped), v1.13.4 run took 10s (skipped)
+   - Read release.yml: detection regex only matches `Merge pull request #N from ..._release-v`
+   - Verified: PR #182 and #186 were squash-merged → commit titles don't match regex
+
+2. Created release worktree from merged master (9b340002)
+
+3. Fixed `.github/workflows/release.yml`:
+   - Added squash merge detection: `^release: v[0-9]+\.[0-9]+\.[0-9]+`
+   - Both patterns now detected (standard + squash)
+
+4. Bumped version: 1.13.4 → 1.13.5
+
+5. Added changelog entries to README.md and README.zh-CN.md
+
+6. Created devlog
+
+7. Verified: typecheck + test + build + CI check
+
+8. Committed (2 commits: CI fix + release bump), pushed, created PR
+
+## Verification
+
+- npm is at 1.13.2 (will be 1.13.5 after this publishes)
+- 843 tests pass
+- CI pr-checks pass (branch name, devlog, changelog)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.13.4",
+    "version": "1.13.5",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Fixes the release CI regex that caused v1.13.3 and v1.13.4 to never publish to npm. Bumps version to 1.13.5 to publish all accumulated changes.

## Root Cause

`.github/workflows/release.yml` detection regex only matched **standard merge commits**:
```
Merge pull request #[0-9]+ from .*[0-9]{4}-[0-9]{2}-[0-9]{2}_release-v
```

PRs #182 (v1.13.3) and #186 (v1.13.4) were **squash-merged**, producing titles like:
```
release: v1.13.3 — quality gate enforcement... (#182)
release: v1.13.4 — protect compress tool calls... (#186)
```

These don't match → `is_release=false` → all publish steps skipped → npm stuck at **1.13.2** while master was at 1.13.4.

Evidence: v1.13.3 Release run ([29982512294](https://github.com/ranxianglei/opencode-acp/actions/runs/29982512294)) took 8s (skipped); v1.13.2 ([29836706741](https://github.com/ranxianglei/opencode-acp/actions/runs/29836706741)) took 1m1s (published).

## Fix

Added second detection pattern for squash merge titles:
```
^release: v[0-9]+\.[0-9]+\.[0-9]+
```

Both merge types are now detected. Tested against all known merge formats:

| Commit title | Match |
|---|---|
| `Merge pull request #171 from ranxianglei/2026-07-21_release-v1.13.2` | ✅ standard |
| `release: v1.13.3 — ... (#182)` | ✅ squash |
| `release: v1.13.4 — ... (#186)` | ✅ squash |
| `fix: protect compress... (#185)` | ❌ correctly skipped |
| `Merge pull request #175 from .../2026-07-22_proportional-baseline` | ❌ correctly skipped |

## What v1.13.5 publishes (accumulated since npm 1.13.2)

- **v1.13.3**: Quality Gate Enforcement + E2E Test Framework + protectedTools Fix (PRs #173, #174, #175, #177, #179)
- **v1.13.4**: Protect Compress Tool Calls from Being Compressed (PR #185)
- **v1.13.5**: Fix Release CI for Squash Merges (this PR)

## Commits

1. `fix(ci): detect squash merges in release workflow` — `.github/workflows/release.yml`
2. `release: v1.13.5 — fix release CI for squash merges` — version bump + changelog + devlog

## Verification

- ✅ Typecheck clean
- ✅ 843 tests pass
- ✅ Build success (dist/index.js 432.52 KB)
- ✅ CI pr-checks all pass (branch name, devlog, changelog)
- ✅ Regex tested against 5 known merge formats (4 correct matches, 1 correct skip)

## After merge

The **new** regex will detect this PR's squash merge → CI creates `v1.13.5` tag → publishes to npm `latest` → creates GitHub Release. No manual steps needed.