### PR TITLE
fix: remove erroneous acknowledgeRisk from E2E scenario 05

### DIFF
--- a/devlog/2026-07-25_fix-scenario05-acknowledge-risk/REQ.md
+++ b/devlog/2026-07-25_fix-scenario05-acknowledge-risk/REQ.md
@@ -1,0 +1,34 @@
+# REQ: Fix E2E scenario 05 — remove erroneous acknowledgeRisk on first compress
+
+## Problem
+
+E2E scenario `05-subagent-compress.json` sets `"acknowledgeRisk": true` on the
+**first** compress call inside the subagent. This parameter is only valid when
+**retrying** after a quality gate rejection. On a first attempt, the compress
+tool correctly rejects it:
+
+```
+Parameter "acknowledgeRisk": true was provided, but no quality gate rejection
+is pending. This parameter is only valid immediately after a compression was
+rejected by the quality gate. Remove it and try again.
+```
+
+This causes the child session to produce **0 blocks**, making the test fail on
+both master and PR #184.
+
+## Root Cause
+
+PR #192 (`test: E2E scenario for subagent compression`) introduced scenario 05
+with `acknowledgeRisk: true` at the top level of the compress step — likely
+copy-pasted from scenario 03 without realising scenario 03 nests it inside
+`retryOnReject`.
+
+## Fix
+
+Remove `"acknowledgeRisk": true` from the compress step in scenario 05. The
+initial compress call should not carry this flag.
+
+## Verification
+
+- Scenario 05 passes on **master** (c149686): `childBlockCount === 1` ✓
+- Scenario 05 passes on **#184** (0d679c8 + master merge): `childBlockCount === 1` ✓

--- a/devlog/2026-07-25_fix-scenario05-acknowledge-risk/WORKLOG.md
+++ b/devlog/2026-07-25_fix-scenario05-acknowledge-risk/WORKLOG.md
@@ -1,0 +1,39 @@
+# WORKLOG: Fix E2E scenario 05
+
+## Investigation
+
+User reported that PR #184 (per-session SessionState registry) "didn't pass" —
+the E2E scenario 05 (subagent compress) was failing. Deep investigation:
+
+1. **Ran scenario 05 on master** → 6 events (child ran), 1 child state file, 0 blocks. FAIL.
+2. **Ran scenario 05 on #184** (without merged #192 infra) → 3 events (child couldn't run — `task` tool not whitelisted). FALSE PASS (childBlockCount assertion skipped).
+3. **Merged master into #184** → 6 events, 1 child state file, 0 blocks. FAIL — same as master.
+4. **Added ACP debug logging** to `hooks.ts` → confirmed child state IS in registry, `isSubAgent=true`, `assignMessageRefs` working (4 IDs assigned by last transform).
+5. **Checked fake LLM log** → compress(m00001..m00003) was sent and a result was received (turn 5 proceeded).
+6. **Queried opencode DB** → found the compress tool result: `status: error`, error message: `acknowledgeRisk provided but no quality gate rejection is pending`.
+
+## Root Cause
+
+`"acknowledgeRisk": true` in scenario 05's compress step. This flag is only
+valid on retry after quality gate rejection. On first attempt, compress tool
+rejects it. The compress never creates a block.
+
+This bug was introduced in PR #192 and affects both master and #184 equally.
+PR #184's per-session state is working correctly.
+
+## Fix Applied
+
+Removed `"acknowledgeRisk": true` from `scripts/e2e/scenarios/05-subagent-compress.json`.
+
+## Files Changed
+
+- `scripts/e2e/scenarios/05-subagent-compress.json` — removed `acknowledgeRisk: true` (1 line)
+- `devlog/2026-07-25_fix-scenario05-acknowledgeRisk/REQ.md` — this requirement
+- `devlog/2026-07-25_fix-scenario05-acknowledgeRisk/WORKLOG.md` — this worklog
+
+## Verification
+
+Both tested with `SKIP_BUILD=1 ./scripts/e2e/run-e2e.sh scripts/e2e/scenarios/05-subagent-compress.json`:
+
+- **master** (c149686): PASS — `childBlockCount === 1` ✓
+- **#184** (0d679c8 + master): PASS — `childBlockCount === 1` ✓

--- a/scripts/e2e/scenarios/05-subagent-compress.json
+++ b/scripts/e2e/scenarios/05-subagent-compress.json
@@ -36,8 +36,7 @@
                     "respond": "compress",
                     "topic": "Auth Research",
                     "summary": "## Authentication Research\n\nResearched authentication methods: passwords biometrics twoFactor certificates. Web apps use session tokens or JWT.\n\n### JWT Implementation\nJWT encodes user claims signs with secret key. Three parts: header payload signature. Client sends via Authorization header. Server verifies signature. verifyToken function at src/auth/jwt.ts line 78. Token signing at src/auth/jwt.ts. Password verification at src/auth/login.ts.\n\n### Security\nrateLimiting against brute force, sessionFixation prevention, httpOnly cookies, csrf protection, https mandatory, sqlInjection prevention. Rate limiter at src/middleware/auth.ts line 30.",
-                    "range": "all",
-                    "acknowledgeRisk": true
+                    "range": "all"
                 },
                 {
                     "respond": "text",


### PR DESCRIPTION
## Summary

E2E scenario `05-subagent-compress.json` was failing on **both master and PR #184** because it set `"acknowledgeRisk": true` on the **first** compress call. This flag is only valid when retrying after a quality gate rejection — the compress tool correctly rejects it on a first attempt, producing 0 blocks.

## Root Cause

PR #192 introduced scenario 05 with `acknowledgeRisk: true` at the top level of the compress step — likely copy-pasted from scenario 03 without noticing that scenario 03 nests it inside `retryOnReject`.

## Fix

Remove the flag. One-line change.

## Verification

- **master** (c149686): `childBlockCount === 1` ✓
- **#184** (0d679c8 + master merge): `childBlockCount === 1` ✓

## Note on PR #184

This investigation confirms **#184 is NOT broken**. The per-session SessionState registry works correctly for subagent compression. The test was simply passing invalid arguments to the compress tool.