### PR TITLE
test: E2E scenario for subagent compression

### DIFF
--- a/devlog/2026-07-23_subagent-e2e-test/REQ.md
+++ b/devlog/2026-07-23_subagent-e2e-test/REQ.md
@@ -1,0 +1,30 @@
+# REQ: E2E Test for Subagent Compression
+
+## Problem
+
+PR #180 (remove subagent history rewriting) deleted a feature. Need to verify
+that ACP compression inside subagent sessions still works correctly.
+
+## Goal
+
+Add an E2E test scenario that:
+1. Spawns a child session via the `task` tool
+2. Accumulates compressible messages inside the child
+3. Calls `compress` inside the child
+4. Verifies the child session's ACP state has a compression block
+
+## Acceptance Criteria
+
+- All 5 E2E scenarios pass (4 existing + 1 new)
+- Parent session has 0 blocks (parent doesn't compress)
+- Child session has 1 block (child compresses successfully)
+- No changes to production code (`lib/`) required
+
+## Technical Approach
+
+- OpenCode sends `x-parent-session-id` HTTP header only on child session LLM
+  requests — the fake LLM uses this to distinguish parent vs child
+- Child session routing: separate turn counter, scenario `subagent_turns` array
+- `extractMessageText` must also search `tool_calls[].function.arguments`
+  because ACP injects `<dcp-message-id>` tags into tool-call-only assistant
+  messages (not text content)

--- a/devlog/2026-07-23_subagent-e2e-test/WORKLOG.md
+++ b/devlog/2026-07-23_subagent-e2e-test/WORKLOG.md
@@ -1,0 +1,52 @@
+# WORKLOG: Subagent E2E Compression Test
+
+## Iteration 1 — 2026-07-23
+
+### Investigation
+
+- Confirmed OpenCode sends `x-parent-session-id` header on child session LLM
+  requests (from OpenCode source `session/llm/request.ts:187-205`)
+- Probe experiment confirmed `task` tool creates child sessions with `parentID`
+- ACP's `assignMessageRefs` and `injectMessageIds` work correctly in subagent
+  sessions when `experimental.allowSubAgents: true`
+
+### Implementation
+
+**`scripts/e2e/fake-llm-server.ts`**:
+- Added `task` and `tool` response types to `ScenarioStep`
+- Child detection via `x-parent-session-id` header
+- `handleChildRequest()`: routes child turns from `subagent_turns` array
+- `handleTaskStep()`: emits `task` tool_use call
+- `toolUseResponse()`: generic SSE streaming for arbitrary tool names
+- Fixed `extractMessageText` to search `tool_calls[].function.arguments`
+  (ACP injects `<dcp-message-id>` tags into tool-call-only assistant messages)
+
+**`scripts/e2e/scenarios/05-subagent-compress.json`**:
+- Parent turn: emit `task` with `subagent_type: "general"`
+- Child turns: 3× bash (accumulate content) → compress (m00001-m00003) → text
+- Verify: `blockCount: 0, childBlockCount: 1`
+
+**`scripts/e2e/run-e2e.sh`**:
+- Added `agent.general` definition to opencode.json
+- Added `task`/`bash` permissions
+- Added `experimental.allowSubAgents: true` to acp.jsonc
+- Pass `ACP_DIR` to verify.ts for child state discovery
+
+**`scripts/e2e/verify.ts`**:
+- Added `childBlockCount` assertion
+- Discovers child state files by scanning ACP directory
+
+### Verification
+
+```
+E2E RESULTS: 5 passed, 0 failed
+```
+
+Child compress log confirms: `found 3 mNNNNN refs: m00001..m00003` →
+`compress: m00001..m00003, summary=647 chars, ack=true`
+
+### Key Finding
+
+ACP's production code (`lib/hooks.ts`, `lib/message-ids.ts`) requires NO changes
+for subagent compression — existing code handles it correctly when
+`allowSubAgents: true` is set.

--- a/scripts/e2e/fake-llm-server.ts
+++ b/scripts/e2e/fake-llm-server.ts
@@ -33,7 +33,7 @@ if (!SCENARIO_PATH) {
 }
 
 interface ScenarioStep {
-    respond: "text" | "compress"
+    respond: "text" | "compress" | "task" | "tool"
     text?: string
     summary?: string
     topic?: string
@@ -48,6 +48,15 @@ interface ScenarioStep {
     range?: "all" | [number, number]
     /** For batch compress: multiple ranges */
     ranges?: Array<{ summary: string; topic?: string; range?: "all" | [number, number] }>
+    /** For task: subagent spawn parameters */
+    description?: string
+    prompt?: string
+    subagent_type?: string
+    /** For task: turns the spawned subagent session will execute */
+    subagent_turns?: ScenarioStep[]
+    /** For tool: arbitrary tool_use call */
+    tool?: string
+    toolArgs?: Record<string, unknown>
 }
 
 interface Scenario {
@@ -59,6 +68,21 @@ interface Scenario {
 const scenario: Scenario = JSON.parse(readFileSync(SCENARIO_PATH, "utf-8"))
 
 process.stderr.write(`[fake-llm] scenario: ${scenario.name} (${scenario.turns.length} turns)\n`)
+
+const CHILD_TURN_COUNTER = TURN_COUNTER + "-child"
+
+function readChildTurnCounter(): number {
+    if (existsSync(CHILD_TURN_COUNTER)) {
+        return parseInt(readFileSync(CHILD_TURN_COUNTER, "utf-8").trim(), 10) || 0
+    }
+    return 0
+}
+
+function incrementChildTurnCounter(): number {
+    const current = readChildTurnCounter()
+    writeFileSync(CHILD_TURN_COUNTER, String(current + 1))
+    return current
+}
 
 // --- HTTP server ---
 
@@ -120,22 +144,27 @@ async function handleChatCompletion(req: Request): Promise<Response> {
     const isStream: boolean = body?.stream === true
     const model: string = body?.model ?? "fake-model"
 
+    const parentSessionId = req.headers.get("x-parent-session-id")
+    const sessionId = req.headers.get("x-session-id") ?? "unknown"
+    const isChild = !!parentSessionId
+
     const lastMsg = messages[messages.length - 1]
     const lastRole = lastMsg?.role
 
     log(
         `  body: stream=${isStream} msgs=${messages.length} ` +
-            `lastRole=${lastRole} tools=${tools.length}`,
+            `lastRole=${lastRole} tools=${tools.length}${isChild ? " [CHILD]" : ""}`,
     )
 
-    // Auxiliary calls (e.g., opencode title generation) have tools=0.
-    // Respond with generic text without consuming a scenario turn.
     if (tools.length === 0) {
         log("  → auxiliary call (tools=0), emitting generic text")
         return textResponse(model, "Session summary.", isStream)
     }
 
-    // After a tool result (role=tool), emit text acknowledgment.
+    if (isChild) {
+        return handleChildRequest(model, messages, lastRole, lastMsg, isStream)
+    }
+
     if (lastRole === "tool" || lastRole === "function") {
         const toolText = extractMessageText(lastMsg)
         if (toolText.includes("QUALITY GATE FAILURE") || toolText.includes("COMPRESSION REJECTED")) {
@@ -177,6 +206,10 @@ async function handleChatCompletion(req: Request): Promise<Response> {
     }
 
     log(`  → turn ${turnIdx + 1}: respond=${step.respond}`)
+
+    if (step.respond === "task") {
+        return handleTaskStep(model, step, isStream)
+    }
 
     if (step.respond === "compress") {
         return handleCompressStep(model, messages, step, isStream)
@@ -252,6 +285,78 @@ function handleCompressStep(
     return compressResponse(model, { content }, step.acknowledgeRisk ?? false, isStream)
 }
 
+function handleChildRequest(
+    model: string,
+    messages: any[],
+    lastRole: string | undefined,
+    lastMsg: any,
+    isStream: boolean,
+): Response {
+    const taskStep = scenario.turns.find((t) => t.respond === "task")
+    const childTurns = taskStep?.subagent_turns ?? []
+
+    if (lastRole === "tool" || lastRole === "function") {
+        const toolText = extractMessageText(lastMsg)
+        if (toolText.includes("QUALITY GATE FAILURE") || toolText.includes("COMPRESSION REJECTED")) {
+            const idx = readChildTurnCounter() - 1
+            const step = childTurns[idx]
+            if (step?.retryOnReject) {
+                const refs = parseMessageRefs(messages)
+                const [startId, endId] = resolveRange(refs, step.range ?? "all")
+                log(`  → [CHILD] retrying compress with acknowledgeRisk`)
+                return compressResponse(
+                    model,
+                    {
+                        content: [
+                            {
+                                topic: step.retryOnReject.topic ?? "Retry",
+                                startId,
+                                endId,
+                                summary: step.retryOnReject.summary,
+                            },
+                        ],
+                    },
+                    step.retryOnReject.acknowledgeRisk ?? true,
+                    isStream,
+                )
+            }
+        }
+    }
+
+    const turnIdx = incrementChildTurnCounter()
+    const step = childTurns[turnIdx]
+
+    if (!step) {
+        log(`  → [CHILD] turn ${turnIdx + 1}: no step, emitting default text`)
+        return textResponse(model, "Task complete.", isStream)
+    }
+
+    log(`  → [CHILD] turn ${turnIdx + 1}: respond=${step.respond}`)
+
+    if (step.respond === "compress") {
+        return handleCompressStep(model, messages, step, isStream)
+    }
+
+    if (step.respond === "tool") {
+        const toolName = step.tool ?? "bash"
+        log(`  → [CHILD] emitting ${toolName} tool call`)
+        return toolUseResponse(model, toolName, step.toolArgs ?? {}, isStream)
+    }
+
+    return textResponse(model, step.text ?? "Done.", isStream)
+}
+
+function handleTaskStep(model: string, step: ScenarioStep, isStream: boolean): Response {
+    const args: Record<string, unknown> = {
+        description: step.description ?? "E2E subagent task",
+        prompt: step.prompt ?? "Complete the assigned task.",
+        subagent_type: step.subagent_type ?? "general",
+    }
+
+    log(`  → emitting task tool call (subagent_type=${args.subagent_type})`)
+    return toolUseResponse(model, "task", args, isStream)
+}
+
 /**
  * Parse <dcp-message-id ...>mNNNNN</dcp-message-id> tags from all messages.
  * Returns an ordered list of unique refs (m00001, m00002, ...).
@@ -278,18 +383,24 @@ function parseMessageRefs(messages: any[]): string[] {
 }
 
 function extractMessageText(msg: any): string {
-    if (typeof msg?.content === "string") return msg.content
-    if (Array.isArray(msg?.content)) {
-        return msg.content
-            .map((part: any) => {
-                if (typeof part === "string") return part
-                if (part?.text) return part.text
-                if (part?.content) return part.content
-                return ""
-            })
-            .join("")
+    const parts: string[] = []
+    if (typeof msg?.content === "string") {
+        parts.push(msg.content)
+    } else if (Array.isArray(msg?.content)) {
+        for (const part of msg.content) {
+            if (typeof part === "string") parts.push(part)
+            else if (part?.text) parts.push(part.text)
+            else if (part?.content) parts.push(part.content)
+        }
     }
-    return ""
+    // ACP injects <dcp-message-id> tags into tool_calls arguments for
+    // assistant messages that contain tool calls (no text content).
+    if (Array.isArray(msg?.tool_calls)) {
+        for (const tc of msg.tool_calls) {
+            if (tc?.function?.arguments) parts.push(String(tc.function.arguments))
+        }
+    }
+    return parts.join("")
 }
 
 /**
@@ -385,6 +496,54 @@ function compressResponse(
     return sseStream(
         model,
         [{ type: "tool_use", toolName: "compress", callId, args: argsJson }],
+        usage,
+    )
+}
+
+function toolUseResponse(
+    model: string,
+    toolName: string,
+    args: Record<string, unknown>,
+    isStream: boolean,
+): Response {
+    const argsJson = JSON.stringify(args)
+    const callId = `call_${crypto.randomUUID().replace(/-/g, "").slice(0, 24)}`
+    const usage = {
+        prompt_tokens: Math.max(1, Math.ceil(argsJson.length / 4)),
+        completion_tokens: Math.max(1, Math.ceil(argsJson.length / 4)),
+        total_tokens: Math.max(2, Math.ceil(argsJson.length / 2)),
+    }
+
+    if (!isStream) {
+        return jsonResponse({
+            id: `chatcmpl-fake-${crypto.randomUUID()}`,
+            object: "chat.completion",
+            created: Math.floor(Date.now() / 1000),
+            model,
+            choices: [
+                {
+                    index: 0,
+                    message: {
+                        role: "assistant",
+                        content: null,
+                        tool_calls: [
+                            {
+                                id: callId,
+                                type: "function",
+                                function: { name: toolName, arguments: argsJson },
+                            },
+                        ],
+                    },
+                    finish_reason: "tool_calls",
+                },
+            ],
+            usage,
+        })
+    }
+
+    return sseStream(
+        model,
+        [{ type: "tool_use", toolName, callId, args: argsJson }],
         usage,
     )
 }

--- a/scripts/e2e/run-e2e.sh
+++ b/scripts/e2e/run-e2e.sh
@@ -94,16 +94,25 @@ cat > "$FAKE_HOME/.config/opencode/opencode.json" <<OCJSON
       }
     }
   },
+  "agent": {
+    "general": {
+      "model": "fake/fake-model",
+      "prompt": "You are a general-purpose assistant."
+    }
+  },
   "model": "fake/fake-model",
   "permission": {
     "compress": "allow",
-    "acp_status": "allow"
+    "acp_status": "allow",
+    "task": "allow",
+    "bash": "allow"
   }
 }
 OCJSON
 
 cat > "$FAKE_HOME/.config/opencode/acp.jsonc" <<'ACPJSON'
 {
+    "experimental": { "allowSubAgents": true },
     "compress": {
         "minCompressRange": 0,
         "maxSummaryLengthHard": 20000
@@ -132,6 +141,7 @@ for scenario in "${SCENARIOS[@]}"; do
     HOME="$FAKE_HOME" timeout -s KILL 120 "$OPENCODE_BIN" session list </dev/null >/dev/null 2>&1 || true
 
     rm -f /tmp/acp-e2e-turn-counter
+    rm -f /tmp/acp-e2e-turn-counter-child
 
     info "starting fake LLM server"
     PORT="$FAKE_LLM_PORT" SCENARIO="$scenario" TURN_COUNTER=/tmp/acp-e2e-turn-counter "$BUN_BIN" run "$SCRIPT_DIR/fake-llm-server.ts" 2>/tmp/acp-e2e-fakellm.log &
@@ -202,7 +212,8 @@ for scenario in "${SCENARIOS[@]}"; do
     fi
 
     info "verifying state"
-    if HOME="$FAKE_HOME" "$NODE_BIN" --import tsx "$SCRIPT_DIR/verify.ts" "$STATE_FILE" "$scenario"; then
+    ACP_DIR="$FAKE_HOME/.local/share/opencode/storage/plugin/acp"
+    if HOME="$FAKE_HOME" "$NODE_BIN" --import tsx "$SCRIPT_DIR/verify.ts" "$STATE_FILE" "$scenario" "$ACP_DIR"; then
         pass "scenario $scenario_name"
         ((TOTAL_PASS++)) || true
     else

--- a/scripts/e2e/scenarios/05-subagent-compress.json
+++ b/scripts/e2e/scenarios/05-subagent-compress.json
@@ -1,0 +1,58 @@
+{
+    "name": "subagent-compress",
+    "description": "Spawn a subagent via task tool, run compression inside it, verify child ACP state has blocks",
+    "turns": [
+        {
+            "respond": "task",
+            "description": "Research auth patterns",
+            "prompt": "Research authentication patterns and report findings.",
+            "subagent_type": "general",
+            "subagent_turns": [
+                {
+                    "respond": "tool",
+                    "tool": "bash",
+                    "toolArgs": {
+                        "command": "echo 'Authentication methods include passwords biometrics twoFactor certificates. Web apps use session tokens or JWT. File: src/auth/login.ts handles password verification, src/auth/jwt.ts implements token signing.'",
+                        "description": "List authentication methods"
+                    }
+                },
+                {
+                    "respond": "tool",
+                    "tool": "bash",
+                    "toolArgs": {
+                        "command": "echo 'JWT encodes user claims signs with secret key. Three parts: header payload signature. Client sends via Authorization header. Server verifies signature. Key file: src/auth/jwt.ts verifyToken function at line 78.'",
+                        "description": "Describe JWT implementation"
+                    }
+                },
+                {
+                    "respond": "tool",
+                    "tool": "bash",
+                    "toolArgs": {
+                        "command": "echo 'Security considerations: rateLimiting against brute force, sessionFixation prevention, httpOnly cookies for token storage, csrf protection, https mandatory, sqlInjection prevention. Rate limiter at src/middleware/auth.ts line 30.'",
+                        "description": "List security considerations"
+                    }
+                },
+                {
+                    "respond": "compress",
+                    "topic": "Auth Research",
+                    "summary": "## Authentication Research\n\nResearched authentication methods: passwords biometrics twoFactor certificates. Web apps use session tokens or JWT.\n\n### JWT Implementation\nJWT encodes user claims signs with secret key. Three parts: header payload signature. Client sends via Authorization header. Server verifies signature. verifyToken function at src/auth/jwt.ts line 78. Token signing at src/auth/jwt.ts. Password verification at src/auth/login.ts.\n\n### Security\nrateLimiting against brute force, sessionFixation prevention, httpOnly cookies, csrf protection, https mandatory, sqlInjection prevention. Rate limiter at src/middleware/auth.ts line 30.",
+                    "range": "all",
+                    "acknowledgeRisk": true
+                },
+                {
+                    "respond": "text",
+                    "text": "Research complete. Findings compressed successfully."
+                }
+            ]
+        },
+        {
+            "respond": "text",
+            "text": "Subagent task completed successfully.",
+            "auto": true
+        }
+    ],
+    "verify": {
+        "blockCount": 0,
+        "childBlockCount": 1
+    }
+}

--- a/scripts/e2e/verify.ts
+++ b/scripts/e2e/verify.ts
@@ -1,23 +1,13 @@
 #!/usr/bin/env node
-/**
- * ACP state verifier for E2E tests.
- *
- * Reads the ACP state JSON file for a given session and asserts
- * that the compression state matches expected values from the scenario.
- *
- * Exit codes: 0 = pass, 1 = fail.
- *
- * Usage:
- *   node --import tsx scripts/e2e/verify.ts <state-file> <scenario-file>
- */
 
-import { readFileSync } from "fs"
+import { readFileSync, readdirSync } from "fs"
 
 interface VerifyExpectations {
     blockCount?: number
     qualityGateRetryPending?: boolean
     minBlockCount?: number
     summaryContains?: string
+    childBlockCount?: number
 }
 
 interface VerifyScenario {
@@ -26,9 +16,10 @@ interface VerifyScenario {
 
 const statePath = process.argv[2]
 const scenarioPath = process.argv[3]
+const acpDir = process.argv[4]
 
 if (!statePath || !scenarioPath) {
-    process.stderr.write("Usage: verify.ts <state-file> <scenario-file>\n")
+    process.stderr.write("Usage: verify.ts <state-file> <scenario-file> [acp-dir]\n")
     process.exit(2)
 }
 
@@ -50,22 +41,53 @@ let failed = 0
 
 function assert(name: string, condition: boolean, detail?: string) {
     if (condition) {
-        console.log(`  ✓ ${name}`)
+        console.log(`  \u2713 ${name}`)
         passed++
     } else {
-        console.error(`  ✗ ${name}${detail ? ` — ${detail}` : ""}`)
+        console.error(`  \u2717 ${name}${detail ? ` \u2014 ${detail}` : ""}`)
         failed++
     }
 }
 
-const blocksById = state?.prune?.messages?.blocksById ?? {}
-const actualBlockCount = Object.keys(blocksById).length
+function countBlocks(s: any): number {
+    return Object.keys(s?.prune?.messages?.blocksById ?? {}).length
+}
+
+function getBlocks(s: any): any[] {
+    return Object.values(s?.prune?.messages?.blocksById ?? {})
+}
+
+const actualBlockCount = countBlocks(state)
 const actualPending = state?.qualityGateRetryPending ?? false
+
+let childStateFiles: string[] = []
+let childBlockCount = 0
+let childBlocks: any[] = []
+
+if (acpDir) {
+    try {
+        const allFiles = readdirSync(acpDir)
+            .filter((f) => f.endsWith(".json"))
+            .map((f) => `${acpDir}/${f}`)
+        childStateFiles = allFiles.filter((f) => f !== statePath)
+        for (const f of childStateFiles) {
+            try {
+                const cs = readJson(f)
+                childBlockCount += countBlocks(cs)
+                childBlocks = childBlocks.concat(getBlocks(cs))
+            } catch {}
+        }
+    } catch {}
+}
 
 console.log(`\nVerifying: ${scenarioPath}`)
 console.log(`  state file: ${statePath}`)
 console.log(`  blocks: ${actualBlockCount}`)
 console.log(`  qualityGateRetryPending: ${actualPending}`)
+if (childStateFiles.length > 0) {
+    console.log(`  child state files: ${childStateFiles.length}`)
+    console.log(`  child blocks: ${childBlockCount}`)
+}
 console.log()
 
 if (expect.blockCount !== undefined) {
@@ -94,7 +116,7 @@ if (expect.qualityGateRetryPending !== undefined) {
 
 if (expect.summaryContains !== undefined) {
     let found = false
-    for (const block of Object.values(blocksById) as any[]) {
+    for (const block of getBlocks(state)) {
         if (block?.summary?.includes(expect.summaryContains)) {
             found = true
             break
@@ -104,6 +126,14 @@ if (expect.summaryContains !== undefined) {
         `summary contains "${expect.summaryContains}"`,
         found,
         "no block summary contains the expected text",
+    )
+}
+
+if (expect.childBlockCount !== undefined) {
+    assert(
+        `childBlockCount === ${expect.childBlockCount}`,
+        childBlockCount === expect.childBlockCount,
+        `got ${childBlockCount} across ${childStateFiles.length} child state file(s)`,
     )
 }
 


### PR DESCRIPTION
## Summary

Adds an E2E test scenario that verifies ACP compression works correctly inside subagent (child) sessions. This is a regression guard for PR #180 (remove subagent history rewriting) — confirms the deleted feature didn't break subagent compression.

## What it tests

- Parent spawns a subagent via the `task` tool (`subagent_type: "general"`)
- Child session accumulates 3 `bash` tool outputs
- Child calls `compress(m00001-m00003)` with a hand-written summary
- Verifies: parent session has 0 blocks, child session has 1 block

## Changes

**No production code changes** — only test/script infrastructure.

| File | Change |
|------|--------|
| `scripts/e2e/fake-llm-server.ts` | Child session detection via `x-parent-session-id` HTTP header; `handleChildRequest()` routes child turns from `subagent_turns` array; `handleTaskStep()` emits `task` tool_use; generic `toolUseResponse()` SSE streaming; `extractMessageText` fixed to search `tool_calls[].function.arguments` (ACP injects `<dcp-message-id>` tags into tool-call-only assistant messages) |
| `scripts/e2e/scenarios/05-subagent-compress.json` | NEW scenario: parent emits `task`, child runs 3× bash → compress → text |
| `scripts/e2e/run-e2e.sh` | Added `agent.general` definition, `task`/`bash` permissions, `experimental.allowSubAgents: true`, pass `ACP_DIR` to verify.ts |
| `scripts/e2e/verify.ts` | Added `childBlockCount` assertion; discovers child state files by scanning ACP directory |
| `devlog/2026-07-23_subagent-e2e-test/{REQ,WORKLOG}.md` | Devlog |

## Key finding

ACP's production code (`lib/hooks.ts`, `lib/message-ids.ts`) requires **no changes** for subagent compression — existing code handles it correctly when `experimental.allowSubAgents: true` is set. OpenCode sends `x-parent-session-id` on child session LLM requests (source: `session/llm/request.ts:187-205`).

## Verification

- `npm run typecheck` ✅
- `npm test` → 846 pass ✅
- E2E (original branch): 5 scenarios pass, 0 fail ✅

## Branch state

Rebased on current master (v1.13.7-dev.1, commit 5e4b309) — 2 commits cherry-picked cleanly, no conflicts.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)

Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>