### PR TITLE
release: v1.14.0-dev.1 — per-session state registry + nudge baseline fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,8 @@ index.ts (Plugin Entry — registers hooks + tools)
     │
     ├─► Message Transform Hook (experimental.chat.messages.transform) ← runs EVERY LLM call
     │       │
-    │       ├─► checkSession() → state init, load persisted state
+    │       ├─► registry.getOrCreate() → resolve per-session state (init + load persisted)
+    │       ├─► updatePerTurnState() → compaction detection + turn count
     │       ├─► stripHallucinations() → remove stale mNNNNN refs from model output
     │       ├─► assignMessageRefs() → bidirectional map: raw message IDs ↔ mNNNNN refs
     │       ├─► syncCompressionBlocks() → deactivate orphaned blocks (messages deleted externally)

--- a/README.md
+++ b/README.md
@@ -472,6 +472,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.0-dev.1 — Per-Session State Registry + Nudge Baseline Fix (Issue #33)
+
+**Problem**: (1) Interleaved subagent sessions shared a single `SessionState` singleton — when a subagent ran, the parent session's compression state was wiped by `resetSessionState`. Subagent `modelContextLimit` was never persisted because `system.transform` (which sets it) fires after `messages.transform` (which reads and saves), so subagents ran with undefined `modelContextLimit`, collapsing `nudgeGrowthTokens` from 50K to 6K and triggering over-compression at 4.9% context. (2) Nudge baseline initialized to `currentTokens` (~55K, includes system prompt) instead of 0, making the effective first-nudge threshold ~105K (10.5%) instead of ~50K (5%) — the model never compressed voluntarily at 5% context, allowing context to grow unchecked to 330K.
+
+**Fix**: (1) New `SessionStateRegistry` — a `Map<sessionId, SessionState>` with soft cap 32 and oldest-first eviction. All hook handlers and compress tools resolve state per-call via `registry.getOrCreate(sessionID)`. Eliminates cross-session state contamination. (2) Baseline initialization changed from `lastPerMessageNudgeTokens = currentTokens` to `= 0` (`lib/messages/inject/inject.ts:308`). Growth now measured from session start; first nudge fires at ~nudgeGrowthTokens (5% of model context).
+
+Files: `lib/state/state.ts`, `lib/hooks.ts`, `index.ts`, `lib/compress/types.ts`, `lib/compress/{range,message,decompress,prune-tool,recap,search,status}.ts`, `lib/messages/inject/inject.ts`. Tests: `tests/registry.test.ts` (NEW, 4 tests), `tests/inject.test.ts` (+1 regression test for baseline init). 848 tests pass.
+
 ### v1.13.5 — Fix Release CI for Squash Merges (PR #187)
 
 **Problem**: The release detection regex in `.github/workflows/release.yml` only matched standard merge commits (`Merge pull request #N from .../YYYY-MM-DD_release-v...`), not squash merges. PRs #182 (v1.13.3) and #186 (v1.13.4) were squash-merged, so the release workflow silently skipped — no tag, no npm publish, no GitHub Release. npm was stuck at 1.13.2 while master had already moved to 1.13.4.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -440,6 +440,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.14.0-dev.1 — Per-Session State Registry + Nudge 基线修复（Issue #33）
+
+**问题**：(1) 交错的子代理会话共享单个 `SessionState` 单例 — 子代理运行时，父会话的压缩状态被 `resetSessionState` 清空。子代理的 `modelContextLimit` 从未被持久化（`system.transform` 设置它时在 `messages.transform` 之后），导致子代理以 undefined 的 `modelContextLimit` 运行，`nudgeGrowthTokens` 从 50K 塌缩到 6K，在 4.9% context 时触发过度压缩。(2) Nudge 基线初始化为 `currentTokens`（~55K，含系统提示词）而非 0，导致首次 nudge 的实际阈值为 ~105K（10.5%）而非 ~50K（5%）— 模型在 5% context 时从不主动压缩，context 无限增长到 330K。
+
+**修复**：(1) 新增 `SessionStateRegistry` — `Map<sessionId, SessionState>` + 软上限 32 + 最旧优先淘汰。所有 hook handler 和 compress 工具通过 `registry.getOrCreate(sessionID)` 按 session 解析状态，彻底消除跨会话状态污染。(2) 基线初始化从 `lastPerMessageNudgeTokens = currentTokens` 改为 `= 0`（`lib/messages/inject/inject.ts:308`）。增长从会话开始计算，首次 nudge 在 ~nudgeGrowthTokens（model context 的 5%）时触发。
+
+文件：`lib/state/state.ts`、`lib/hooks.ts`、`index.ts`、`lib/compress/types.ts`、`lib/compress/{range,message,decompress,prune-tool,recap,search,status}.ts`、`lib/messages/inject/inject.ts`。测试：`tests/registry.test.ts`（新增，4 个测试）、`tests/inject.test.ts`（+1 基线初始化回归测试）。848 tests pass。
+
 ### v1.13.5 — 修复 Release CI 对 Squash Merge 的检测（PR #187）
 
 **问题**：`.github/workflows/release.yml` 的发布检测正则只认标准 merge commit（`Merge pull request #N from .../YYYY-MM-DD_release-v...`），不认 squash merge。PR #182（v1.13.3）和 #186（v1.13.4）都是 squash 合并，导致 release workflow 静默跳过 — 没有 tag、没有 npm 发布、没有 GitHub Release。npm 卡在 1.13.2，而 master 已经到了 1.13.4。

--- a/TESTING.md
+++ b/TESTING.md
@@ -56,7 +56,7 @@ Zero external dependencies. Test deterministic logic in isolation.
 | Test File | Source Module | What It Tests |
 |-----------|--------------|---------------|
 | `token-counting.test.ts` | `lib/token-utils.ts` | `countAllMessageTokens`, `countToolTokens`, `estimateTokensBatch`, `extractToolContent`, `extractCompletedToolOutput` |
-| `message-ids.test.ts` | `lib/message-ids.ts`, `lib/state/state.ts` | `assignMessageRefs`, `checkSession` (ID reset after native compaction) |
+| `message-ids.test.ts` | `lib/message-ids.ts`, `lib/state/state.ts` | `assignMessageRefs`, `updatePerTurnState` (ID reset after native compaction) |
 | `message-utils.test.ts` | `lib/messages/query.ts` | `isIgnoredUserMessage` |
 | `message-priority.test.ts` | `lib/messages/priority.ts`, `lib/messages/inject/inject.ts`, `lib/messages/inject/utils.ts`, `lib/messages/prune.ts`, `lib/messages/utils.ts` | `buildPriorityMap`, `injectMessageIds`, `applyAnchoredNudges`, `prune`, `stripHallucinationsFromString` |
 | `input-budget.test.ts` | `lib/messages/inject/utils.ts` | `computeInputBudget` |
@@ -92,7 +92,7 @@ Not yet implemented. Will test the complete message transform pipeline from `hoo
 |--------------|-------------|----------------------|
 | `lib/token-utils.ts` | `token-counting.test.ts`, `token-usage.test.ts` | `countAllMessageTokens`, `countToolTokens`, `estimateTokensBatch`, `extractToolContent`, `extractCompletedToolOutput`, `getCurrentTokenUsage` |
 | `lib/message-ids.ts` | `message-ids.test.ts` | `assignMessageRefs` |
-| `lib/state/state.ts` | `message-ids.test.ts` | `checkSession` |
+| `lib/state/state.ts` | `registry.test.ts`, `message-ids.test.ts` | `SessionStateRegistry`, `updatePerTurnState`, `ensureSessionInitialized` |
 | `lib/state/utils.ts` | (indirect via other tests) | `isMessageCompacted`, `serializePruneMessagesState` |
 | `lib/messages/query.ts` | `message-utils.test.ts` | `isIgnoredUserMessage` |
 | `lib/messages/shape.ts` | `message-utils.test.ts` | `isMessageWithInfo` (indirect) |

--- a/devlog/2026-07-24_per-session-state/DESIGN.md
+++ b/devlog/2026-07-24_per-session-state/DESIGN.md
@@ -1,0 +1,92 @@
+# DESIGN - Per-Session State Registry
+
+- Task ID: `2026-07-24_per-session-state`
+- Home Repo: `opencode-acp`
+- Created: 2026-07-24
+- Status: Draft (Oracle-validated)
+
+## 1. Problem Statement
+
+- **What problem are we solving?** One shared `SessionState` singleton causes cross-session state corruption when sessions interleave (parent + subagents). Most visible symptom: subagent `modelContextLimit` is always `undefined` → over-compression at ~5% context.
+- **Why now?** Blocking reliable multi-agent review workflows (#33). Root cause confirmed from `sst/opencode` source: `experimental.chat.system.transform` DOES fire for subagents with `model.limit.context` populated; the value is lost purely due to the shared-state reset/load thrash.
+
+## 2. Goals & Non-Goals
+
+- **Goals**:
+  - Each OpenCode session gets its own `SessionState` held for its lifetime; no reset-on-switch.
+  - `modelContextLimit`, `isSubAgent`, `manualMode`, compression blocks, nudge anchors all isolated per session.
+  - Preserve all existing behavior (compaction detection, currentTurn, GC, persistence).
+- **Non-Goals**: safety-net nudge suppression; provider.list; full eviction policy; upstream opencode change.
+
+## 3. Current Architecture
+
+```
+index.ts: const state = createSessionState()  // ONE shared singleton
+   └─ passed to all hooks + compressToolContext
+hooks.ts messages.transform → checkSession(state, messages):
+   if state.sessionId !== lastSessionId → ensureSessionInitialized → resetSessionState (WIPES all)
+                                                       → loadSessionState (reload from {sessionId}.json)
+```
+- **Pain points**: reset-on-switch wipes `modelContextLimit` (set only by system.transform, which fires AFTER messages.transform saves). Also flips `isSubAgent`/`manualMode` to whichever session ran last.
+
+## 4. Proposed Architecture
+
+```
+index.ts: const registry = new SessionStateRegistry(logger)
+   └─ registry holds Map<sessionId, SessionState> + a SHARED compressionTiming
+
+SessionStateRegistry:
+  get(sessionId)            // sync, returns cached or undefined
+  all()                     // iterate all session states (for event-handler apply)
+  getOrCreate(client, sessionId, messages, manualModeDefault, config)  // lazy create + init (idempotent)
+  compressionTiming         // SHARED CompressionTimingState (hoisted out of per-session identity)
+
+Each hook resolves its own state at entry:
+  messages.transform: sessionId = lastUserMessage.info.sessionID → registry.getOrCreate(...)
+                       → updatePerTurnState(state, ...)  // compaction + currentTurn (the non-switch parts of checkSession)
+  system.transform:   registry.get(input.sessionID) → set state.modelContextLimit
+  command:            registry.getOrCreate(client, input.sessionID, messages, ...)
+  event:              uses registry.compressionTiming (shared); on complete, iterate registry.all() for apply
+  compress tools:     resolve state at execute entry (registry.get(toolCtx.sessionID))
+```
+
+### Why shared `compressionTiming` (hoist)
+The event handler has no `sessionID` in its input. If each session had its OWN `compressionTiming` map, `consumeCompressionStart` (destructive `.delete`) would consume the start in the wrong session, leaving the owning session dangling. Solution: the registry assigns ONE shared `compressionTiming` object to every session's `state.compressionTiming` (same reference). Record/consume operate on a single map (correct). The apply step (`applyPendingCompressionDurations`) matches `pendingByCallId` against each session's `blocksById`, so we iterate `registry.all()` and only the owning session gets `applied > 0` (and deletes the pending entry). This preserves the `SessionState.compressionTiming` field shape → tests/fixtures unchanged.
+
+### compress tool context
+`ToolFactoryContext` (new) = `{ client, registry, logger, config, prompts }`. Each factory resolves state at `execute` entry into a local `ToolContext` (shape unchanged) so the ~10 compress modules are untouched.
+
+## 5. Design Decisions & Rationale
+
+| Decision | Options Considered | Chosen | Why |
+|----------|--------------------|--------|-----|
+| State container | (a) shared singleton+reset (b) per-session registry | registry | Only correct option; reset thrash is the bug |
+| compressionTiming | (a) per-session + iterate-all (b) hoist to shared ref | hoist (shared ref) | Iterate-all is INCORRECT: consume is destructive; shared ref keeps single map |
+| compress tool state | (a) resolve at entry (b) thread registry everywhere | resolve at entry | Minimizes blast radius; modules untouched |
+| Eviction | (a) none (b) soft cap (c) full LRU/TTL | soft cap (~32) | v1 daemon-safety; cheap; full policy premature |
+| Async init guard | (a) none (b) in-flight Promise per session | none for v1 | JS single-threaded: Map.set + sessionId assignment are sync before await; OpenCode fires hooks sequentially per session |
+| Smaller fix (isolate modelContextLimit only) | side Map<sessionId,number> | rejected | Masks one symptom; leaves block/anchor/isSubAgent corruption |
+
+## 6. Impact Analysis
+
+- **Backward compatibility**: No persisted-state format change. Existing `{sessionId}.json` (incl. `modelContextLimit`) loads as before. Subagent JSONs with corrupt `modelContextLimit: undefined` self-heal (restore guard skips non-number; next system.transform sets it).
+- **Performance**: One extra Map lookup per hook (negligible). Registry memory bounded by soft cap. Event apply iterates ≤ cap sessions (cheap).
+- **Security**: N/A (no new I/O surfaces).
+- **Dependencies**: none.
+
+## 7. Migration Plan
+
+- **Steps**: None. Pure in-process refactor; persistence unchanged.
+- **Feature flags**: N/A.
+
+## 8. Open Questions
+
+- [ ] (resolved by Oracle) event handler: hoist compressionTiming — confirmed.
+- [ ] Eviction cap value: 32 (configurable later).
+
+## Invariants preserved (Oracle checklist)
+- `if (!lastUserMessage) return` BEFORE registry.getOrCreate (cannot derive sessionId otherwise).
+- `INTERNAL_AGENT_NAMES` skip BEFORE registry.getOrCreate (title/summary/compaction must not init bogus sessions).
+- Post-compaction `saveSessionState` kept inside `updatePerTurnState`.
+- `applyPendingCompressionDurations` during init uses the SHARED compressionTiming (registry assigns it before ensureSessionInitialized; `resetSessionState` must NOT recreate compressionTiming).
+- Incidentally fixes: `isSubAgent`/`manualMode` no longer flip-flop across sessions (latent bug).

--- a/devlog/2026-07-24_per-session-state/REQ.md
+++ b/devlog/2026-07-24_per-session-state/REQ.md
@@ -1,0 +1,63 @@
+# REQ - Per-Session State Registry (fix subagent over-compression)
+
+- Task ID: `2026-07-24_per-session-state`
+- Home Repo: `opencode-acp`
+- Created: 2026-07-24
+- Status: InProgress
+- Priority: P0
+- Owner: bot
+- References: dog/opencode-acp#33
+
+## 1. Background & Problem Statement
+
+- **Context**: During dual-agent PR review, review SUBAGENT sessions (e.g. `ses_06e3a79b`) over-compressed — they were nudged to compress at only ~20K context (~5% of the 1M window) and compressed content they were actively using.
+- **Current behavior (symptom)**: Subagent `modelContextLimit` is `undefined` on every transform (debug log: `filterRecommendedRanges: modelContextLimit unknown` ×7), so the adaptive nudge growth floor falls back to 6000 tokens instead of 50000 → the subagent gets "soft efficiency" nudges at ~5% context.
+- **Root cause** (source-confirmed): ACP uses ONE shared `SessionState` singleton (`index.ts:38`) passed to ALL hooks/tools. On every session switch (parent↔subagent interleaving), `ensureSessionInitialized`→`resetSessionState` wipes `modelContextLimit=undefined` (`state.ts:149`). `modelContextLimit` is set ONLY by the `system.transform` hook (`hooks.ts:85-86`), which fires AFTER `messages.transform` (which runs the nudge logic + saves) within a call. So the subagent's 1M is never persisted and never survives to the next transform. Parent works because it is not interleaved/reset.
+- **Expected behavior**: Each session keeps its own `SessionState`; `modelContextLimit` set by `system.transform` persists across that session's transforms. Subagent should see the same 50000-token growth floor as the parent.
+- **Impact**: Subagents over-compress (lose context they need); also latent concurrency hazards: `isSubAgent`/`manualMode`/compression blocks/nudge anchors get cross-contaminated when the shared singleton is reset on switch.
+
+## 2. Reproduction (if applicable)
+
+- **Environment**: opencode dual-agent review; glm-5.2 (1M context window); ACP v1.13.3.
+- **Minimal reproduction steps**:
+  1. Run a parent agent that spawns 2 subagent reviewers (interleaving transforms).
+  2. Observe ACP debug logs: subagent logs `modelContextLimit unknown`; parent logs `growthThreshold=50000`.
+  3. Subagent receives "soft efficiency" nudge at ~5% context and compresses active content.
+- **Relevant configuration**: default config; `experimental.allowSubAgents` false.
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+  - Backward compatibility: per-session JSON persistence format unchanged (no migration).
+  - No `as any`/`@ts-ignore` (AGENTS.md).
+  - Internal `dcp` naming preserved (AGENTS.md §2.6).
+  - All 591 existing tests must still pass.
+- **Non-Goals** (explicitly out of scope for v1):
+  - NO "suppress nudge when limit unknown" safety net (user wants to observe whether per-session state alone fixes over-compression).
+  - NO `provider.list` lookup (system.transform already supplies the limit once state is isolated).
+  - NO full LRU/TTL eviction (soft cap only).
+  - NO upstream opencode change (system.transform input lacks `parentSessionID`, but per-session state makes that irrelevant).
+
+## 4. Acceptance Criteria (must be testable)
+
+- **Correctness**:
+  - [ ] Each session has its own `SessionState`; switching sessions does not reset another session's `modelContextLimit`.
+  - [ ] Subagent's `modelContextLimit` is set by its own `system.transform` and survives to subsequent `messages.transform` calls.
+  - [ ] Compression durations still attach to the owning session's blocks (event handler correctness preserved).
+- **Performance / Stability**:
+  - [ ] Soft cap prevents unbounded registry growth (daemon-safe).
+- **Regression**:
+  - [ ] All existing tests pass.
+  - [ ] New tests cover: per-session isolation of modelContextLimit; registry getOrCreate idempotency; event handler apply across sessions.
+
+## 5. Proposed Approach
+
+- **Affected modules & entry files**:
+  - `lib/state/state.ts` — new `SessionStateRegistry`; extract `updatePerTurnState` from `checkSession`.
+  - `index.ts` — wire `registry` instead of shared `state`.
+  - `lib/hooks.ts` — all 4 handlers resolve state per-call via registry.
+  - `lib/compress/types.ts` — add `ToolFactoryContext`.
+  - `lib/compress/*.ts` factories — resolve state at `execute` entry.
+  - `lib/compress/timing.ts` — unchanged (reads shared `state.compressionTiming`).
+- **Risks**: event handler must not iterate-and-consume (destructive); see DESIGN §5.
+- **Rollback strategy**: Revert the PR (no persisted-state migration, so fully reversible).

--- a/devlog/2026-07-24_per-session-state/WORKLOG.md
+++ b/devlog/2026-07-24_per-session-state/WORKLOG.md
@@ -1,0 +1,34 @@
+# WORKLOG - Per-Session State Registry
+
+- Task ID: `2026-07-24_per-session-state`
+- Branch: `2026-07-24_per-session-state` (base: master be0f116 / v1.13.3)
+- Started: 2026-07-24
+
+## Investigation (prior session, summarized)
+- Root cause confirmed from `sst/opencode` dev HEAD `adba484d`: `experimental.chat.system.transform` DOES fire for subagent chat completions on the same dispatch path as the parent, and `input.model.limit.context` IS populated (required field on `Provider.Model`). Dispatch: task tool → child session (parentID) → ops.prompt → handle.process → processor → llm.stream → `session/llm/request.ts:69-73`.
+- The subagent's `modelContextLimit` is lost because the shared ACP `SessionState` singleton is reset on every session switch (`resetSessionState` wipes it), and `system.transform` (which sets it) fires after `messages.transform` (which reads+saves), so it is never persisted for interleaved subagents.
+
+## Implementation
+- [x] Branch + devlog created.
+- [x] `lib/state/state.ts`: added `SessionStateRegistry` (Map<sessionId,SessionState> + shared `compressionTiming` + soft cap 32, eviction oldest-first); added `updatePerTurnState` (compaction detection + currentTurn) extracted from `checkSession`; removed `checkSession`.
+- [x] `index.ts`: `new SessionStateRegistry(logger)`; handlers + compress tool factory context take the registry.
+- [x] `lib/hooks.ts`: all 4 handlers resolve state per-call. messages.transform resolves via `registry.getOrCreate(lastUserMessage.info.sessionID)` then `updatePerTurnState`; keeps `INTERNAL_AGENT_NAMES` + `!lastUserMessage` early structure. When there is no resolvable user message, an ephemeral state keeps state-independent stages (e.g. `stripHallucinations`) running (matches pre-refactor behavior).
+- [x] `lib/compress/types.ts`: added `ToolFactoryContext` + `resolveToolContext(factoryCtx, sessionID)`.
+- [x] `lib/compress/{range,message,decompress,prune-tool,recap,search,status}.ts`: factory param is now `ToolFactoryContext`; `resolveToolContext` runs at execute entry. Compress modules unchanged (still take resolved `ToolContext`).
+- [x] `lib/compress/pipeline.ts`: unchanged — `ensureSessionInitialized` is now an idempotent safety no-op.
+- Per user directive (@dog): **no** suppress-nudge/modelContextLimit-unknown safety net was added — keep observing the behavior in this first revision.
+
+## Tests
+- [x] `tests/registry-stub.ts` (new): `singletonRegistry(state)` (compress-tool unit tests) + `createTestRegistry(state)` (hook-handler tests, supports `getOrCreate` + session-switch).
+- [x] Updated 13 test files: compress-tool factories use `singletonRegistry(state)`; hook handlers use `createTestRegistry(state)`; command-handler direct calls still pass `state` (resolved in `createCommandExecuteHandler`).
+- [x] Rewrote `session switch` test (e2e-blocks-nudges) — old shared-singleton "reset" assertion is obsolete under per-session state; now asserts session A's state is preserved when session B runs (the #33 fix).
+
+## Verification
+- [x] `node ./node_modules/typescript/bin/tsc --noEmit` clean (exit 0).
+- [x] `npm run build` clean (exit 0; dist/index.js 434.76 KB).
+- [x] `node --import tsx --test tests/*.test.ts` — **837 pass, 0 fail**.
+- [ ] Deploy locally (`scripts/dev-deploy.sh`); observe subagent `modelContextLimit` now populated across interleaved sessions.
+
+## Review (AGENTS.md §5.3 — dual-agent required)
+- [ ] Agent review 1.
+- [ ] Agent review 2.

--- a/devlog/2026-07-24_per-session-state/WORKLOG.md
+++ b/devlog/2026-07-24_per-session-state/WORKLOG.md
@@ -30,5 +30,12 @@
 - [ ] Deploy locally (`scripts/dev-deploy.sh`); observe subagent `modelContextLimit` now populated across interleaved sessions.
 
 ## Review (AGENTS.md §5.3 — dual-agent required)
-- [ ] Agent review 1.
-- [ ] Agent review 2.
+- [x] Agent review 1 (correctness/lifecycle): APPROVE — no Critical/Major. Minors: dead `consumeCompressionStart`, defense-in-depth on eviction save (decided skip).
+- [x] Agent review 2 (backward-compat/API/tests): REQUEST CHANGES → resolved. Major M1 (real `SessionStateRegistry` untested) fixed via `tests/registry.test.ts` (4 tests: idempotency, per-session isolation, shared compressionTiming, eviction+reload).
+
+## Review fixes applied
+- [x] `tests/registry.test.ts` (new): 4 tests against the real `SessionStateRegistry` — R2 M1.
+- [x] Removed unused `client` param from `createSystemPromptHandler` + `index.ts` call site — R2 n1.
+- [x] Removed dead `consumeCompressionStart` export from `lib/compress/timing.ts`; updated stale comment in `state.ts` — R1 M3 / R2 n2.
+- [x] Updated doc drift: `AGENTS.md §2.2` data-flow + `TESTING.md` (`checkSession` → `registry.getOrCreate` + `updatePerTurnState`) — R2 m3.
+- [x] 841 tests pass (was 837, +4 registry), typecheck + build clean.

--- a/devlog/2026-07-24_per-session-state/WORKLOG.md
+++ b/devlog/2026-07-24_per-session-state/WORKLOG.md
@@ -39,3 +39,10 @@
 - [x] Removed dead `consumeCompressionStart` export from `lib/compress/timing.ts`; updated stale comment in `state.ts` — R1 M3 / R2 n2.
 - [x] Updated doc drift: `AGENTS.md §2.2` data-flow + `TESTING.md` (`checkSession` → `registry.getOrCreate` + `updatePerTurnState`) — R2 m3.
 - [x] 841 tests pass (was 837, +4 registry), typecheck + build clean.
+
+## Issue #33 follow-up: nudge baseline initialization fix + regression test
+- **Bug found during testing**: `lib/messages/inject/inject.ts:308` initialized `lastPerMessageNudgeTokens = currentTokens` (first transform's absolute value ~55K, includes system prompt). Effective first-nudge threshold became ~105K (10.5%) instead of ~50K (5%). The nudge never fired at 5% context, so the model never compressed voluntarily → context grew unchecked to 330K.
+- **Fix**: Changed to `lastPerMessageNudgeTokens = 0`. Growth now measured from session start; first nudge fires at ~nudgeGrowthTokens (5% of model context).
+- **Why tests missed it**: Every test in `tests/inject.test.ts` manually sets `lastPerMessageNudgeTokens` before calling `injectCompressNudges`, bypassing the initialization path (line 304-309). No test exercised the `undefined → initialized` transition.
+- **Regression test added**: `tests/inject.test.ts` — "baseline initialized to 0 on first transform, not currentTokens (issue #33 regression)". Simulates two sequential calls: turn 1 establishes baseline (assert =0), turn 2 verifies nudge fires at ~5.8% growth from baseline 0. Verified: FAILS with bug reverted (`55000 !== 0`), PASSES with fix.
+- 842 tests pass (841 + 1 regression), typecheck clean.

--- a/devlog/2026-07-25_release-v1.14.0-dev.1/REQ.md
+++ b/devlog/2026-07-25_release-v1.14.0-dev.1/REQ.md
@@ -1,0 +1,28 @@
+# REQ - Release v1.14.0-dev.1
+
+- Task ID: `2026-07-25_release-v1.14.0-dev.1`
+- Branch: `2026-07-25_release-v1.14.0-dev.1` (base: `2026-07-24_per-session-state` which merges github/master v1.13.5)
+- Type: Dev prerelease (npm `dev` tag)
+
+## Goal
+
+Publish a dev prerelease to npm `dev` tag so users can opt in via `opencode-acp@dev` to test the per-session state registry and nudge baseline fix before a stable release.
+
+## Changes included (since v1.13.5 master)
+
+1. **Per-Session State Registry** (`2026-07-24_per-session-state` branch):
+   - `SessionStateRegistry`: `Map<sessionId, SessionState>` with soft cap 32 + oldest-first eviction
+   - All hook handlers + compress tools resolve state per-call via `registry.getOrCreate(sessionID)`
+   - Eliminates cross-session state contamination for interleaved subagents
+
+2. **Nudge Baseline Fix** (issue #33):
+   - `lib/messages/inject/inject.ts:308`: baseline init from `currentTokens` → `0`
+   - First nudge now fires at ~5% context (50K on 1M model) instead of ~10.5%
+
+3. **Regression Test**:
+   - `tests/inject.test.ts`: "baseline initialized to 0 on first transform, not currentTokens (issue #33 regression)"
+   - Verified: FAILS with bug reverted, PASSES with fix
+
+## Prerelease detection
+
+Version `1.14.0-dev.1` contains `-`, so CI `release.yml` will publish with `--tag dev` and mark GitHub Release as `prerelease: true`.

--- a/devlog/2026-07-25_release-v1.14.0-dev.1/WORKLOG.md
+++ b/devlog/2026-07-25_release-v1.14.0-dev.1/WORKLOG.md
@@ -1,0 +1,23 @@
+# WORKLOG - Release v1.14.0-dev.1
+
+- Task ID: `2026-07-25_release-v1.14.0-dev.1`
+- Branch: `2026-07-25_release-v1.14.0-dev.1` (base: `2026-07-24_per-session-state`)
+- Started: 2026-07-25
+
+## Steps
+
+- [x] Created worktree at `/tmp/opencode-release-dev` from `2026-07-24_per-session-state` (which merges github/master v1.13.5)
+- [x] Created release branch `2026-07-25_release-v1.14.0-dev.1`
+- [x] Bumped version: `1.13.5` → `1.14.0-dev.1` in `package.json`
+- [x] Added changelog entry to `README.md` (English)
+- [x] Added changelog entry to `README.zh-CN.md` (Chinese)
+- [x] Created devlog entry (`REQ.md` + `WORKLOG.md`)
+- [ ] Run `check-pr.sh` to verify CI compliance
+- [ ] `npm install` + `npm run build` + `npm test` in worktree
+- [ ] Commit, push to github, create PR
+- [ ] Human merges PR → CI auto-publishes to npm `dev` tag
+
+## Verification
+
+- Version: `1.14.0-dev.1` (contains `-` → CI detects as prerelease → `--tag dev`)
+- 848 tests pass (verified on base branch `2026-07-24_per-session-state`)

--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,7 @@ import {
     type HostPermissionSnapshot,
 } from "./lib/host-permissions"
 import { Logger } from "./lib/logger"
-import { createSessionState } from "./lib/state"
+import { SessionStateRegistry } from "./lib/state"
 import { PromptStore } from "./lib/prompts/store"
 import {
     createChatMessageTransformHandler,
@@ -35,7 +35,7 @@ const server: Plugin = (async (ctx) => {
     }
 
     const logger = new Logger(config.debug)
-    const state = createSessionState()
+    const registry = new SessionStateRegistry(logger)
     const prompts = new PromptStore(logger, ctx.directory, config.experimental.customPrompts)
     const hostPermissions: HostPermissionSnapshot = {
         global: undefined,
@@ -55,7 +55,7 @@ const server: Plugin = (async (ctx) => {
 
     const compressToolContext = {
         client: ctx.client,
-        state,
+        registry,
         logger,
         config,
         prompts,
@@ -63,14 +63,15 @@ const server: Plugin = (async (ctx) => {
 
     return {
         "experimental.chat.system.transform": createSystemPromptHandler(
-            state,
+            ctx.client,
+            registry,
             logger,
             config,
             prompts,
         ),
         "experimental.chat.messages.transform": createChatMessageTransformHandler(
             ctx.client,
-            state,
+            registry,
             logger,
             config,
             prompts,
@@ -79,13 +80,13 @@ const server: Plugin = (async (ctx) => {
         "experimental.text.complete": createTextCompleteHandler(),
         "command.execute.before": createCommandExecuteHandler(
             ctx.client,
-            state,
+            registry,
             logger,
             config,
             ctx.directory,
             hostPermissions,
         ),
-        event: createEventHandler(state, logger),
+        event: createEventHandler(registry, logger),
         tool: {
             ...(config.compress.permission !== "deny" && {
                 compress:

--- a/index.ts
+++ b/index.ts
@@ -63,7 +63,6 @@ const server: Plugin = (async (ctx) => {
 
     return {
         "experimental.chat.system.transform": createSystemPromptHandler(
-            ctx.client,
             registry,
             logger,
             config,

--- a/lib/compress/decompress.ts
+++ b/lib/compress/decompress.ts
@@ -1,5 +1,5 @@
 import { tool } from "@opencode-ai/plugin"
-import type { ToolContext } from "./types"
+import { type ToolContext, type ToolFactoryContext, resolveToolContext } from "./types"
 import type { CompressionTarget } from "../commands/compression-targets"
 import type { CompressionBlock } from "../state/types"
 import type { SessionState, WithParts } from "../state"
@@ -264,11 +264,12 @@ function extractMessageText(m: WithParts): string {
     return `[${role}]\n${content}`
 }
 
-export function createDecompressTool(ctx: ToolContext): ReturnType<typeof tool> {
+export function createDecompressTool(factoryCtx: ToolFactoryContext): ReturnType<typeof tool> {
     return tool({
         description: TOOL_DESCRIPTION,
         args: buildSchema(),
         async execute(args, toolCtx) {
+            const ctx = resolveToolContext(factoryCtx, toolCtx.sessionID)
             const { rawMessages } = await prepareDecompressSession(ctx, toolCtx)
 
             const contextUsageBefore = ctx.state.modelContextLimit

--- a/lib/compress/message.ts
+++ b/lib/compress/message.ts
@@ -1,5 +1,5 @@
 import { tool } from "@opencode-ai/plugin"
-import type { ToolContext } from "./types"
+import { type ToolFactoryContext, resolveToolContext } from "./types"
 import { countMessageCharacters, countTokens } from "../token-utils"
 import { MESSAGE_FORMAT_EXTENSION } from "../prompts/extensions/tool"
 import { formatIssues, formatResult, resolveMessages, validateArgs } from "./message-utils"
@@ -67,14 +67,15 @@ function buildSchema(maxSummaryLengthHard: number) {
     }
 }
 
-export function createCompressMessageTool(ctx: ToolContext): ReturnType<typeof tool> {
-    ctx.prompts.reload()
-    const runtimePrompts = ctx.prompts.getRuntimePrompts()
+export function createCompressMessageTool(factoryCtx: ToolFactoryContext): ReturnType<typeof tool> {
+    factoryCtx.prompts.reload()
+    const runtimePrompts = factoryCtx.prompts.getRuntimePrompts()
 
     return tool({
         description: runtimePrompts.compressMessage + MESSAGE_FORMAT_EXTENSION,
-        args: buildSchema(ctx.config.compress.maxSummaryLengthHard),
+        args: buildSchema(factoryCtx.config.compress.maxSummaryLengthHard),
         async execute(args, toolCtx) {
+            const ctx = resolveToolContext(factoryCtx, toolCtx.sessionID)
             const input = args as CompressMessageToolArgs
             validateArgs(input)
 

--- a/lib/compress/prune-tool.ts
+++ b/lib/compress/prune-tool.ts
@@ -1,5 +1,5 @@
 import { tool } from "@opencode-ai/plugin"
-import type { ToolContext } from "./types"
+import { type ToolFactoryContext, resolveToolContext } from "./types"
 import { fetchSessionMessages } from "./search"
 import { finalizeSession, prepareSession } from "./pipeline"
 
@@ -11,8 +11,8 @@ Args:
 - toolType: tool name to prune (e.g., "todowrite", "bash", "edit")
 - keepLatest: how many recent calls to keep visible (default 3)`
 
-export function createPruneTool(ctx: ToolContext): ReturnType<typeof tool> {
-    ctx.prompts.reload()
+export function createPruneTool(factoryCtx: ToolFactoryContext): ReturnType<typeof tool> {
+    factoryCtx.prompts.reload()
 
     return tool({
         description: PRUNE_TOOL_DESCRIPTION,
@@ -26,6 +26,7 @@ export function createPruneTool(ctx: ToolContext): ReturnType<typeof tool> {
                 .describe("How many recent calls to keep visible (default 3)"),
         },
         async execute(args, toolCtx) {
+            const ctx = resolveToolContext(factoryCtx, toolCtx.sessionID)
             const keepLatest = args.keepLatest ?? 3
             const { rawMessages } = await prepareSession(
                 ctx,

--- a/lib/compress/range.ts
+++ b/lib/compress/range.ts
@@ -1,5 +1,5 @@
 import { tool } from "@opencode-ai/plugin"
-import type { ToolContext } from "./types"
+import { type ToolFactoryContext, resolveToolContext } from "./types"
 import { countMessageCharacters, countTokens } from "../token-utils"
 import { RANGE_FORMAT_EXTENSION } from "../prompts/extensions/tool"
 import {
@@ -92,14 +92,15 @@ function buildSchema(maxSummaryLengthHard: number) {
     }
 }
 
-export function createCompressRangeTool(ctx: ToolContext): ReturnType<typeof tool> {
-    ctx.prompts.reload()
-    const runtimePrompts = ctx.prompts.getRuntimePrompts()
+export function createCompressRangeTool(factoryCtx: ToolFactoryContext): ReturnType<typeof tool> {
+    factoryCtx.prompts.reload()
+    const runtimePrompts = factoryCtx.prompts.getRuntimePrompts()
 
     return tool({
         description: runtimePrompts.compressRange + RANGE_FORMAT_EXTENSION,
-        args: buildSchema(ctx.config.compress.maxSummaryLengthHard),
+        args: buildSchema(factoryCtx.config.compress.maxSummaryLengthHard),
         async execute(args, toolCtx) {
+            const ctx = resolveToolContext(factoryCtx, toolCtx.sessionID)
             const input = args as CompressRangeToolArgs
             validateArgs(input)
 

--- a/lib/compress/recap.ts
+++ b/lib/compress/recap.ts
@@ -1,6 +1,6 @@
 import { tool } from "@opencode-ai/plugin"
 import type { CompressionBlock } from "../state/types"
-import type { ToolContext } from "./types"
+import { type ToolFactoryContext, resolveToolContext } from "./types"
 
 function formatCoverage(block: CompressionBlock): string {
     const count = block.effectiveMessageIds?.length || 0
@@ -14,7 +14,7 @@ Call this tool to re-fetch a specific block's summary without decompressing the 
 Args:
 - blockId: optional block number (e.g., 5). If omitted, lists all active blocks with brief info.`
 
-export function createAcpContextRecapTool(ctx: ToolContext): ReturnType<typeof tool> {
+export function createAcpContextRecapTool(factoryCtx: ToolFactoryContext): ReturnType<typeof tool> {
     return tool({
         description: RECAP_TOOL_DESCRIPTION,
         args: {
@@ -23,7 +23,8 @@ export function createAcpContextRecapTool(ctx: ToolContext): ReturnType<typeof t
                 .optional()
                 .describe("Block number to retrieve (e.g., 5). If omitted, lists all active blocks."),
         },
-        async execute(args) {
+        async execute(args, toolCtx) {
+            const ctx = resolveToolContext(factoryCtx, toolCtx.sessionID)
             const msgState = ctx.state.prune.messages
             const activeIds = Array.from(msgState.activeBlockIds).sort((a, b) => a - b)
 

--- a/lib/compress/search.ts
+++ b/lib/compress/search.ts
@@ -4,7 +4,13 @@ import { formatBlockRef, formatMessageRef, parseBoundaryId, parseMessageRef } fr
 import { isIgnoredUserMessage } from "../messages/query"
 import { filterMessages } from "../messages/shape"
 import { countAllMessageTokens } from "../token-utils"
-import type { BoundaryReference, SearchContext, SelectionResolution, ToolContext } from "./types"
+import {
+    type BoundaryReference,
+    type SearchContext,
+    type SelectionResolution,
+    type ToolFactoryContext,
+    resolveToolContext,
+} from "./types"
 
 export async function fetchSessionMessages(client: any, sessionId: string): Promise<WithParts[]> {
     const response = await client.session.messages({
@@ -380,8 +386,8 @@ function buildSearchPreview(text: string, firstTerm: string): string {
     return text.substring(0, 200) + (text.length > 200 ? "..." : "")
 }
 
-export function createSearchContextTool(ctx: ToolContext): ReturnType<typeof tool> {
-    ctx.prompts.reload()
+export function createSearchContextTool(factoryCtx: ToolFactoryContext): ReturnType<typeof tool> {
+    factoryCtx.prompts.reload()
 
     return tool({
         description: SEARCH_CONTEXT_TOOL_DESCRIPTION,
@@ -398,7 +404,8 @@ export function createSearchContextTool(ctx: ToolContext): ReturnType<typeof too
                 .optional()
                 .describe("If true, also search visible (uncompressed) messages. Slower but more thorough (default: false)"),
         },
-        async execute(args) {
+        async execute(args, toolCtx) {
+            const ctx = resolveToolContext(factoryCtx, toolCtx.sessionID)
             const query = (args.query || "").toLowerCase().trim()
             const limit = args.limit ?? 10
 

--- a/lib/compress/status.ts
+++ b/lib/compress/status.ts
@@ -1,5 +1,5 @@
 import { tool } from "@opencode-ai/plugin"
-import type { ToolContext } from "./types"
+import { type ToolContext, type ToolFactoryContext, resolveToolContext } from "./types"
 import { formatAge } from "../ui/utils"
 import type { CompressionBlock, WithParts } from "../state/types"
 import {
@@ -390,8 +390,8 @@ function buildVisibleWithSummaries(rawMessages: WithParts[], ctx: ToolContext): 
     return visible
 }
 
-export function createAcpStatusTool(ctx: ToolContext): ReturnType<typeof tool> {
-    ctx.prompts.reload()
+export function createAcpStatusTool(factoryCtx: ToolFactoryContext): ReturnType<typeof tool> {
+    factoryCtx.prompts.reload()
 
     return tool({
         description: ACP_STATUS_TOOL_DESCRIPTION,
@@ -419,6 +419,7 @@ export function createAcpStatusTool(ctx: ToolContext): ReturnType<typeof tool> {
             limit: tool.schema.number().optional().describe("Max items to list (default 30)"),
         },
         async execute(args, toolCtx) {
+            const ctx = resolveToolContext(factoryCtx, toolCtx.sessionID)
             const scope =
                 args.scope === "compressed" || args.scope === "uncompressed"
                     ? args.scope

--- a/lib/compress/timing.ts
+++ b/lib/compress/timing.ts
@@ -16,17 +16,6 @@ export function buildCompressionTimingKey(messageId: string, callId: string): st
     return `${messageId}:${callId}`
 }
 
-export function consumeCompressionStart(
-    state: SessionState,
-    messageId: string,
-    callId: string,
-): number | undefined {
-    const key = buildCompressionTimingKey(messageId, callId)
-    const start = state.compressionTiming.startsByCallId.get(key)
-    state.compressionTiming.startsByCallId.delete(key)
-    return start
-}
-
 export function resolveCompressionDuration(
     startedAt: number | undefined,
     eventTime: number | undefined,

--- a/lib/compress/types.ts
+++ b/lib/compress/types.ts
@@ -2,6 +2,7 @@ import type { PluginConfig } from "../config"
 import type { Logger } from "../logger"
 import type { PromptStore } from "../prompts/store"
 import type { CompressionBlock, CompressionMode, SessionState, WithParts } from "../state"
+import type { SessionStateRegistry } from "../state"
 
 export interface ToolContext {
     client: any
@@ -9,6 +10,37 @@ export interface ToolContext {
     logger: Logger
     config: PluginConfig
     prompts: PromptStore
+}
+
+export interface ToolFactoryContext {
+    client: any
+    registry: SessionStateRegistry
+    logger: Logger
+    config: PluginConfig
+    prompts: PromptStore
+}
+
+// [FIX #33] Resolve the caller's per-session state at tool-call time and build a
+// ToolContext bound to it. A compress tool can only run after messages.transform
+// initialized the session, so the state is guaranteed present.
+export function resolveToolContext(
+    factoryCtx: ToolFactoryContext,
+    sessionID: string,
+): ToolContext {
+    const state = factoryCtx.registry.get(sessionID)
+    if (!state) {
+        throw new Error(
+            `ACP: session ${sessionID} has no initialized state. ` +
+                "messages.transform must run before a compress tool call.",
+        )
+    }
+    return {
+        client: factoryCtx.client,
+        state,
+        logger: factoryCtx.logger,
+        config: factoryCtx.config,
+        prompts: factoryCtx.prompts,
+    }
 }
 
 export interface CompressRangeEntry {

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -21,7 +21,6 @@ import { buildProtectedToolsExtension } from "./prompts/extensions/system"
 import {
     applyPendingCompressionDurations,
     buildCompressionTimingKey,
-    consumeCompressionStart,
     resolveCompressionDuration,
 } from "./compress/timing"
 import { filterMessages, filterMessagesInPlace } from "./messages/shape"
@@ -39,7 +38,7 @@ import {
 } from "./commands"
 import { type HostPermissionSnapshot } from "./host-permissions"
 import { compressPermission, syncCompressPermissionState } from "./compress-permission"
-import { checkSession, ensureSessionInitialized, saveSessionState, syncToolCache } from "./state"
+import { createSessionState, saveSessionState, syncToolCache, updatePerTurnState, type SessionStateRegistry } from "./state"
 import { cacheSystemPromptTokens } from "./ui/utils"
 import { runTruncateGC, shouldRunMajorGC, getGCParams } from "./gc/truncate"
 import { runBatchCleanup } from "./gc/merge"
@@ -71,7 +70,8 @@ function isInternalAgentRequest(messages: WithParts[]): boolean {
 }
 
 export function createSystemPromptHandler(
-    state: SessionState,
+    client: any,
+    registry: SessionStateRegistry,
     logger: Logger,
     config: PluginConfig,
     prompts: PromptStore,
@@ -83,11 +83,14 @@ export function createSystemPromptHandler(
         },
         output: { system: string[] },
     ) => {
-        if (input.model?.limit?.context) {
+        // messages.transform creates the session state before this fires; if
+        // absent (internal-agent early-return), there is nothing to attribute.
+        const state = input.sessionID ? registry.get(input.sessionID) : undefined
+        if (state && input.model?.limit?.context) {
             state.modelContextLimit = input.model.limit.context
         }
 
-        if (state.isSubAgent && !config.experimental.allowSubAgents) {
+        if (!state || (state.isSubAgent && !config.experimental.allowSubAgents)) {
             return
         }
 
@@ -97,10 +100,7 @@ export function createSystemPromptHandler(
             return
         }
 
-        const effectivePermission =
-            input.sessionID && state.sessionId === input.sessionID
-                ? compressPermission(state, config)
-                : config.compress.permission
+        const effectivePermission = compressPermission(state, config)
 
         if (effectivePermission === "deny") {
             return
@@ -168,7 +168,7 @@ function runMajorGC(
 
 export function createChatMessageTransformHandler(
     client: any,
-    state: SessionState,
+    registry: SessionStateRegistry,
     logger: Logger,
     config: PluginConfig,
     prompts: PromptStore,
@@ -185,14 +185,31 @@ export function createChatMessageTransformHandler(
         }
 
         // [FIX Bug 37] Skip OpenCode internal agents (title/summary/compaction).
-        // These small hidden LLM requests must not be mutated, and running
-        // checkSession on them would corrupt shared state (currentTurn, etc.).
+        // These small hidden LLM requests must not be mutated, and resolving a
+        // session state for them would corrupt it (currentTurn, etc.).
         if (isInternalAgentRequest(messages)) {
             logger.debug("Skipping message transform for internal agent request")
             return
         }
 
-        await checkSession(client, state, logger, output.messages, config.manualMode.enabled, config)
+        const lastUserMessage = getLastUserMessage(messages)
+        let state: SessionState
+        if (!lastUserMessage) {
+            // Ephemeral state: no session to resolve, but keep running
+            // state-independent stages (e.g. stripHallucinations).
+            state = createSessionState()
+        } else {
+            // [FIX #33] Per-session state: each session keeps its own SessionState,
+            // so interleaved sessions no longer reset each other's modelContextLimit.
+            state = await registry.getOrCreate(
+                client,
+                lastUserMessage.info.sessionID,
+                messages,
+                config.manualMode.enabled,
+                config,
+            )
+            await updatePerTurnState(state, logger, messages)
+        }
 
         syncCompressPermissionState(state, config, hostPermissions, output.messages)
 
@@ -266,7 +283,7 @@ export function createChatMessageTransformHandler(
 
 export function createCommandExecuteHandler(
     client: any,
-    state: SessionState,
+    registry: SessionStateRegistry,
     logger: Logger,
     config: PluginConfig,
     workingDirectory: string,
@@ -286,11 +303,9 @@ export function createCommandExecuteHandler(
             })
             const messages = filterMessages(messagesResponse.data || messagesResponse)
 
-            await ensureSessionInitialized(
+            const state = await registry.getOrCreate(
                 client,
-                state,
                 input.sessionID,
-                logger,
                 messages,
                 config.manualMode.enabled,
                 config,
@@ -392,7 +407,7 @@ export function createTextCompleteHandler() {
     }
 }
 
-export function createEventHandler(state: SessionState, logger: Logger) {
+export function createEventHandler(registry: SessionStateRegistry, logger: Logger) {
     return async (input: { event: any }) => {
         const eventTime =
             typeof input.event?.time === "number" && Number.isFinite(input.event.time)
@@ -411,6 +426,12 @@ export function createEventHandler(state: SessionState, logger: Logger) {
             return
         }
 
+        // [FIX #33] The event hook carries no sessionID. compressionTiming is
+        // shared on the registry so record/consume use one map (a per-session map
+        // would let the destructive consume delete the start in the wrong
+        // session). The apply step iterates sessions; only the owner matches.
+        const timing = registry.compressionTiming
+
         if (part.state.status === "pending") {
             if (typeof part.callID !== "string" || typeof part.messageID !== "string") {
                 return
@@ -418,10 +439,10 @@ export function createEventHandler(state: SessionState, logger: Logger) {
 
             const startedAt = eventTime ?? Date.now()
             const key = buildCompressionTimingKey(part.messageID, part.callID)
-            if (state.compressionTiming.startsByCallId.has(key)) {
+            if (timing.startsByCallId.has(key)) {
                 return
             }
-            state.compressionTiming.startsByCallId.set(key, startedAt)
+            timing.startsByCallId.set(key, startedAt)
             logger.debug("Recorded compression start", {
                 messageID: part.messageID,
                 callID: part.callID,
@@ -436,31 +457,31 @@ export function createEventHandler(state: SessionState, logger: Logger) {
             }
 
             const key = buildCompressionTimingKey(part.messageID, part.callID)
-            const start = consumeCompressionStart(state, part.messageID, part.callID)
+            const start = timing.startsByCallId.get(key)
+            timing.startsByCallId.delete(key)
             const durationMs = resolveCompressionDuration(start, eventTime, part.state.time)
             if (typeof durationMs !== "number") {
                 return
             }
 
-            state.compressionTiming.pendingByCallId.set(key, {
+            timing.pendingByCallId.set(key, {
                 messageId: part.messageID,
                 callId: part.callID,
                 durationMs,
             })
 
-            const updates = applyPendingCompressionDurations(state)
-            if (updates === 0) {
-                return
+            for (const state of registry.all()) {
+                const updates = applyPendingCompressionDurations(state)
+                if (updates > 0) {
+                    await saveSessionState(state, logger)
+                    logger.info("Attached compression time to blocks", {
+                        messageID: part.messageID,
+                        callID: part.callID,
+                        blocks: updates,
+                        durationMs,
+                    })
+                }
             }
-
-            await saveSessionState(state, logger)
-
-            logger.info("Attached compression time to blocks", {
-                messageID: part.messageID,
-                callID: part.callID,
-                blocks: updates,
-                durationMs,
-            })
             return
         }
 
@@ -469,7 +490,7 @@ export function createEventHandler(state: SessionState, logger: Logger) {
         }
 
         if (typeof part.callID === "string" && typeof part.messageID === "string") {
-            state.compressionTiming.startsByCallId.delete(
+            timing.startsByCallId.delete(
                 buildCompressionTimingKey(part.messageID, part.callID),
             )
         }

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -70,7 +70,6 @@ function isInternalAgentRequest(messages: WithParts[]): boolean {
 }
 
 export function createSystemPromptHandler(
-    client: any,
     registry: SessionStateRegistry,
     logger: Logger,
     config: PluginConfig,

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -302,7 +302,10 @@ export const injectCompressNudges = (
     }
 
     if (state.nudges.lastPerMessageNudgeTokens === undefined && currentTokens !== undefined) {
-        state.nudges.lastPerMessageNudgeTokens = currentTokens
+        // Baseline 0 so the first nudge fires at ~nudgeGrowthTokens absolute (5%),
+        // not baseline + nudgeGrowthTokens (~10.9% when currentTokens includes
+        // system prompt overhead).
+        state.nudges.lastPerMessageNudgeTokens = 0
         baselineReEstablished = true
     }
 

--- a/lib/state/state.ts
+++ b/lib/state/state.ts
@@ -1,7 +1,11 @@
 import type { SessionState, ToolParameterEntry, WithParts } from "./types"
 import type { PluginConfig } from "../config"
 import type { Logger } from "../logger"
-import { applyPendingCompressionDurations } from "../compress/timing"
+import {
+    applyPendingCompressionDurations,
+    type CompressionTimingState,
+    type PendingCompressionDuration,
+} from "../compress/timing"
 import { loadSessionState, saveSessionState } from "./persistence"
 import { rebuildCompressionState } from "./rebuild"
 import {
@@ -14,41 +18,17 @@ import {
     loadPruneMap,
     collectTurnNudgeAnchors,
 } from "./utils"
-import { getLastUserMessage } from "../messages/query"
 import { parseMessageRef, formatMessageRef } from "../message-ids"
 
-export const checkSession = async (
-    client: any,
+/**
+ * Per-turn state update (compaction detection + turn count). Extracted from the
+ * old `checkSession`; session-switch + init now live in SessionStateRegistry.
+ */
+export async function updatePerTurnState(
     state: SessionState,
     logger: Logger,
     messages: WithParts[],
-    manualModeDefault: boolean,
-    config?: PluginConfig,
-): Promise<void> => {
-    const lastUserMessage = getLastUserMessage(messages)
-    if (!lastUserMessage) {
-        return
-    }
-
-    const lastSessionId = lastUserMessage.info.sessionID
-
-    if (state.sessionId === null || state.sessionId !== lastSessionId) {
-        logger.info(`Session changed: ${state.sessionId} -> ${lastSessionId}`)
-        try {
-            await ensureSessionInitialized(
-                client,
-                state,
-                lastSessionId,
-                logger,
-                messages,
-                manualModeDefault,
-                config,
-            )
-        } catch (err: any) {
-            logger.error("Failed to initialize session state", { error: err.message })
-        }
-    }
-
+): Promise<void> {
     const lastCompactionTimestamp = findLastCompactionTimestamp(messages)
     if (lastCompactionTimestamp > state.lastCompaction) {
         state.lastCompaction = lastCompactionTimestamp
@@ -65,6 +45,94 @@ export const checkSession = async (
     }
 
     state.currentTurn = countTurns(state, messages)
+}
+
+// Soft cap on held sessions — guards a long-lived plugin process (daemon mode)
+// from unbounded growth. Evicted sessions reload from persisted JSON on next
+// access; modelContextLimit and all persisted fields survive eviction.
+const REGISTRY_SOFT_CAP = 32
+
+// [FIX #33] Per-session state. Replaces the single shared SessionState singleton
+// whose resetSessionState-on-switch wiped modelContextLimit (set only by
+// system.transform, which fires AFTER messages.transform) and flipped
+// isSubAgent/manualMode across interleaved sessions. Each session now keeps its
+// own state for its lifetime — no reset-on-switch.
+//
+// compressionTiming is SHARED (hoisted here) rather than per-session: the `event`
+// hook carries no sessionID, and a per-session map would let the destructive
+// consumeCompressionStart delete entries in the wrong session (leaving the owning
+// session dangling). One shared map = correct record/consume; the apply step
+// iterates all sessions and only the owner matches (applied > 0).
+export class SessionStateRegistry {
+    private readonly states = new Map<string, SessionState>()
+    readonly compressionTiming: CompressionTimingState = {
+        startsByCallId: new Map<string, number>(),
+        pendingByCallId: new Map<string, PendingCompressionDuration>(),
+    }
+
+    constructor(private readonly logger: Logger) {}
+
+    get(sessionId: string): SessionState | undefined {
+        return this.states.get(sessionId)
+    }
+
+    all(): SessionState[] {
+        return Array.from(this.states.values())
+    }
+
+    get size(): number {
+        return this.states.size
+    }
+
+    // Idempotent: ensureSessionInitialized returns immediately once
+    // state.sessionId === sessionId (assigned synchronously before any await),
+    // so repeat calls for the same session never re-reset.
+    async getOrCreate(
+        client: any,
+        sessionId: string,
+        messages: WithParts[],
+        manualModeDefault: boolean,
+        config?: PluginConfig,
+    ): Promise<SessionState> {
+        let state = this.states.get(sessionId)
+        if (!state) {
+            state = createSessionState()
+            // Assign shared compressionTiming BEFORE ensureSessionInitialized so
+            // its init-time applyPendingCompressionDurations reads the shared map.
+            state.compressionTiming = this.compressionTiming
+            this.states.set(sessionId, state)
+            this.enforceSoftCap()
+        }
+        try {
+            await ensureSessionInitialized(
+                client,
+                state,
+                sessionId,
+                this.logger,
+                messages,
+                manualModeDefault,
+                config,
+            )
+        } catch (err: any) {
+            this.logger.error("Failed to initialize session state", {
+                error: err.message,
+            })
+        }
+        state.compressionTiming = this.compressionTiming
+        return state
+    }
+
+    private enforceSoftCap(): void {
+        if (this.states.size <= REGISTRY_SOFT_CAP) return
+        const oldest = this.states.keys().next().value
+        if (oldest !== undefined) {
+            this.states.delete(oldest as string)
+            this.logger.info("SessionStateRegistry evicted session (soft cap)", {
+                sessionId: oldest,
+                remaining: this.states.size,
+            })
+        }
+    }
 }
 
 export function createSessionState(): SessionState {

--- a/lib/state/state.ts
+++ b/lib/state/state.ts
@@ -59,9 +59,9 @@ const REGISTRY_SOFT_CAP = 32
 // own state for its lifetime — no reset-on-switch.
 //
 // compressionTiming is SHARED (hoisted here) rather than per-session: the `event`
-// hook carries no sessionID, and a per-session map would let the destructive
-// consumeCompressionStart delete entries in the wrong session (leaving the owning
-// session dangling). One shared map = correct record/consume; the apply step
+// hook carries no sessionID, and a per-session map would let the event hook
+// delete start entries in the wrong session (leaving the owning session
+// dangling). One shared map = correct record/consume; the apply step
 // iterates all sessions and only the owner matches (applied > 0).
 export class SessionStateRegistry {
     private readonly states = new Map<string, SessionState>()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-acp",
-    "version": "1.13.1",
+    "version": "1.14.0-dev.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-acp",
-            "version": "1.13.1",
+            "version": "1.14.0-dev.1",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.13.5",
+    "version": "1.14.0-dev.1",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",

--- a/tests/acp-status.test.ts
+++ b/tests/acp-status.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 import { createAcpStatusTool } from "../lib/compress/status"
-import type { ToolContext } from "../lib/compress/types"
+import type { ToolFactoryContext } from "../lib/compress/types"
 import type { CompressionBlock, PrunedMessageEntry, SessionState } from "../lib/state/types"
+import { singletonRegistry } from "./registry-stub"
 
 const SID = "session-acp-status-test"
 
@@ -91,10 +92,10 @@ function makeToolContext(
     activeIds: number[],
     blocks: Map<number, CompressionBlock>,
     client?: any,
-): ToolContext {
+): ToolFactoryContext {
     return {
         client: client ?? {},
-        state: makeState(activeIds, blocks),
+        registry: singletonRegistry(makeState(activeIds, blocks)),
         logger: { enabled: false } as any,
         config: {} as any,
         prompts: { reload: () => {} } as any,
@@ -272,9 +273,9 @@ test("acp_status: scope=uncompressed defaults to ranges view", async () => {
     const mockClient = makeMockClient(mockMsgs)
     const state = makeState([], new Map())
     state.messageIds.byRawId.set("raw-1", "m00001")
-    const ctx: ToolContext = {
+    const ctx: ToolFactoryContext = {
         client: mockClient,
-        state,
+        registry: singletonRegistry(state),
         logger: { enabled: false } as any,
         config: {} as any,
         prompts: { reload: () => {} } as any,
@@ -293,9 +294,9 @@ test("acp_status: scope=uncompressed view=messages shows per-message listing", a
     const mockClient = makeMockClient(mockMsgs)
     const state = makeState([], new Map())
     state.messageIds.byRawId.set("raw-1", "m00001")
-    const ctx: ToolContext = {
+    const ctx: ToolFactoryContext = {
         client: mockClient,
-        state,
+        registry: singletonRegistry(state),
         logger: { enabled: false } as any,
         config: {} as any,
         prompts: { reload: () => {} } as any,
@@ -317,9 +318,9 @@ test("acp_status: scope=uncompressed view=messages with tool filter shows filter
     const mockClient = makeMockClient(mockMsgs)
     const state = makeState([], new Map())
     state.messageIds.byRawId.set("raw-1", "m00001")
-    const ctx: ToolContext = {
+    const ctx: ToolFactoryContext = {
         client: mockClient,
-        state,
+        registry: singletonRegistry(state),
         logger: { enabled: false } as any,
         config: {} as any,
         prompts: { reload: () => {} } as any,

--- a/tests/batch-compress.test.ts
+++ b/tests/batch-compress.test.ts
@@ -8,6 +8,7 @@ import { validateArgs } from "../lib/compress/range-utils"
 import { createSessionState, type WithParts } from "../lib/state"
 import type { PluginConfig } from "../lib/config"
 import { Logger } from "../lib/logger"
+import { singletonRegistry } from "./registry-stub"
 import type { CompressRangeToolArgs } from "../lib/compress/types"
 
 const testDataHome = join(tmpdir(), `opencode-dcp-tests-${process.pid}`)
@@ -117,7 +118,7 @@ function buildToolCtx(sessionID: string, state: ReturnType<typeof createSessionS
                 get: async () => ({ data: { parentID: null } }),
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger: new Logger(false),
         config: buildConfig(),
         prompts: {

--- a/tests/compress-message.test.ts
+++ b/tests/compress-message.test.ts
@@ -7,6 +7,7 @@ import { createCompressMessageTool } from "../lib/compress/message"
 import { createSessionState, type WithParts } from "../lib/state"
 import type { PluginConfig } from "../lib/config"
 import { Logger } from "../lib/logger"
+import { singletonRegistry } from "./registry-stub"
 
 const testDataHome = join(tmpdir(), `opencode-dcp-message-tests-${process.pid}`)
 const testConfigHome = join(tmpdir(), `opencode-dcp-message-config-tests-${process.pid}`)
@@ -153,7 +154,7 @@ function buildMessages(sessionID: string): WithParts[] {
 test("compress message tool appends non-editable format extension", () => {
     const tool = createCompressMessageTool({
         client: {},
-        state: createSessionState(),
+        registry: singletonRegistry(createSessionState()),
         logger: new Logger(false),
         config: buildConfig(),
         prompts: {
@@ -181,7 +182,7 @@ test("compress message mode batches individual message summaries", async () => {
                 get: async () => ({ data: { parentID: null } }),
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger,
         config: buildConfig(),
         prompts: {
@@ -250,7 +251,7 @@ test("compress message mode appends protected prompt info", async () => {
                 get: async () => ({ data: { parentID: null } }),
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger,
         config,
         prompts: {
@@ -309,7 +310,7 @@ test("compress message mode ignores protect tags on ignored user messages", asyn
                 get: async () => ({ data: { parentID: null } }),
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger,
         config,
         prompts: {
@@ -360,7 +361,7 @@ test("compress message mode stores call id for later duration attachment", async
                 get: async () => ({ data: { parentID: null } }),
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger,
         config: buildConfig(),
         prompts: {
@@ -411,7 +412,7 @@ test("compress message mode does not partially apply when preparation fails", as
                 get: async () => ({ data: { parentID: null } }),
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger,
         config,
         prompts: {
@@ -459,7 +460,7 @@ test("compress message mode rejects compressed block ids", async () => {
                 get: async () => ({ data: { parentID: null } }),
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger,
         config: buildConfig(),
         prompts: {
@@ -508,7 +509,7 @@ test("compress message mode skips protected user message references", async () =
                 get: async () => ({ data: { parentID: null } }),
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger,
         config,
         prompts: {
@@ -592,7 +593,7 @@ test("compress message mode allows messages containing compress tool parts", asy
                 get: async () => ({ data: { parentID: null } }),
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger,
         config: buildConfig(),
         prompts: {
@@ -651,7 +652,7 @@ test("compress message mode sends one aggregated notification for batched messag
                 },
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger,
         config,
         prompts: {
@@ -706,7 +707,7 @@ test("compress message mode skips messages that are already actively compressed"
                 get: async () => ({ data: { parentID: null } }),
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger,
         config: buildConfig(),
         prompts: {
@@ -778,7 +779,7 @@ test("compress message mode skips invalid batch entries and reports issues", asy
                 get: async () => ({ data: { parentID: null } }),
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger,
         config: buildConfig(),
         prompts: {
@@ -843,7 +844,7 @@ test("compress message mode reports issues when every batch entry is skipped", a
                 get: async () => ({ data: { parentID: null } }),
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger,
         config: buildConfig(),
         prompts: {

--- a/tests/compress-range.test.ts
+++ b/tests/compress-range.test.ts
@@ -7,6 +7,7 @@ import { createCompressRangeTool } from "../lib/compress/range"
 import { createSessionState, type WithParts } from "../lib/state"
 import type { PluginConfig } from "../lib/config"
 import { Logger } from "../lib/logger"
+import { singletonRegistry } from "./registry-stub"
 
 const testDataHome = join(tmpdir(), `opencode-dcp-tests-${process.pid}`)
 const testConfigHome = join(tmpdir(), `opencode-dcp-config-tests-${process.pid}`)
@@ -150,7 +151,7 @@ test("compress range rebuilds subagent message refs after session state was rese
                 get: async () => ({ data: { parentID: "ses_parent" } }),
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger,
         config: buildConfig(),
         prompts: {
@@ -236,7 +237,7 @@ test("compress range mode appends protected prompt info", async () => {
                 get: async () => ({ data: { parentID: null } }),
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger,
         config,
         prompts: {
@@ -296,7 +297,7 @@ test("compress range mode batches multiple ranges into one notification", async 
                 },
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger,
         config,
         prompts: {
@@ -354,7 +355,7 @@ test("compress range mode rejects overlapping batched ranges", async () => {
                 get: async () => ({ data: { parentID: "ses_parent" } }),
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger,
         config: buildConfig(),
         prompts: {

--- a/tests/compression-groups.test.ts
+++ b/tests/compression-groups.test.ts
@@ -10,6 +10,7 @@ import { handleRecompressCommand } from "../lib/commands/recompress"
 import { createSessionState, type WithParts } from "../lib/state"
 import type { PluginConfig } from "../lib/config"
 import { Logger } from "../lib/logger"
+import { singletonRegistry } from "./registry-stub"
 
 const testDataHome = join(tmpdir(), `opencode-dcp-compression-groups-${process.pid}`)
 const testConfigHome = join(tmpdir(), `opencode-dcp-compression-groups-config-${process.pid}`)
@@ -185,7 +186,7 @@ test("compression notifications increment by tool call across range and message 
 
     const rangeTool = createCompressRangeTool({
         client,
-        state,
+        registry: singletonRegistry(state),
         logger,
         config: rangeConfig,
         prompts: {
@@ -219,7 +220,7 @@ test("compression notifications increment by tool call across range and message 
 
     const messageTool = createCompressMessageTool({
         client,
-        state,
+        registry: singletonRegistry(state),
         logger,
         config: messageConfig,
         prompts: {
@@ -277,7 +278,7 @@ test("decompress groups batched message compressions by tool call", async () => 
 
     const tool = createCompressMessageTool({
         client,
-        state,
+        registry: singletonRegistry(state),
         logger,
         config: buildConfig("message"),
         prompts: {
@@ -377,7 +378,7 @@ test("decompress keeps batched ranges individually restorable", async () => {
 
     const tool = createCompressRangeTool({
         client,
-        state,
+        registry: singletonRegistry(state),
         logger,
         config: buildConfig("range"),
         prompts: {

--- a/tests/e2e-blocks-nudges.test.ts
+++ b/tests/e2e-blocks-nudges.test.ts
@@ -15,6 +15,7 @@ import type { PluginConfig } from "../lib/config"
 import { createChatMessageTransformHandler } from "../lib/hooks"
 import { Logger } from "../lib/logger"
 import { createSessionState, type WithParts, type SessionState } from "../lib/state"
+import { createTestRegistry } from "./registry-stub"
 import { isSyntheticMessage } from "../lib/messages/query"
 import { mkdtempSync, rmSync } from "node:fs"
 import { join } from "node:path"
@@ -180,7 +181,7 @@ function setupPipeline(
     const logger = new Logger(false)
     const handler = createChatMessageTransformHandler(
         createMockClient(),
-        state,
+        createTestRegistry(state),
         logger,
         config,
         createMockPrompts(),
@@ -410,7 +411,7 @@ test("tool error pruning: error tool inputs are preserved (prefix cache fix)", a
 
 // ─── Test: Session switch resets state ──────────────────────────────────────
 
-test("session switch: state is reinitialized when session changes", async () => {
+test("session switch: each session keeps its own state (no cross-session reset)", async () => {
     const { state, handler } = setupPipeline(SID_A)
 
     // First call with session A
@@ -426,8 +427,9 @@ test("session switch: state is reinitialized when session changes", async () => 
     assert.equal(state.messageIds.byRawId.get("u1a"), "m00001")
     assert.equal(state.messageIds.byRawId.get("a1a"), "m00002")
 
-    // Second call with a DIFFERENT session (session B)
-    // checkSession detects the change and reinitializes
+    // Second call with a DIFFERENT session (session B).
+    // Per-session state (#33): session B resolves its own state; session A is
+    // left untouched instead of being reset by the shared singleton.
     const output2 = {
         messages: [
             makeUserMessage("u1b", "Hello B", SID_B),
@@ -436,15 +438,10 @@ test("session switch: state is reinitialized when session changes", async () => 
     }
     await handler({}, output2)
 
-    // Session should have switched
-    assert.equal(state.sessionId, SID_B)
-
-    // Old message IDs should be cleared (state reset on session switch)
-    assert.equal(state.messageIds.byRawId.has("u1a"), false, "old session IDs should be cleared")
-
-    // New session gets fresh IDs
-    assert.equal(state.messageIds.byRawId.get("u1b"), "m00001")
-    assert.equal(state.messageIds.byRawId.get("a1b"), "m00002")
+    // Session A's state is preserved, not reset by session B's activity
+    assert.equal(state.sessionId, SID_A)
+    assert.equal(state.messageIds.byRawId.get("u1a"), "m00001", "session A IDs preserved")
+    assert.equal(state.messageIds.byRawId.get("a1a"), "m00002")
 })
 
 // ─── Test: Message IDs injected into tool parts ─────────────────────────────

--- a/tests/e2e-message-transform.test.ts
+++ b/tests/e2e-message-transform.test.ts
@@ -23,6 +23,7 @@ import { isSyntheticMessage } from "../lib/messages/query"
 import { mkdtempSync, rmSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
+import { createTestRegistry } from "./registry-stub"
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -185,7 +186,7 @@ function setupPipeline(stateOverrides: Partial<SessionState> = {}) {
 
     const handler = createChatMessageTransformHandler(
         client,
-        state,
+        createTestRegistry(state),
         logger,
         config,
         prompts,
@@ -748,7 +749,7 @@ test("deny permission: still filters messages and strips hallucinations", async 
     const logger = new Logger(false)
     const handler = createChatMessageTransformHandler(
         createMockClient(),
-        state,
+        createTestRegistry(state),
         logger,
         config,
         createMockPrompts(),

--- a/tests/hooks-permission.test.ts
+++ b/tests/hooks-permission.test.ts
@@ -14,6 +14,7 @@ import {
     saveSessionState,
     type WithParts,
 } from "../lib/state"
+import { createTestRegistry } from "./registry-stub"
 
 function buildConfig(permission: "allow" | "ask" | "deny" = "allow"): PluginConfig {
     return {
@@ -100,7 +101,7 @@ test("chat message transform strips hallucinated tags even when compress is deni
     const config = buildConfig("deny")
     const handler = createChatMessageTransformHandler(
         { session: { get: async () => ({}) } } as any,
-        state,
+        createTestRegistry(state),
         logger,
         config,
         {
@@ -127,7 +128,7 @@ test("chat message transform drops messages without info instead of crashing", a
     const config = buildConfig("deny")
     const handler = createChatMessageTransformHandler(
         { session: { get: async () => ({}) } } as any,
-        state,
+        createTestRegistry(state),
         logger,
         config,
         {
@@ -171,7 +172,7 @@ test("command execute exits after effective permission resolves to deny", async 
                 },
             },
         } as any,
-        createSessionState(),
+        createTestRegistry(createSessionState()),
         new Logger(false),
         buildConfig("deny"),
         "/tmp",
@@ -196,7 +197,7 @@ test("text complete strips hallucinated metadata tags", async () => {
 test("event hook attaches durations to matching blocks by message and call id", async () => {
     const state = createSessionState()
     state.sessionId = "session-1"
-    const handler = createEventHandler(state, new Logger(false))
+    const handler = createEventHandler(createTestRegistry(state), new Logger(false))
     const originalNow = Date.now
     Date.now = () => 100
 
@@ -389,7 +390,7 @@ test("event hook attaches durations to matching blocks by message and call id", 
 test("event hook falls back to completed runtime when running duration missing", async () => {
     const state = createSessionState()
     state.sessionId = "session-1"
-    const handler = createEventHandler(state, new Logger(false))
+    const handler = createEventHandler(createTestRegistry(state), new Logger(false))
 
     state.prune.messages.blocksById.set(1, {
         blockId: 1,
@@ -480,7 +481,7 @@ test("event hook queues duration updates until the matching session is loaded", 
 
     const liveState = createSessionState()
     liveState.sessionId = otherSessionId
-    const handler = createEventHandler(liveState, logger)
+    const handler = createEventHandler(createTestRegistry(liveState), logger)
 
     await handler({
         event: {
@@ -560,7 +561,7 @@ test("event hook queues duration updates until the matching session is loaded", 
 test("event hook keeps same call id distinct across message ids", async () => {
     const state = createSessionState()
     state.sessionId = "session-1"
-    const handler = createEventHandler(state, new Logger(false))
+    const handler = createEventHandler(createTestRegistry(state), new Logger(false))
 
     state.prune.messages.blocksById.set(1, {
         blockId: 1,

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -448,6 +448,66 @@ test("voluntary compress (no nudge shown) does NOT reset baseline", () => {
     assert.equal(state.nudges.compressBaselineSet, false, "lock NOT set for voluntary compress")
 })
 
+test("baseline initialized to 0 on first transform, not currentTokens (issue #33 regression)", () => {
+    // REGRESSION: lastPerMessageNudgeTokens was initialized to currentTokens
+    // (~55K, includes system prompt). This made the effective first-nudge
+    // threshold ~105K (10.5% of 1M) instead of ~50K (5%). The nudge never
+    // fired at 5% context, so the model never compressed voluntarily.
+    //
+    // FIX: initialize to 0 so growth is measured from session start.
+    //
+    // WHY EXISTING TESTS MISSED THIS: every other test in this file manually
+    // sets lastPerMessageNudgeTokens before calling injectCompressNudges,
+    // bypassing the initialization path entirely.
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    assert.equal(
+        state.nudges.lastPerMessageNudgeTokens,
+        undefined,
+        "fresh state has undefined baseline — no growth tracking yet",
+    )
+
+    const config = buildConfig()
+    config.compress.maxContextLimit = 500_000
+    config.compress.minContextLimit = 200_000
+
+    // Turn 1: first message transform. currentTokens = 55K (input 50K + output 5K).
+    // Baseline is undefined → gets initialized. No nudge fires (baseline establishment).
+    const messages1: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "work", { input: 50_000, output: 5_000 }),
+    ]
+    injectCompressNudges(state, config, logger, messages1, {} as any)
+
+    // THE CRITICAL ASSERTION: baseline must be 0, NOT 55K (currentTokens).
+    // With the old bug, this would be 55_000, making the next nudge threshold 105K.
+    assert.equal(
+        state.nudges.lastPerMessageNudgeTokens,
+        0,
+        "baseline initialized to 0 — growth measured from session start, not from first-turn absolute tokens",
+    )
+    assert.equal(
+        state.nudges.shouldInjectThisTurn,
+        false,
+        "first turn never nudges — baseline establishment only",
+    )
+
+    // Turn 2: context grew slightly to 58K. Growth from baseline 0 = 58K > 50K threshold.
+    // Nudge MUST fire at ~5.8% context. With the old bug (baseline=55K), growth
+    // would be 58K-55K=3K < 50K → nudge suppressed → model never compresses voluntarily.
+    const messages2: WithParts[] = [
+        userMsg("u2", "more"),
+        assistantMsgWithTokens("a2", "work", { input: 53_000, output: 5_000 }),
+    ]
+    injectCompressNudges(state, config, logger, messages2, {} as any)
+
+    assert.equal(
+        state.nudges.shouldInjectThisTurn,
+        true,
+        "58K growth from baseline 0 (>= 50K nudgeGrowthTokens) → nudge fires at ~5.8% — the bug suppressed this",
+    )
+})
+
 test("nudge threshold restores to full after compress (issue #23)", () => {
     const state = createSessionState()
     state.modelContextLimit = 1_000_000

--- a/tests/protected-tool-exclusion.test.ts
+++ b/tests/protected-tool-exclusion.test.ts
@@ -8,6 +8,7 @@ import { createCompressMessageTool } from "../lib/compress/message"
 import { createSessionState, type WithParts } from "../lib/state"
 import type { PluginConfig } from "../lib/config"
 import { Logger } from "../lib/logger"
+import { singletonRegistry } from "./registry-stub"
 import {
     messageContainsProtectedTool,
     filterProtectedToolMessages,
@@ -198,7 +199,7 @@ function buildRangeToolCtx(config: PluginConfig, rawMessages: WithParts[], state
                 get: async () => ({ data: { parentID: null } }),
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger,
         config,
         prompts: {
@@ -219,7 +220,7 @@ function buildMessageToolCtx(config: PluginConfig, rawMessages: WithParts[], sta
                 get: async () => ({ data: { parentID: null } }),
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger,
         config,
         prompts: {

--- a/tests/quality-gate-enforcement.test.ts
+++ b/tests/quality-gate-enforcement.test.ts
@@ -13,6 +13,7 @@ import { createSessionState, resetSessionState, type WithParts } from "../lib/st
 import type { PluginConfig } from "../lib/config"
 import type { QualityGateResult } from "../lib/compress/quality-gate/types"
 import { Logger } from "../lib/logger"
+import { singletonRegistry } from "./registry-stub"
 
 const testDataHome = join(tmpdir(), `opencode-acp-qg-tests-${process.pid}`)
 const testConfigHome = join(tmpdir(), `opencode-acp-qg-config-tests-${process.pid}`)
@@ -321,7 +322,7 @@ function buildToolContext(state: ReturnType<typeof createSessionState>, config: 
                 get: async () => ({ data: { parentID: null } }),
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger: new Logger(false),
         config,
         prompts: {

--- a/tests/recap.test.ts
+++ b/tests/recap.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 import { createAcpContextRecapTool } from "../lib/compress/recap"
-import type { ToolContext } from "../lib/compress/types"
+import type { ToolFactoryContext } from "../lib/compress/types"
 import type { CompressionBlock, PrunedMessageEntry, SessionState } from "../lib/state/types"
+import { singletonRegistry } from "./registry-stub"
 
 const SID = "session-recap-test"
 
@@ -82,10 +83,10 @@ function makeState(activeIds: number[], blocks: Map<number, CompressionBlock>): 
 function makeToolContext(
     activeIds: number[],
     blocks: Map<number, CompressionBlock>,
-): ToolContext {
+): ToolFactoryContext {
     return {
         client: {},
-        state: makeState(activeIds, blocks),
+        registry: singletonRegistry(makeState(activeIds, blocks)),
         logger: { enabled: false } as any,
         config: {} as any,
         prompts: { reload: () => {} } as any,

--- a/tests/registry-stub.ts
+++ b/tests/registry-stub.ts
@@ -1,0 +1,56 @@
+import { createSessionState, type SessionState } from "../lib/state"
+
+// Test helper: builds a SessionStateRegistry stub that resolves any sessionID
+// to a single state. Compress-tool unit tests operate on one state per test, so
+// this matches the registry.get() surface that resolveToolContext calls.
+export function singletonRegistry(state: SessionState): {
+    get: (sessionId: string) => SessionState | undefined
+    all: () => SessionState[]
+    size: number
+    compressionTiming: SessionState["compressionTiming"]
+} {
+    return {
+        get: () => state,
+        all: () => [state],
+        get size() {
+            return 1
+        },
+        compressionTiming: state.compressionTiming,
+    }
+}
+
+// Test helper: Map-backed registry for hook-handler tests. getOrCreate()
+// returns the seeded state for its session and lazily creates fresh states
+// for other sessionIDs (e.g. session-switch tests).
+export function createTestRegistry(seedState: SessionState) {
+    const states = new Map<string, SessionState>()
+    if (seedState.sessionId) {
+        states.set(seedState.sessionId, seedState)
+    }
+    const sharedTiming = seedState.compressionTiming
+    return {
+        compressionTiming: sharedTiming,
+        get size() {
+            return states.size
+        },
+        get(sid: string) {
+            return states.get(sid)
+        },
+        async getOrCreate(
+            _client: unknown,
+            sid: string,
+        ): Promise<SessionState> {
+            let s = states.get(sid)
+            if (!s) {
+                s = createSessionState()
+                s.sessionId = sid
+                s.compressionTiming = sharedTiming
+                states.set(sid, s)
+            }
+            return s
+        },
+        all() {
+            return [...states.values()]
+        },
+    }
+}

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for the real SessionStateRegistry (not the test stub).
+ *
+ * Covers the acceptance criteria from devlog/2026-07-24_per-session-state/REQ.md:
+ *   - getOrCreate idempotency
+ *   - per-session isolation of modelContextLimit (the #33 fix)
+ *   - shared compressionTiming across sessions
+ *   - soft-cap eviction + reload from persisted JSON
+ */
+
+import assert from "node:assert/strict"
+import test, { beforeEach, afterEach } from "node:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { SessionStateRegistry, saveSessionState, type WithParts } from "../lib/state"
+import { Logger } from "../lib/logger"
+
+function makeClient(): any {
+    return { session: { get: async () => ({ data: { parentID: null } }) } }
+}
+
+const MESSAGES: WithParts[] = []
+const MANUAL_MODE = false
+
+let tempDir: string
+let prevData: string | undefined
+let prevConfig: string | undefined
+
+beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "acp-registry-"))
+    prevData = process.env.XDG_DATA_HOME
+    prevConfig = process.env.XDG_CONFIG_HOME
+    process.env.XDG_DATA_HOME = tempDir
+    process.env.XDG_CONFIG_HOME = tempDir
+})
+
+afterEach(() => {
+    if (prevData === undefined) delete process.env.XDG_DATA_HOME
+    else process.env.XDG_DATA_HOME = prevData
+    if (prevConfig === undefined) delete process.env.XDG_CONFIG_HOME
+    else process.env.XDG_CONFIG_HOME = prevConfig
+    rmSync(tempDir, { recursive: true, force: true })
+})
+
+test("getOrCreate is idempotent: same sessionId returns the same state without re-init", async () => {
+    const registry = new SessionStateRegistry(new Logger(false))
+    const first = await registry.getOrCreate(makeClient(), "session-1", MESSAGES, MANUAL_MODE)
+    assert.equal(first.sessionId, "session-1")
+    first.modelContextLimit = 200000
+
+    const second = await registry.getOrCreate(makeClient(), "session-1", MESSAGES, MANUAL_MODE)
+    assert.equal(second, first)
+    assert.equal(second.modelContextLimit, 200000)
+    assert.equal(registry.size, 1)
+})
+
+test("per-session isolation: modelContextLimit set on session A survives session B init", async () => {
+    const registry = new SessionStateRegistry(new Logger(false))
+    const a = await registry.getOrCreate(makeClient(), "session-A", MESSAGES, MANUAL_MODE)
+    a.modelContextLimit = 200000
+
+    const b = await registry.getOrCreate(makeClient(), "session-B", MESSAGES, MANUAL_MODE)
+
+    assert.notEqual(a, b)
+    assert.equal(a.modelContextLimit, 200000)
+    assert.equal(b.modelContextLimit, undefined)
+    assert.equal(registry.size, 2)
+})
+
+test("compressionTiming is the same shared object across all sessions", async () => {
+    const registry = new SessionStateRegistry(new Logger(false))
+    const a = await registry.getOrCreate(makeClient(), "session-A", MESSAGES, MANUAL_MODE)
+    const b = await registry.getOrCreate(makeClient(), "session-B", MESSAGES, MANUAL_MODE)
+
+    assert.equal(a.compressionTiming, registry.compressionTiming)
+    assert.equal(b.compressionTiming, registry.compressionTiming)
+
+    a.compressionTiming.startsByCallId.set("message-1:call-1", 100)
+    assert.equal(b.compressionTiming.startsByCallId.get("message-1:call-1"), 100)
+})
+
+test("soft-cap eviction drops the oldest session; reload restores persisted modelContextLimit", async () => {
+    const logger = new Logger(false)
+    const registry = new SessionStateRegistry(logger)
+
+    const first = await registry.getOrCreate(makeClient(), "session-0", MESSAGES, MANUAL_MODE)
+    first.modelContextLimit = 200000
+    await saveSessionState(first, logger)
+
+    for (let i = 1; i <= 32; i++) {
+        await registry.getOrCreate(makeClient(), `session-${i}`, MESSAGES, MANUAL_MODE)
+    }
+
+    assert.equal(registry.get("session-0"), undefined)
+    assert.equal(registry.size, 32)
+
+    const reloaded = await registry.getOrCreate(makeClient(), "session-0", MESSAGES, MANUAL_MODE)
+    assert.equal(reloaded.modelContextLimit, 200000)
+})

--- a/tests/search-context.test.ts
+++ b/tests/search-context.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 import { createSearchContextTool } from "../lib/compress/search"
-import type { ToolContext } from "../lib/compress/types"
+import type { ToolFactoryContext } from "../lib/compress/types"
 import type { CompressionBlock, PrunedMessageEntry, SessionState } from "../lib/state/types"
+import { singletonRegistry } from "./registry-stub"
 
 // --- Factory helpers ---
 
@@ -81,10 +82,10 @@ function makeState(blocks: Map<number, CompressionBlock>): SessionState {
     }
 }
 
-function makeToolContext(blocks: Map<number, CompressionBlock>): ToolContext {
+function makeToolContext(blocks: Map<number, CompressionBlock>): ToolFactoryContext {
     return {
         client: {},
-        state: makeState(blocks),
+        registry: singletonRegistry(makeState(blocks)),
         logger: { enabled: false } as any,
         config: {} as any,
         prompts: { reload: () => {} } as any,

--- a/tests/soft-block.test.ts
+++ b/tests/soft-block.test.ts
@@ -4,6 +4,7 @@ import { createCompressRangeTool } from "../lib/compress/range"
 import { createSessionState, type WithParts } from "../lib/state"
 import type { PluginConfig } from "../lib/config"
 import { Logger } from "../lib/logger"
+import { singletonRegistry } from "./registry-stub"
 
 const testDataHome = `/tmp/opencode-dcp-dangerous-${process.pid}`
 process.env.XDG_DATA_HOME = testDataHome
@@ -102,7 +103,7 @@ function createTool(state: any, rawMessages: WithParts[], sessionID: string, con
                 get: async () => ({ data: { parentID: null } }),
             },
         },
-        state,
+        registry: singletonRegistry(state),
         logger: new Logger(false),
         config,
         prompts: {


### PR DESCRIPTION
## Summary

Dev prerelease for testing before stable v1.14.0. Contains two major fixes from issue #33:

### 1. Per-Session State Registry
- **Problem**: Interleaved subagent sessions shared a single `SessionState` singleton. Subagent `modelContextLimit` was lost because `resetSessionState` cleared it before it could be persisted, causing `nudgeGrowthTokens` to collapse from 50K to 6K → over-compression at 4.9%.
- **Fix**: `SessionStateRegistry` — `Map<sessionId, SessionState>` with soft cap 32 + oldest-first eviction. All hook handlers and compress tools resolve state per-call.

### 2. Nudge Baseline Initialization Fix (issue #33)
- **Problem**: `lastPerMessageNudgeTokens` initialized to `currentTokens` (~55K, includes system prompt) instead of 0 → effective first-nudge threshold was ~105K (10.5%), not ~50K (5%). Model never compressed voluntarily → context grew to 330K.
- **Fix**: Initialize to `0`. First nudge now fires at ~5% context.
- **Regression test**: `tests/inject.test.ts` — verified to FAIL with bug reverted, PASS with fix.

## Test plan
- [x] 848 tests pass
- [x] Build clean (dist/index.js 434.74 KB)
- [x] CI check-pr.sh all passed
- [x] Deployed locally and verified bundle contains the fix

## Prerelease
Version `1.14.0-dev.1` contains `-` → CI will publish with `--tag dev` + mark as GitHub prerelease.

Install: `opencode plugin opencode-acp@dev --global`