### PR TITLE
release: v1.13.8-dev.1 — sync dev tag with v1.13.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,12 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.13.8-dev.1 — Dev Prerelease Sync (master @ v1.13.7)
+
+**Purpose**: Sync the `dev` npm tag with v1.13.7 stable. Content is identical to v1.13.7 — no new code changes. This brings `opencode-acp@dev` up to parity with `opencode-acp@latest` (1.13.7).
+
+Files: `package.json`, `README.md`, `README.zh-CN.md`. 851 tests pass (no source changes).
+
 ### v1.13.7 — Per-Session State + Inactive Block Fixes + Preserve First User Message (PRs #184, #193, #196)
 
 **Problem**: Three bugs since v1.13.6. (1) **Subagent state isolation failure** (PR #184): ACP stored a single global `SessionState` per plugin instance. When subagent (child) sessions ran interleaved with the parent, the child's state overwrote the parent's `modelContextLimit` — losing the 1M context window and falling back to the 6K adaptive floor, causing over-aggressive nudging in the parent. The `compressionTiming` tracker was also shared across sessions, risking cross-session collision. (2) **Inactive block opacity** (PR #193): `decompress` rejected inactive blocks with "not active — may have already been decompressed", and `acp_status` hid consumed/inactive blocks entirely. Users could not decompress blocks that were GC'd or consumed by secondary compression, and could not see them in status output. (3) **Zero-user session freeze** (PR #196): When compression pruned all user-role messages (all fell inside compressed ranges), zhipuai-lb rejected the request with HTTP 400 code 1214 (`"messages 参数非法"`, `isRetryable: false`), freezing the session. The v1.13.2 `preserve-last-user` fix searched the messages array for a pruned user to restore — but after OpenCode compaction removes pruned messages from the array, the search finds nothing and zero-user requests slip through.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -443,6 +443,12 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.13.8-dev.1 — Dev 预发布同步（master @ v1.13.7）
+
+**目的**：将 npm `dev` 标签同步到 v1.13.7 稳定版。内容与 v1.13.7 完全相同 —— 无新代码变更。使 `opencode-acp@dev` 与 `opencode-acp@latest`（1.13.7）保持一致。
+
+文件：`package.json`、`README.md`、`README.zh-CN.md`。851 项测试通过（无源码变更）。
+
 ### v1.13.7 — 每会话状态隔离 + 失活块修复 + 保留首条用户消息（PR #184、#193、#196）
 
 **问题**：v1.13.6 之后的三个 bug。（1）**子代理状态隔离失败**（PR #184）：ACP 为每个插件实例存储单个全局 `SessionState`。当子代理（child）会话与父会话交替运行时，子会话的状态覆盖了父会话的 `modelContextLimit` —— 丢失 1M 上下文窗口，回退到 6K 自适应下限，导致父会话中过度触发压缩提醒。`compressionTiming` 追踪器也跨会话共享，存在跨会话碰撞风险。（2）**失活块不可见**（PR #193）：`decompress` 拒绝失活块（"not active — may have already been decompressed"），`acp_status` 完全隐藏被消费/失活的块。用户无法解压被 GC 回收或被二次压缩消费的块，也无法在状态输出中看到它们。（3）**零用户消息会话冻结**（PR #196）：当压缩剪枝了所有 user 角色消息（全部落在压缩范围内）时，zhipuai-lb 拒绝请求（HTTP 400，code 1214，`"messages 参数非法"`，`isRetryable: false`），冻结会话。v1.13.2 的 `preserve-last-user` 修复在消息数组中搜索被剪枝的用户消息来恢复 —— 但 OpenCode 压缩移除被剪枝的消息后，搜索找不到任何内容，零用户请求仍然漏过。

--- a/devlog/2026-07-25_release-v1.13.8-dev.1/REQ.md
+++ b/devlog/2026-07-25_release-v1.13.8-dev.1/REQ.md
@@ -1,0 +1,26 @@
+# REQ: Release v1.13.8-dev.1
+
+## Goal
+
+Sync the npm `dev` tag with v1.13.7 stable. Content is identical to v1.13.7 — no new code changes.
+
+## Version
+
+- Current: `1.13.7`
+- Target: `1.13.8-dev.1` (dev prerelease, npm `dev` tag)
+
+## Scope
+
+Version bump + changelog entries. No source code changes.
+
+## Acceptance Criteria
+
+- [x] `package.json` version bumped to `1.13.8-dev.1`
+- [x] Changelog entries added to `README.md` and `README.zh-CN.md` with `### v1.13.8-dev.1` header
+- [x] Devlog created
+- [x] typecheck + tests + build pass
+- [x] PR created
+
+## Note
+
+This PR depends on #197 (v1.13.7 stable) being merged first. If #197 is still open when this is reviewed, the diff will include v1.13.7 changes as well. Merge #197 first, then rebase this PR on master before merging.

--- a/devlog/2026-07-25_release-v1.13.8-dev.1/WORKLOG.md
+++ b/devlog/2026-07-25_release-v1.13.8-dev.1/WORKLOG.md
@@ -1,0 +1,18 @@
+# WORKLOG: Release v1.13.8-dev.1
+
+## 2026-07-25
+
+### Branch setup
+- Created worktree `/home/dog/projects/opencode-acp-release-v1.13.8-dev` from `2026-07-25_release-v1.13.7` at `6b77cb1`
+- Branch: `2026-07-25_release-v1.13.8-dev.1`
+
+### Changes
+- `package.json`: version `1.13.7` → `1.13.8-dev.1`
+- `README.md`: Added `### v1.13.8-dev.1` changelog entry (dev sync with v1.13.7)
+- `README.zh-CN.md`: Added Chinese translation
+- `devlog/2026-07-25_release-v1.13.8-dev.1/REQ.md` + `WORKLOG.md`: created
+
+### Verification
+- typecheck: PASS
+- 851 tests pass
+- build: PASS

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.13.7",
+    "version": "1.13.8-dev.1",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Dev prerelease sync. Content is identical to v1.13.7 stable — no new code changes. Brings `opencode-acp@dev` up to parity with `opencode-acp@latest`.

**⚠️ Merge #197 (v1.13.7 stable) first**, then rebase this PR on master before merging.

After merge, CI detects the `-` in version → publishes with `--tag dev` → creates prerelease GitHub Release.

## Test plan
- [x] typecheck: PASS
- [x] 851 tests pass
- [x] build: PASS

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)