### PR TITLE
fix: preserve first user message to guarantee API validity

### DIFF
--- a/devlog/2026-07-25_preserve-first-user-msg/REQ.md
+++ b/devlog/2026-07-25_preserve-first-user-msg/REQ.md
@@ -1,0 +1,34 @@
+# REQ — preserve-first-user
+
+## Problem
+
+Sessions freeze with `APIError 400, code 1214, "messages 参数非法"` (zhipuai-lb
+rejects requests with zero user-role messages). Reproduced in
+`ses_0b89319b1ffeK25eKU3GMfCK8U`: pre-compress 128 msgs / 12 user, post-compress
+11 msgs / **0 user**. A month-long bug.
+
+## Root cause
+
+`filterCompressedRanges` (lib/messages/prune.ts) had a `preserve-last-user`
+fix (v1.13.2, commit `1044a42`) that restored the most recent pruned user
+message when filtering would otherwise leave zero user messages. The fix
+searched `messages[i].info.role === "user" && !survive[i]`, depending on the
+pruned user message still being present in the `messages` array. After OpenCode
+compaction, pruned messages are not guaranteed to still be in the array — so the
+restore found nothing and zero-user requests slipped through.
+
+## Solution
+
+Replace `preserve-last-user` with `preserve-first-user`: the first user message
+in the session (the original task) is always `survive=true`, unconditionally,
+regardless of prune state. OpenCode never deletes the first user message, so
+this guarantee always holds and does not depend on array integrity.
+
+## Acceptance criteria
+
+- `lib/messages/prune.ts`: first user message force-preserved
+- `tests/prune.test.ts`: 5 `preserve-last-user` tests rewritten for the new
+  invariant; the "zero user msgs at all" test still passes unchanged
+- `npm run typecheck` clean
+- `npm test` all green
+- `npm run build` clean

--- a/devlog/2026-07-25_preserve-first-user-msg/WORKLOG.md
+++ b/devlog/2026-07-25_preserve-first-user-msg/WORKLOG.md
@@ -1,0 +1,69 @@
+# WORKLOG — preserve-first-user
+
+## Changes
+
+### lib/messages/prune.ts
+
+Replaced the 16-line `preserve-last-user` loop (lines 209-224) with a 4-line
+`preserve-first-user` block:
+
+```typescript
+const firstUserIdx = messages.findIndex((msg) => msg.info.role === "user")
+if (firstUserIdx >= 0) {
+    survive[firstUserIdx] = true
+}
+```
+
+The previous implementation depended on the most recent pruned user message
+still being in the `messages` array. After OpenCode compaction removes pruned
+messages, there was nothing to restore, and zero-user requests hit the provider.
+
+### tests/prune.test.ts
+
+Rewrote the 5 tests under the `preserve-last-user` section:
+
+1. "always preserve first user msg even when it falls in a compressed range" —
+   first user survives, later pruned users stay pruned
+2. "always preserve first user even when a newer uncompressed user survives" —
+   both first (force-preserved) and newer (uncompressed) survive
+3. "preserve first user when multiple user msgs are all compressed" — only the
+   first survives, middle/newest stay pruned
+4. "no restoration when input has zero user messages at all" — unchanged, still
+   valid (`findIndex` returns -1, guard skips)
+5. "preserved first user msg keeps its original parts intact" — asserts first
+   user content is byte-identical
+
+## Verification
+
+- `npm run typecheck` — clean
+- `npm test` — **846 pass, 0 fail**
+- `npm run build` — clean
+
+## Tests modified
+
+### tests/prune.test.ts (5 tests rewritten)
+All under the renamed `preserve-first-user` section. Tests 1, 3, 5 assert the
+first user is force-preserved. Test 2 asserts both first user (force-preserved)
+and newer uncompressed user survive. Test 4 (zero user msgs) unchanged.
+
+### tests/e2e-message-transform.test.ts (3 tests updated)
+- "message IDs remain consistent": u1 now survives (force-preserved)
+- "Bug 36 — no adjacent users": updated to accept u1+u2 adjacency as an accepted
+  trade-off (the `isForcePreservedFirstUser` exception). The no-adjacent-users
+  invariant still holds for all non-first-user pairs.
+- "compressed messages are replaced with summaries": u1 now survives
+
+## Trade-off: API validity vs no-adjacent-users
+
+preserve-first-user can produce two adjacent user messages when the first user
+is compressed and a later user also survives (e.g., `[u1, u2, a2]`). This is an
+accepted trade-off:
+
+- **Zero user messages** → hard API rejection (zhipuai-lb code 1214, session
+  freezes). MUST prevent.
+- **Adjacent user messages** → accepted by virtually all providers (OpenAI,
+  Anthropic, Google, zhipuai-lb). Soft concern at most.
+
+The Bug 36 test was updated to reflect this: the no-adjacent-users invariant
+still holds for all non-first-user pairs, but the force-preserved first user
+is exempted.

--- a/lib/messages/prune.ts
+++ b/lib/messages/prune.ts
@@ -206,21 +206,17 @@ const filterCompressedRanges = (
         return false
     })
 
-    // [FIX preserve-last-user] zhipuai-lb rejects requests with zero user-role
-    // messages (code 1214, "The messages parameter is illegal"), freezing the
-    // session. Trigger: compress range extends past the most recent user msg
-    // and no newer user msg has arrived yet (right after a compress tool call).
-    // Restore the most recent pruned user msg in that case.
-    const anyUserSurvives = messages.some(
-        (msg, i) => survive[i] && msg.info.role === "user",
-    )
-    if (!anyUserSurvives) {
-        for (let i = messages.length - 1; i >= 0; i--) {
-            if (messages[i]!.info.role === "user" && !survive[i]) {
-                survive[i] = true
-                break
-            }
-        }
+    // [FIX preserve-first-user] zhipuai-lb (and most providers) reject requests
+    // with zero user-role messages (code 1214, "The messages parameter is
+    // illegal"), freezing the session. The first user message is the session's
+    // original task — it must always survive compression to guarantee API
+    // validity. This is simpler and more reliable than the previous
+    // "restore most recent pruned user" approach, which depended on the
+    // pruned message still being in the messages array (not guaranteed after
+    // OpenCode compaction).
+    const firstUserIdx = messages.findIndex((msg) => msg.info.role === "user")
+    if (firstUserIdx >= 0) {
+        survive[firstUserIdx] = true
     }
 
     const result: WithParts[] = []

--- a/tests/e2e-message-transform.test.ts
+++ b/tests/e2e-message-transform.test.ts
@@ -374,7 +374,7 @@ test("compression blocks: compressed messages are replaced with summaries", asyn
 
     const remainingIds = output.messages.map((m: any) => m.info.id)
 
-    assert.ok(!remainingIds.includes("u1"), "u1 should be pruned")
+    assert.ok(remainingIds.includes("u1"), "u1 (first user) is force-preserved even when compressed")
     assert.ok(!remainingIds.includes("a1"), "a1 should be pruned")
 
     assert.ok(remainingIds.includes("u2"), "u2 should survive")
@@ -467,15 +467,26 @@ test("compression summary: never produces two consecutive user turns (Bug 36)", 
         (m: any, idx: number) => !(idx === lastIdx && isSyntheticMessage(m)),
     )
 
+    // With preserve-first-user, u1 (the first user message) is always
+    // force-preserved even when it falls in a compression range. When a
+    // later user message (u2) also survives, u1 and u2 become adjacent.
+    // This is an accepted trade-off: zero user messages is a hard API
+    // rejection (zhipuai-lb code 1214), while adjacent user messages are
+    // accepted by virtually all providers. The no-adjacent-users invariant
+    // still holds for all NON-first-user pairs.
     for (let i = 1; i < historical.length; i++) {
         const prev = historical[i - 1]!
         const curr = historical[i]!
         const bothUser = prev.info.role === "user" && curr.info.role === "user"
+        const isForcePreservedFirstUser = i === 1 && prev.info.id === "u1"
         assert.ok(
-            !bothUser,
-            `adjacent user turns at index ${i - 1}/${i} (ids ${prev.info.id}, ${curr.info.id})`,
+            !bothUser || isForcePreservedFirstUser,
+            `unexpected adjacent user turns at index ${i - 1}/${i} (ids ${prev.info.id}, ${curr.info.id})`,
         )
     }
+
+    const u1 = historical.find((m: WithParts) => m.info.id === "u1")
+    assert.ok(u1, "u1 (first user) should be force-preserved even when compressed")
 
     const u2 = historical.find((m: WithParts) => m.info.id === "u2")
     assert.ok(u2, "u2 should survive")
@@ -674,7 +685,7 @@ test("message IDs remain consistent after compression and pruning", async () => 
     assert.equal(new Set(allRefs).size, allRefs.length, "no duplicate message refs")
 
     const outputIds = output.messages.map((m: any) => m.info.id)
-    assert.ok(!outputIds.includes("u1"), "u1 should be pruned from output")
+    assert.ok(outputIds.includes("u1"), "u1 (first user) is force-preserved even when compressed")
     assert.ok(!outputIds.includes("a1"), "a1 should be pruned from output")
     assert.ok(outputIds.includes("u2"), "u2 should survive")
     assert.ok(outputIds.includes("a2"), "a2 should survive")

--- a/tests/prune.test.ts
+++ b/tests/prune.test.ts
@@ -758,9 +758,10 @@ test("stripStepMarkers leaves messages without step markers untouched", () => {
 })
 
 // =====================================================================
-// preserve-last-user — restore the most recent user msg when filtering
-// would otherwise leave zero user-role messages (FIX preserve-last-user).
-// Reproduces the zhipuai-lb code 1214 freeze from issue #20 follow-up.
+// preserve-first-user — the first user message is the session's original
+// task and is always force-preserved (survive=true), even when it falls
+// inside a compression range. Guarantees every request has ≥1 user msg
+// (zhipuai-lb code 1214 freeze from issue #20).
 // =====================================================================
 
 // Minimal block setup: filterCompressedRanges only reads byMessageId, so this
@@ -780,7 +781,7 @@ function setupBlock(
     }
 }
 
-test("restore most recent user msg when all user msgs fall in compressed range", () => {
+test("always preserve first user msg even when it falls in a compressed range", () => {
     const state = createSessionState()
     // Block 1 compresses m1 (user), m2 (assistant), m3 (user)
     setupBlock(state, 1, ["m1", "m2", "m3"])
@@ -796,24 +797,24 @@ test("restore most recent user msg when all user msgs fall in compressed range",
     prune(state, logger, buildConfig(), messages)
 
     const ids = messages.map((m) => m.info.id)
-    assert.ok(!ids.includes("m1"), "m1 was compressed and is NOT the latest user → stays pruned")
+    assert.ok(ids.includes("m1"), "m1 is the first user msg → always preserved (API validity)")
     assert.ok(!ids.includes("m2"), "m2 stays pruned")
-    assert.ok(ids.includes("m3"), "m3 IS the latest user → restored to keep request shape valid")
+    assert.ok(!ids.includes("m3"), "m3 stays pruned (only the FIRST user is force-preserved)")
     assert.ok(ids.includes("m4"), "uncompressed m4 survives")
     assert.ok(ids.includes("m5"), "uncompressed m5 survives")
 
     const survivingUsers = messages.filter((m) => m.info.role === "user")
-    assert.equal(survivingUsers.length, 1, "exactly one user msg restored")
-    assert.equal(survivingUsers[0]!.info.id, "m3", "the restored user msg is the most recent one")
+    assert.equal(survivingUsers.length, 1, "exactly one user msg survives (the first one)")
+    assert.equal(survivingUsers[0]!.info.id, "m1", "the surviving user is the first message")
 
-    const m3Idx = ids.indexOf("m3")
+    const m1Idx = ids.indexOf("m1")
     const m4Idx = ids.indexOf("m4")
-    assert.ok(m3Idx < m4Idx, "restored m3 preserves original ordering relative to m4")
+    assert.ok(m1Idx < m4Idx, "preserved m1 keeps original ordering relative to m4")
 })
 
-test("do NOT restore pruned user when an uncompressed user already survives", () => {
+test("always preserve first user even when a newer uncompressed user survives", () => {
     const state = createSessionState()
-    // Block 1 compresses only m1 (user). Later user msgs m3 stay uncompressed.
+    // Block 1 compresses only m1 (user). Later user msg m4 stays uncompressed.
     setupBlock(state, 1, ["m1", "m2"])
 
     const messages: WithParts[] = [
@@ -827,14 +828,17 @@ test("do NOT restore pruned user when an uncompressed user already survives", ()
     prune(state, logger, buildConfig(), messages)
 
     const ids = messages.map((m) => m.info.id)
-    assert.ok(!ids.includes("m1"), "m1 stays pruned (a newer user msg already survives)")
+    assert.ok(ids.includes("m1"), "m1 (first user) ALWAYS preserved even when compressed")
     assert.ok(!ids.includes("m2"), "m2 stays pruned")
     assert.ok(ids.includes("m3"), "m3 survives")
-    assert.ok(ids.includes("m4"), "m4 survives (the real latest user)")
+    assert.ok(ids.includes("m4"), "m4 survives (newer user)")
     assert.ok(ids.includes("m5"), "m5 survives")
+
+    const survivingUsers = messages.filter((m) => m.info.role === "user")
+    assert.equal(survivingUsers.length, 2, "both first user (force-preserved) and newer user survive")
 })
 
-test("restore most recent user when multiple user msgs are all compressed", () => {
+test("preserve first user when multiple user msgs are all compressed", () => {
     const state = createSessionState()
     // Block 1 compresses m1, m2, m3, m4, m5 — three of which are user msgs.
     setupBlock(state, 1, ["m1", "m2", "m3", "m4", "m5"])
@@ -851,14 +855,14 @@ test("restore most recent user when multiple user msgs are all compressed", () =
     prune(state, logger, buildConfig(), messages)
 
     const ids = messages.map((m) => m.info.id)
-    assert.ok(!ids.includes("m1"), "older user m1 stays pruned")
+    assert.ok(ids.includes("m1"), "m1 is the FIRST user → always preserved")
     assert.ok(!ids.includes("m3"), "middle user m3 stays pruned")
-    assert.ok(ids.includes("m5"), "m5 is the MOST RECENT user → restored")
+    assert.ok(!ids.includes("m5"), "newest user m5 stays pruned (only first is force-preserved)")
     assert.ok(ids.includes("m6"), "m6 survives")
 
     const survivingUsers = messages.filter((m) => m.info.role === "user")
-    assert.equal(survivingUsers.length, 1, "exactly one user msg restored")
-    assert.equal(survivingUsers[0]!.info.id, "m5")
+    assert.equal(survivingUsers.length, 1, "exactly one user msg survives (the first)")
+    assert.equal(survivingUsers[0]!.info.id, "m1")
 })
 
 test("no restoration when input has zero user messages at all", () => {
@@ -878,21 +882,21 @@ test("no restoration when input has zero user messages at all", () => {
     assert.deepEqual(ids, ["a1", "a3"], "no user msg to restore — behavior unchanged")
 })
 
-test("restored user msg keeps its original parts intact", () => {
+test("preserved first user msg keeps its original parts intact", () => {
     const state = createSessionState()
     setupBlock(state, 1, ["u1", "a1", "u2"])
 
     const messages: WithParts[] = [
-        userMessage("u1", "old", 1),
+        userMessage("u1", "ORIGINAL TASK", 1),
         assistantMessage("a1", 2),
-        userMessage("u2", "RESTORE ME", 3),
+        userMessage("u2", "follow-up", 3),
         assistantMessage("a2", "tail", 4),
     ]
 
     prune(state, logger, buildConfig(), messages)
 
-    const restored = messages.find((m) => m.info.id === "u2")
-    assert.ok(restored, "u2 was restored")
-    const text = restored!.parts.map((p: any) => p.text ?? "").join("")
-    assert.equal(text, "RESTORE ME", "restored user msg content is byte-identical to original")
+    const preserved = messages.find((m) => m.info.id === "u1")
+    assert.ok(preserved, "u1 (first user) was force-preserved")
+    const text = preserved!.parts.map((p: any) => p.text ?? "").join("")
+    assert.equal(text, "ORIGINAL TASK", "preserved first user msg content is byte-identical to original")
 })


### PR DESCRIPTION
## Summary

Fixes the month-long session-freeze bug (zhipuai-lb code 1214, "messages 参数非法") where compression leaves zero user-role messages in the request.

### Root cause

The v1.13.2 `preserve-last-user` fix (`lib/messages/prune.ts`) searched the messages array for a pruned user message to restore when filtering would leave zero users. After OpenCode compaction removes pruned messages from the array, the search finds nothing — zero-user requests slip through and the provider hard-rejects.

Reproduced in `ses_0b89319b1ffeK25eKU3GMfCK8U`: pre-compress 128 msgs / 12 user → post-compress 11 msgs / **0 user** → API 400 code 1214 → session frozen.

### Fix

Replace `preserve-last-user` with `preserve-first-user`: the first user message (the session's original task, always present in the array) is unconditionally force-preserved (`survive = true`), regardless of prune state. This does not depend on the integrity of the pruned portion of the array.

```typescript
const firstUserIdx = messages.findIndex((msg) => msg.info.role === "user")
if (firstUserIdx >= 0) {
    survive[firstUserIdx] = true
}
```

### Trade-off

When the first user is compressed and a later user also survives, two adjacent user messages can appear (e.g., `[u1, u2, a2]`). This is an accepted trade-off:
- **Zero user messages** → hard API rejection (code 1214). MUST prevent.
- **Adjacent user messages** → accepted by virtually all providers (OpenAI, Anthropic, Google, zhipuai-lb).

The Bug 36 e2e test was updated: the force-preserved first user is exempted from the adjacent-user check. The no-adjacent-users invariant still holds for all non-first-user pairs.

### Files
- `lib/messages/prune.ts` — preserve-first-user logic (replaces preserve-last-user)
- `tests/prune.test.ts` — 5 tests rewritten for new invariant
- `tests/e2e-message-transform.test.ts` — 3 e2e tests updated

### Verification
- `npm run typecheck` — clean
- `npm test` — **846 pass, 0 fail**
- `npm run build` — clean

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)