### PR TITLE
release: v1.13.7-dev.1 — sync dev tag with master

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.13.7-dev.1 — Dev Prerelease Sync (master @ v1.13.6)
+
+**Purpose**: Sync the `dev` npm tag (stuck at `1.12.10-dev.1`) with current master. The `dev` tag had fallen far behind `latest` (1.13.6), making it impossible for early adopters to test the latest fixes via `opencode-acp@dev`.
+
+**Content**: Identical to v1.13.6 stable (master HEAD `5d67b84`). No new code changes. This is a dev-tag-only release to bring `opencode-acp@dev` up to parity with `opencode-acp@latest`.
+
+Files: `package.json`, `README.md`, `README.zh-CN.md`. 846 tests pass (no source changes).
+
 ### v1.13.6 — Force-Protect Compress Tool Regardless of User Config (PR #188)
 
 **Problem**: `compress.protectedTools` uses a replace merge policy (PR #177): a user setting `protectedTools: ["skill"]` or `protectedTools: []` silently removed `"compress"` from the protected list. This made compress summaries — the sole record of compressed conversation — vulnerable to being pruned by subsequent sequential compressions, causing irreversible data loss.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -443,6 +443,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.13.7-dev.1 — Dev 预发布同步（master @ v1.13.6）
+
+**目的**：将 npm `dev` 标签（卡在 `1.12.10-dev.1`）同步到当前 master。`dev` 标签已远远落后于 `latest`（1.13.6），导致早期采用者无法通过 `opencode-acp@dev` 测试最新修复。
+
+**内容**：与 v1.13.6 稳定版完全相同（master HEAD `5d67b84`）。无新代码变更。仅为 dev 标签发布，使 `opencode-acp@dev` 与 `opencode-acp@latest` 保持一致。
+
+文件：`package.json`、`README.md`、`README.zh-CN.md`。846 项测试通过（无源码变更）。
+
 ### v1.13.6 — 强制保护 compress 工具，无视用户配置（PR #188）
 
 **问题**：`compress.protectedTools` 使用替换式合并策略（PR #177）：用户设置 `protectedTools: ["skill"]` 或 `protectedTools: []` 会静默地从保护列表中移除 `"compress"`。这使得 compress 摘要 — 压缩对话的唯一记录 — 容易被后续的顺序压缩裁剪，导致不可恢复的数据丢失。

--- a/devlog/2026-07-25_release-v1.13.7-dev.1/REQ.md
+++ b/devlog/2026-07-25_release-v1.13.7-dev.1/REQ.md
@@ -1,0 +1,28 @@
+# REQ — v1.13.7-dev.1 Dev Prerelease
+
+## Goal
+
+Publish current master (v1.13.6) as a dev prerelease to advance the npm `dev`
+tag, which is stuck at `1.12.10-dev.1` — far behind `latest` (1.13.6).
+
+## Background
+
+The `dev` tag lets early adopters opt into unreleased changes via
+`opencode-acp@dev`. It hasn't been updated since `1.12.10-dev.1`, so it's missing
+all v1.13.x changes (quality gate, compress protection, CI fixes, force-protect).
+
+## Scope
+
+- Bump `package.json` version to `1.13.7-dev.1` (contains hyphen → CI uses `--tag dev`)
+- Add changelog entries to both READMEs
+- Create devlog
+- No source code changes
+
+## Acceptance Criteria
+
+- [x] Version set to `1.13.7-dev.1`
+- [x] Changelog entries added
+- [x] Devlog created
+- [ ] CI check passes
+- [ ] PR created
+- [ ] After merge: npm `dev` tag points to `1.13.7-dev.1`

--- a/devlog/2026-07-25_release-v1.13.7-dev.1/WORKLOG.md
+++ b/devlog/2026-07-25_release-v1.13.7-dev.1/WORKLOG.md
@@ -1,0 +1,23 @@
+# WORKLOG — v1.13.7-dev.1 Dev Prerelease
+
+## Steps
+
+1. **Checked npm tags**: `latest` = 1.13.6, `dev` = 1.12.10-dev.1 (stale).
+2. **Created worktree**: `/home/dog/projects/opencode-acp-dev-1.13.7`, branch `2026-07-25_release-v1.13.7-dev.1`, based on `github/master` at `5d67b84` (v1.13.6 merged).
+3. **Bumped version**: `package.json` 1.13.6 → `1.13.7-dev.1`.
+4. **Added changelog**: `### v1.13.7-dev.1` entry to both READMEs explaining this is a dev-tag sync.
+5. **Created devlog**: REQ.md + WORKLOG.md.
+6. **Verification**: typecheck + test + build (pending CI check).
+7. **Commit + push + PR** (pending).
+
+## Why 1.13.7-dev.1
+
+- `1.13.6-dev.1` would be semver-lower than the already-published `1.13.6` stable.
+- `1.13.7-dev.1` signals "ahead of stable 1.13.6, prerelease of what becomes 1.13.7".
+- The hyphen triggers CI to use `--tag dev` and mark GitHub Release as prerelease.
+
+## No Source Changes
+
+This release contains zero source code changes. It is purely a version bump to
+advance the npm `dev` tag. All v1.13.x features (quality gate, compress
+protection, force-protect, CI fixes) are already on master.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-acp",
-    "version": "1.13.6",
+    "version": "1.13.7-dev.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-acp",
-            "version": "1.13.6",
+            "version": "1.13.7-dev.1",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.13.6",
+    "version": "1.13.7-dev.1",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

**Dev prerelease** to advance the npm `dev` tag (stuck at `1.12.10-dev.1`) to current master (v1.13.6).

### Why

The `dev` tag is far behind `latest`:

| Tag | Version |
|-----|---------|
| `latest` | 1.13.6 |
| `dev` | 1.12.10-dev.1 ← stale |

Early adopters using `opencode-acp@dev` are missing all v1.13.x changes (quality gate, compress protection, CI fixes, force-protect).

### What changed

- **No source code changes.** Identical to v1.13.6 stable (master HEAD `5d67b84`).
- Version bump: `1.13.6` → `1.13.7-dev.1`
- Changelog entries added to both READMEs
- Devlog created

### Why 1.13.7-dev.1

- Version contains hyphen (`-`) → CI detects prerelease → publishes with `--tag dev` + marks GitHub Release as `prerelease: true`
- `1.13.7` base signals "ahead of stable 1.13.6"
- When v1.13.7 stable is eventually released, it will replace `dev` on the `latest` tag; dev can then move to the next prerelease

### Verification

- `npm run typecheck` ✅
- `npm test` — 846 tests pass ✅
- `npm run build` ✅
- `./scripts/ci/check-pr.sh` — all checks pass ✅

### After merge

CI detects `YYYY-MM-DD_release-v*` branch merge → reads version `1.13.7-dev.1` → sees hyphen → publishes with `--tag dev` → creates **prerelease** GitHub Release.

Install with: `opencode plugin opencode-acp@dev --global`

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)