### PR TITLE
release: v1.13.9-dev.1 — remove subagent history rewriting

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.13.9-dev.1 — Remove Subagent History Rewriting (PR #180)
+
+**Problem**: `injectExtendedSubAgentResults` rewrote historical `<task_result>` tool outputs in the parent agent's message history on every transform run when `experimental.allowSubAgents: true`. The `subAgentResultCache` was cleared on every parent↔child session switch and was never persisted, so each transform run re-fetched the subagent session and produced a new historical message body — invalidating the provider prefix cache (observed: ~56% hit rate vs healthy 96–98%, prefix frozen at ~22K tokens).
+
+**Fix**: PR #180 — Removed `injectExtendedSubAgentResults` from the message-transform pipeline and `appendProtectedTools`. Deleted `lib/messages/inject/subagent-results.ts` (82 lines) and `lib/subagents/subagent-results.ts` (74 lines). Dropped `subAgentResultCache` field from `SessionState`. The rewrite was redundant: OpenCode natively appends a `state="completed"` message with the full subagent result immediately after the `task` call completes. `experimental.allowSubAgents` still controls whether ACP runs inside subagent sessions — only the parent-history rewriting is gone. Dual-agent reviewed (both APPROVE).
+
+Files: `lib/hooks.ts`, `lib/compress/protected-content.ts`, `lib/compress/{message,range}.ts`, `lib/state/{state,types}.ts`, `lib/messages/index.ts`, `AGENTS.md`. 851 tests pass.
+
 ### v1.13.8-dev.1 — Dev Prerelease Sync (master @ v1.13.7)
 
 **Purpose**: Sync the `dev` npm tag with v1.13.7 stable. Content is identical to v1.13.7 — no new code changes. This brings `opencode-acp@dev` up to parity with `opencode-acp@latest` (1.13.7).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -443,6 +443,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.13.9-dev.1 — 移除子代理历史重写（PR #180）
+
+**问题**：`injectExtendedSubAgentResults` 在 `experimental.allowSubAgents: true` 时，每次消息变换都会重写父代理历史中的 `<task_result>` 工具输出。`subAgentResultCache` 在每次父↔子会话切换时被清空且从不持久化，导致每次变换都重新获取子代理会话并生成新的历史消息体 —— 使 provider prefix cache 失效（观察到的命中率约 56%，健康水平为 96-98%，prefix 冻结在约 22K tokens）。
+
+**修复**：PR #180 —— 从消息变换管道和 `appendProtectedTools` 中移除 `injectExtendedSubAgentResults`。删除 `lib/messages/inject/subagent-results.ts`（82 行）和 `lib/subagents/subagent-results.ts`（74 行）。从 `SessionState` 中移除 `subAgentResultCache` 字段。重写是冗余的：OpenCode 原生在 `task` 调用完成后立即追加一条 `state="completed"` 消息（含完整子代理结果）。`experimental.allowSubAgents` 仍然控制 ACP 是否在子代理会话中运行 —— 只是移除了父历史重写。经双 Agent 审查（均 APPROVE）。
+
+文件：`lib/hooks.ts`、`lib/compress/protected-content.ts`、`lib/compress/{message,range}.ts`、`lib/state/{state,types}.ts`、`lib/messages/index.ts`、`AGENTS.md`。851 项测试通过。
+
 ### v1.13.8-dev.1 — Dev 预发布同步（master @ v1.13.7）
 
 **目的**：将 npm `dev` 标签同步到 v1.13.7 稳定版。内容与 v1.13.7 完全相同 —— 无新代码变更。使 `opencode-acp@dev` 与 `opencode-acp@latest`（1.13.7）保持一致。

--- a/devlog/2026-07-25_release-v1.13.9-dev.1/REQ.md
+++ b/devlog/2026-07-25_release-v1.13.9-dev.1/REQ.md
@@ -1,0 +1,20 @@
+# REQ: Release v1.13.9-dev.1
+
+## Goal
+
+Publish a dev prerelease (`opencode-acp@dev`) containing PR #180 (remove subagent history rewriting).
+
+## Version
+
+`1.13.9-dev.1` — published to npm `dev` tag (not `latest`).
+
+## What's New Since v1.13.8-dev.1
+
+- **PR #180**: Remove `injectExtendedSubAgentResults` — the code path that rewrote historical `<task_result>` tool outputs in the parent agent's message history, causing provider prefix-cache stalls. Deleted 2 files (156 lines), removed `subAgentResultCache` from `SessionState`. `experimental.allowSubAgents` still controls subagent ACP; only the parent-history rewriting is gone.
+
+## Verification
+
+- `npm run typecheck` — clean
+- `npm test` — 851 pass / 0 fail
+- `npm run build` — clean
+- Dual-agent review: both APPROVE (Oracle + General)

--- a/devlog/2026-07-25_release-v1.13.9-dev.1/WORKLOG.md
+++ b/devlog/2026-07-25_release-v1.13.9-dev.1/WORKLOG.md
@@ -1,0 +1,19 @@
+# WORKLOG: Release v1.13.9-dev.1
+
+## Steps
+
+1. Branched from latest master (`311a771`) — includes PR #180 (merged)
+2. Bumped `package.json` version: `1.13.8-dev.1` → `1.13.9-dev.1`
+3. Added changelog entries to `README.md` and `README.zh-CN.md`
+4. Created devlog (REQ + WORKLOG)
+5. Verified: typecheck clean, 851 tests pass, build clean
+
+## CI Behavior
+
+Per AGENTS.md §5.4.5: version `1.13.9-dev.1` contains a hyphen → CI publishes with `--tag dev` and marks GitHub Release as prerelease.
+
+## Install (after merge)
+
+```json
+{ "plugin": { "opencode-acp": "dev" } }
+```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.13.8-dev.1",
+    "version": "1.13.9-dev.1",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Dev prerelease `v1.13.9-dev.1` — publishes PR #180 (remove subagent history rewriting) to the npm `dev` tag.

### What's new since `v1.13.8-dev.1`

- **PR #180** — Removed `injectExtendedSubAgentResults` from the message-transform pipeline. This code rewrote historical `<task_result>` tool outputs in the parent agent's message history on every transform run when `experimental.allowSubAgents: true`, invalidating the provider prefix cache (~56% hit rate vs healthy 96–98%). Deleted 2 files (156 lines) + `subAgentResultCache` from `SessionState`. Dual-agent reviewed (both APPROVE).

### CI behavior

Version `1.13.9-dev.1` contains a hyphen → CI publishes with `--tag dev` and marks the GitHub Release as **prerelease**.

### Install

```json
{ "plugin": { "opencode-acp": "dev" } }
```

### Verification

- `check-pr.sh` — ✓ all checks passed
- `npm run typecheck` — clean
- `npm test` — 851 pass / 0 fail
- `npm run build` — clean

> **Note**: Per AGENTS.md §5.1.1.2, PR merges are a human-only operation. The human clicks "Merge" — CI auto-publishes to npm `dev` tag.