### PR TITLE
fix: preserve recent messages from compression (task context loss)

### DIFF
--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -313,6 +313,28 @@
                     "type": ["number", "string"],
                     "default": "98%",
                     "description": "Context usage threshold at which the growth floor is bypassed and nudges fire unconditionally (emergency override). Accepts absolute token count or percentage string (e.g. \"98%\")."
+                },
+                "lastSegmentSoftBlock": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Master switch for recent-message protection. When false, all protection (preserveRecentMessages, preserveRecentTokens, preserveLastUserMessage) is disabled."
+                },
+                "preserveRecentMessages": {
+                    "type": "number",
+                    "default": 20,
+                    "minimum": 0,
+                    "description": "Minimum number of recent messages always protected from compression, regardless of nudge recommendation."
+                },
+                "preserveRecentTokens": {
+                    "type": "number",
+                    "default": 20000,
+                    "minimum": 0,
+                    "description": "Minimum token window of recent messages always protected from compression. The protection zone is the union of preserveRecentMessages count and preserveRecentTokens window."
+                },
+                "preserveLastUserMessage": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Always protect the most recent user message from compression."
                 }
             },
             "default": {
@@ -334,7 +356,11 @@
                 "minCompressRange": 5000,
                 "minNudgeGrowthRatio": 0.45,
                 "minNudgeGrowthFloor": 5000,
-                "emergencyThresholdPercent": "98%"
+                "emergencyThresholdPercent": "98%",
+                "lastSegmentSoftBlock": true,
+                "preserveRecentMessages": 20,
+                "preserveRecentTokens": 20000,
+                "preserveLastUserMessage": true
             }
         },
         "gc": {

--- a/devlog/2026-07-26_preserve-recent-messages/REQ.md
+++ b/devlog/2026-07-26_preserve-recent-messages/REQ.md
@@ -1,0 +1,47 @@
+# REQ: Preserve Recent Messages from Compression
+
+## Problem
+
+When the model calls `compress`, it can include recent messages (active task context) in the compression range. The existing `checkLastSegmentDangerous` only protected the **last 1 visible message** — the model could bypass it by leaving just 1 message after the range.
+
+This caused **task context loss**: the model compressed its own active work history, then lost track of what it was doing and pivoted to unrelated tasks.
+
+## Root Cause
+
+1. `checkLastSegmentDangerous` (`pipeline.ts:236`) only checked `lastVisibleId` — 1 message
+2. `filterRecommendedRanges` correctly excluded the last segment from recommendations, but the model could voluntarily extend the range beyond recommendations
+3. No enforcement mechanism bridged the gap between recommendation (advisory) and execution (enforced)
+
+## Solution
+
+Replace single-message protection with a multi-rule protected zone:
+
+1. **Last N messages** (default: 20) — protect the most recent visible messages
+2. **Last N tokens** (default: 20,000) — protect ~20K tokens expanding backward from the end
+3. **Last user message** (default: true) — always protect the most recent user message
+
+All three rules are combined (union). The protected zone is enforced at two layers:
+- **Recommendation filter**: Protected ranges excluded from nudge's recommended list
+- **Compress enforcement**: `checkProtectedRange` rejects compress calls covering protected messages (unless `dangerous: true`)
+
+## Config
+
+```jsonc
+{
+    "compress": {
+        "preserveRecentMessages": 20,
+        "preserveRecentTokens": 20000,
+        "preserveLastUserMessage": true
+    }
+}
+```
+
+All fields are optional with defaults. `lastSegmentSoftBlock: false` disables all protection (master switch, same as before).
+
+## Growth Accounting
+
+When all compressible ranges fall within the protected zone, the nudge is automatically suppressed (treated as `nothingToCompress`). This prevents the model from being asked to compress when there's nothing safe to compress.
+
+## Scope
+
+Separate branch from tier-compression (PR #200). This is a bug fix, shipped as v1.13.10 hotfix.

--- a/devlog/2026-07-26_preserve-recent-messages/WORKLOG.md
+++ b/devlog/2026-07-26_preserve-recent-messages/WORKLOG.md
@@ -1,0 +1,58 @@
+# WORKLOG: Preserve Recent Messages from Compression
+
+## Changes
+
+### 1. Config (`lib/config.ts`)
+- Added 3 optional fields to `CompressConfig`: `preserveRecentMessages`, `preserveRecentTokens`, `preserveLastUserMessage`
+- Added defaults to `DEFAULT_CONFIG.compress`: 20 / 20000 / true
+
+### 2. Pipeline (`lib/compress/pipeline.ts`)
+- Replaced `checkLastSegmentDangerous` with `checkProtectedRange`
+- Added `computeProtectedRawIds` — computes protected message IDs from 3 rules (message count, token count, last user message)
+- Fixed `preserveN=0` bug: `slice(-0)` returns all elements in JavaScript; added `if (preserveN > 0)` guard
+- Error message now shows actual config values instead of hardcoded "20"
+
+### 3. Inject Utils (`lib/messages/inject/utils.ts`)
+- Added `computeProtectedRefs` — same 3-rule computation but returns refs (mNNNNN) for recommendation filtering
+- Added `excludeProtectedRanges` — filters ranges whose startRef is in the protected set
+- Fixed same `preserveN=0` bug
+
+### 4. Inject (`lib/messages/inject/inject.ts`)
+- Imported `computeProtectedRefs` and `excludeProtectedRanges`
+- Applied protection filtering BEFORE `filterRecommendedRanges` — protected ranges never appear in recommendations
+- Nudge suppression is automatic: if all ranges are filtered → `nothingToCompress` → nudge suppressed
+
+### 5. Callers Updated
+- `lib/compress/range.ts`: `checkLastSegmentDangerous` → `checkProtectedRange`
+- `lib/compress/message.ts`: same
+
+### 6. Tests
+
+**`tests/soft-block.test.ts`** (rewritten, 8 tests):
+1. Compressing recent messages fails without `dangerous`
+2. Compressing recent messages with `dangerous: true` succeeds
+3. Compressing old messages (outside 20-msg window) succeeds
+4. `lastSegmentSoftBlock: false` disables protection
+5. Error message mentions protected message IDs
+6. Last user message always protected (even outside message-count window)
+7. Custom `preserveRecentMessages: 5` only protects last 5
+8. `preserveRecentMessages: 0` + `preserveRecentTokens: 0` disables all protection
+
+**`tests/preserve-recent.test.ts`** (new, 7 tests):
+1. Default config protects last 40 msgs (token rule broader than count)
+2. Last user message always protected with count=1
+3. Token-only protection (count=0)
+4. All disabled returns empty set
+5. `excludeProtectedRanges` removes ranges starting in protected zone
+6. Empty protected set returns all ranges
+7. Nudge suppressed when all compressible ranges are in protected zone
+
+**Existing tests updated:**
+- `tests/inject.test.ts`: Added `preserveRecentMessages: 0, preserveRecentTokens: 0, preserveLastUserMessage: false` to `buildConfig()` — disables protection for nudge growth tests
+- `tests/e2e-blocks-nudges.test.ts`: Same config fields added
+
+## Verification
+
+- typecheck: PASS
+- 861 tests pass, 0 fail
+- Build: PASS

--- a/lib/compress/message.ts
+++ b/lib/compress/message.ts
@@ -8,7 +8,7 @@ import {
     prepareSession,
     snapshotCompressionState,
     restoreCompressionState,
-    checkLastSegmentDangerous,
+    checkProtectedRange,
     checkPhantomBlock,
     type NotificationEntry,
 } from "./pipeline"
@@ -138,7 +138,7 @@ export function createCompressMessageTool(factoryCtx: ToolFactoryContext): Retur
             const dangerous =
                 (args as { dangerous?: boolean }).dangerous === true
 
-            const lastSegmentError = checkLastSegmentDangerous(
+            const lastSegmentError = checkProtectedRange(
                 ctx,
                 plans.map((p) => p.selection.messageIds),
                 rawMessages,

--- a/lib/compress/pipeline.ts
+++ b/lib/compress/pipeline.ts
@@ -246,6 +246,7 @@ export function computeProtectedRawIds(
         const id = msg?.info?.id
         if (!id || typeof id !== "string") continue
         if (isSyntheticMessage(msg)) continue
+        if (isIgnoredUserMessage(msg)) continue
         if (state.prune.messages.byMessageId.has(id)) continue
         let tokens = 0
         for (const part of msg.parts || []) {

--- a/lib/compress/pipeline.ts
+++ b/lib/compress/pipeline.ts
@@ -226,11 +226,71 @@ export function checkPhantomBlock(
 }
 
 /**
- * Stateless check: if any plan covers the most recent visible message,
- * the caller must pass `dangerous: true` to proceed. Returns an Error
- * to throw if the caller did not opt in.
+ * Compute the set of protected message raw IDs based on recent-message,
+ * recent-token, and last-user-message rules. These IDs cannot be included
+ * in a compression plan unless the caller passes `dangerous: true`.
  */
-export function checkLastSegmentDangerous(
+export function computeProtectedRawIds(
+    rawMessages: WithParts[],
+    state: SessionState,
+    compress: import("../config").CompressConfig,
+): Set<string> {
+    const preserveN = compress.preserveRecentMessages ?? 20
+    const preserveTokens = compress.preserveRecentTokens ?? 20000
+    const preserveLastUser = compress.preserveLastUserMessage ?? true
+
+    const result = new Set<string>()
+
+    const visible: { id: string; tokens: number; isUser: boolean }[] = []
+    for (const msg of rawMessages) {
+        const id = msg?.info?.id
+        if (!id || typeof id !== "string") continue
+        if (isSyntheticMessage(msg)) continue
+        if (state.prune.messages.byMessageId.has(id)) continue
+        let tokens = 0
+        for (const part of msg.parts || []) {
+            if (part.type === "text" && typeof (part as any).text === "string") {
+                tokens += Math.round(((part as any).text as string).length / 4)
+            } else if (part.type !== "text" && part.type !== "reasoning") {
+                tokens += Math.round(JSON.stringify(part).length / 4)
+            }
+        }
+        visible.push({ id, tokens, isUser: msg.info.role === "user" })
+    }
+
+    if (preserveN > 0) {
+        for (const m of visible.slice(-preserveN)) {
+            result.add(m.id)
+        }
+    }
+
+    if (preserveTokens > 0) {
+        let tokenAccum = 0
+        for (let i = visible.length - 1; i >= 0 && tokenAccum < preserveTokens; i--) {
+            result.add(visible[i]!.id)
+            tokenAccum += visible[i]!.tokens
+        }
+    }
+
+    if (preserveLastUser) {
+        for (let i = visible.length - 1; i >= 0; i--) {
+            if (visible[i]!.isUser) {
+                result.add(visible[i]!.id)
+                break
+            }
+        }
+    }
+
+    return result
+}
+
+/**
+ * Reject compression plans that cover protected messages (last N messages,
+ * last N tokens, or the most recent user message). The caller must pass
+ * `dangerous: true` to proceed. Returns an Error to throw if the caller
+ * did not opt in.
+ */
+export function checkProtectedRange(
     ctx: ToolContext,
     allPlanMessageIds: string[][],
     rawMessages: WithParts[],
@@ -238,17 +298,30 @@ export function checkLastSegmentDangerous(
 ): Error | null {
     if (ctx.config.compress.lastSegmentSoftBlock === false) return null
 
-    const lastVisibleId = getLastVisibleMessageId(rawMessages, ctx.state)
-    if (!lastVisibleId) return null
+    const protectedIds = computeProtectedRawIds(rawMessages, ctx.state, ctx.config.compress)
+    if (protectedIds.size === 0) return null
 
-    const coversLast = allPlanMessageIds.some((ids) => ids.includes(lastVisibleId))
-    if (!coversLast) return null
+    const coveredProtected: string[] = []
+    for (const ids of allPlanMessageIds) {
+        for (const id of ids) {
+            if (protectedIds.has(id)) {
+                coveredProtected.push(id)
+            }
+        }
+    }
 
+    if (coveredProtected.length === 0) return null
     if (dangerous) return null
 
+    const sample = coveredProtected.slice(0, 3).join(", ")
+    const nMsgs = ctx.config.compress.preserveRecentMessages ?? 20
+    const nToks = ctx.config.compress.preserveRecentTokens ?? 20000
     return new Error(
-        `This range includes the most recent message (${lastVisibleId}), which is likely still needed for the current task step.\n\n` +
-            `If you are certain this content is genuinely consumed and must be compressed, re-issue the call with \`dangerous: true\`.\n` +
-            `Otherwise, compress older ranges that do not include the tail of the conversation.`,
+        `This range includes ${coveredProtected.length} protected recent message(s) (${sample}), ` +
+            "which are likely still needed for the current task step.\n\n" +
+            `Protected zone: last ${nMsgs} messages + last ${nToks >= 1000 ? `${nToks / 1000}K` : nToks} tokens + most recent user message.\n` +
+            "If you are certain this content is genuinely consumed and must be compressed, " +
+            "re-issue the call with `dangerous: true`.\n" +
+            "Otherwise, compress older ranges that do not include the tail of the conversation.",
     )
 }

--- a/lib/compress/range.ts
+++ b/lib/compress/range.ts
@@ -7,7 +7,7 @@ import {
     prepareSession,
     snapshotCompressionState,
     restoreCompressionState,
-    checkLastSegmentDangerous,
+    checkProtectedRange,
     checkPhantomBlock,
     type NotificationEntry,
 } from "./pipeline"
@@ -173,7 +173,7 @@ export function createCompressRangeTool(factoryCtx: ToolFactoryContext): ReturnT
             const dangerous =
                 (args as { dangerous?: boolean }).dangerous === true
 
-            const lastSegmentError = checkLastSegmentDangerous(
+            const lastSegmentError = checkProtectedRange(
                 ctx,
                 filteredPlans.map((p) => p.selection.messageIds),
                 rawMessages,

--- a/lib/config-validation.ts
+++ b/lib/config-validation.ts
@@ -49,6 +49,10 @@ export const VALID_CONFIG_KEYS = new Set([
     "compress.emergencyThresholdPercent",
     "compress.maxVisibleSegments",
     "compress.keepEmbedMaxChars",
+    "compress.lastSegmentSoftBlock",
+    "compress.preserveRecentMessages",
+    "compress.preserveRecentTokens",
+    "compress.preserveLastUserMessage",
     "gc",
     "gc.algorithm",
     "gc.promotionThreshold",
@@ -540,6 +544,72 @@ export function validateConfigTypes(config: Record<string, any>): ValidationErro
                     key: "compress.keepEmbedMaxChars",
                     expected: "positive number (>= 100)",
                     actual: `${compress.keepEmbedMaxChars}`,
+                })
+            }
+
+            if (
+                compress.lastSegmentSoftBlock !== undefined &&
+                typeof compress.lastSegmentSoftBlock !== "boolean"
+            ) {
+                errors.push({
+                    key: "compress.lastSegmentSoftBlock",
+                    expected: "boolean",
+                    actual: typeof compress.lastSegmentSoftBlock,
+                })
+            }
+
+            if (
+                compress.preserveRecentMessages !== undefined &&
+                typeof compress.preserveRecentMessages !== "number"
+            ) {
+                errors.push({
+                    key: "compress.preserveRecentMessages",
+                    expected: "number",
+                    actual: typeof compress.preserveRecentMessages,
+                })
+            }
+
+            if (
+                typeof compress.preserveRecentMessages === "number" &&
+                compress.preserveRecentMessages < 0
+            ) {
+                errors.push({
+                    key: "compress.preserveRecentMessages",
+                    expected: "non-negative number (>= 0)",
+                    actual: `${compress.preserveRecentMessages}`,
+                })
+            }
+
+            if (
+                compress.preserveRecentTokens !== undefined &&
+                typeof compress.preserveRecentTokens !== "number"
+            ) {
+                errors.push({
+                    key: "compress.preserveRecentTokens",
+                    expected: "number",
+                    actual: typeof compress.preserveRecentTokens,
+                })
+            }
+
+            if (
+                typeof compress.preserveRecentTokens === "number" &&
+                compress.preserveRecentTokens < 0
+            ) {
+                errors.push({
+                    key: "compress.preserveRecentTokens",
+                    expected: "non-negative number (>= 0)",
+                    actual: `${compress.preserveRecentTokens}`,
+                })
+            }
+
+            if (
+                compress.preserveLastUserMessage !== undefined &&
+                typeof compress.preserveLastUserMessage !== "boolean"
+            ) {
+                errors.push({
+                    key: "compress.preserveLastUserMessage",
+                    expected: "boolean",
+                    actual: typeof compress.preserveLastUserMessage,
                 })
             }
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -40,6 +40,12 @@ export interface CompressConfig {
     maxVisibleSegments: number
     keepEmbedMaxChars: number
     lastSegmentSoftBlock?: boolean
+    /** Protect the last N visible messages from compression (default: 20). */
+    preserveRecentMessages?: number
+    /** Protect the last ~N tokens of visible messages (default: 20000). */
+    preserveRecentTokens?: number
+    /** Always protect the most recent user message (default: true). */
+    preserveLastUserMessage?: boolean
 }
 
 export interface Commands {
@@ -235,6 +241,9 @@ const defaultConfig: PluginConfig = {
         maxVisibleSegments: 50,
         keepEmbedMaxChars: 2000,
         lastSegmentSoftBlock: true,
+        preserveRecentMessages: 20,
+        preserveRecentTokens: 20000,
+        preserveLastUserMessage: true,
     },
     strategies: {
         deduplication: {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -475,6 +475,9 @@ export function mergeCompress(
     maxVisibleSegments: override.maxVisibleSegments ?? base.maxVisibleSegments,
     keepEmbedMaxChars: override.keepEmbedMaxChars ?? base.keepEmbedMaxChars,
     lastSegmentSoftBlock: override.lastSegmentSoftBlock ?? base.lastSegmentSoftBlock,
+    preserveRecentMessages: override.preserveRecentMessages ?? base.preserveRecentMessages,
+    preserveRecentTokens: override.preserveRecentTokens ?? base.preserveRecentTokens,
+    preserveLastUserMessage: override.preserveLastUserMessage ?? base.preserveLastUserMessage,
     }
 }
 

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -26,9 +26,11 @@ import {
     applyAnchoredNudges,
     buildCompressibleRanges,
     buildContextUsageGuidance,
+    computeProtectedRefs,
     computeShouldNudge,
     countMessagesAfterIndex,
     estimateContextComposition,
+    excludeProtectedRanges,
     filterRecommendedRanges,
     findLastNonIgnoredMessage,
     formatCompressibleRanges,
@@ -322,8 +324,12 @@ export const injectCompressNudges = (
         config.compress.protectedTools,
         config.protectedFilePatterns,
     )
+
+    const protectedRefs = computeProtectedRefs(messages, state, config.compress)
+    const unprotectedCompressible = excludeProtectedRanges(contextRanges.compressible, protectedRefs)
+
     const recommendedRanges = filterRecommendedRanges(
-        contextRanges.compressible,
+        unprotectedCompressible,
         contextRanges.protected,
         { modelContextLimit, growthRatio: 0.05, logger },
     )

--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -1058,3 +1058,80 @@ export function formatCompressibleRanges(
 
     return `Compressible ranges (oldest first):\n${lines.join("\n")}`
 }
+
+/**
+ * Compute the set of protected message refs (mNNNNN) that should be excluded
+ * from compression recommendations. Combines three rules:
+ *   1. Last N messages (preserveRecentMessages, default 20)
+ *   2. Last N tokens expanding backward (preserveRecentTokens, default 20000)
+ *   3. Most recent user message (preserveLastUserMessage, default true)
+ *
+ * Only considers visible, non-synthetic, non-pruned messages.
+ */
+export function computeProtectedRefs(
+    messages: WithParts[],
+    state: SessionState,
+    compress: PluginConfig["compress"],
+): Set<string> {
+    const preserveN = compress.preserveRecentMessages ?? 20
+    const preserveTokens = compress.preserveRecentTokens ?? 20000
+    const preserveLastUser = compress.preserveLastUserMessage ?? true
+
+    const result = new Set<string>()
+
+    const visible: { ref: string; tokens: number; isUser: boolean }[] = []
+    for (const msg of messages) {
+        if (isSyntheticMessage(msg)) continue
+        const ref = state.messageIds.byRawId.get(msg.info.id)
+        if (!ref) continue
+        if (state.prune.messages.byMessageId.has(msg.info.id)) continue
+
+        let tokens = 0
+        for (const part of msg.parts || []) {
+            if (part.type === "text" && typeof (part as any).text === "string") {
+                tokens += Math.round(((part as any).text as string).length / 4)
+            } else if (part.type !== "text" && part.type !== "reasoning") {
+                tokens += Math.round(JSON.stringify(part).length / 4)
+            }
+        }
+        visible.push({ ref, tokens, isUser: msg.info.role === "user" })
+    }
+
+    if (preserveN > 0) {
+        for (const m of visible.slice(-preserveN)) {
+            result.add(m.ref)
+        }
+    }
+
+    if (preserveTokens > 0) {
+        let tokenAccum = 0
+        for (let i = visible.length - 1; i >= 0 && tokenAccum < preserveTokens; i--) {
+            result.add(visible[i]!.ref)
+            tokenAccum += visible[i]!.tokens
+        }
+    }
+
+    if (preserveLastUser) {
+        for (let i = visible.length - 1; i >= 0; i--) {
+            if (visible[i]!.isUser) {
+                result.add(visible[i]!.ref)
+                break
+            }
+        }
+    }
+
+    return result
+}
+
+/**
+ * Filter compressible ranges to exclude those that start within the protected
+ * zone. Since the protected zone is always at the tail of the conversation,
+ * a range whose startRef is protected is entirely within the protected zone.
+ */
+export function excludeProtectedRanges(
+    ranges: CompressibleRange[],
+    protectedRefs: Set<string>,
+): CompressibleRange[] {
+    if (protectedRefs.size === 0) return ranges
+    return ranges.filter((r) => !protectedRefs.has(r.startRef))
+}

--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -1073,6 +1073,8 @@ export function computeProtectedRefs(
     state: SessionState,
     compress: PluginConfig["compress"],
 ): Set<string> {
+    if (compress.lastSegmentSoftBlock === false) return new Set()
+
     const preserveN = compress.preserveRecentMessages ?? 20
     const preserveTokens = compress.preserveRecentTokens ?? 20000
     const preserveLastUser = compress.preserveLastUserMessage ?? true
@@ -1082,6 +1084,7 @@ export function computeProtectedRefs(
     const visible: { ref: string; tokens: number; isUser: boolean }[] = []
     for (const msg of messages) {
         if (isSyntheticMessage(msg)) continue
+        if (isIgnoredUserMessage(msg)) continue
         const ref = state.messageIds.byRawId.get(msg.info.id)
         if (!ref) continue
         if (state.prune.messages.byMessageId.has(msg.info.id)) continue
@@ -1124,14 +1127,18 @@ export function computeProtectedRefs(
 }
 
 /**
- * Filter compressible ranges to exclude those that start within the protected
- * zone. Since the protected zone is always at the tail of the conversation,
- * a range whose startRef is protected is entirely within the protected zone.
+ * Filter compressible ranges to exclude those overlapping the protected zone.
+ * Since the protected zone is always at the tail of the conversation, a range
+ * whose startRef or endRef is protected is partially or fully within the zone.
+ * Compressing such a range would either be rejected by the enforcement check
+ * or waste model effort — exclude it preemptively.
  */
 export function excludeProtectedRanges(
     ranges: CompressibleRange[],
     protectedRefs: Set<string>,
 ): CompressibleRange[] {
     if (protectedRefs.size === 0) return ranges
-    return ranges.filter((r) => !protectedRefs.has(r.startRef))
+    return ranges.filter(
+        (r) => !protectedRefs.has(r.startRef) && !protectedRefs.has(r.endRef),
+    )
 }

--- a/scripts/e2e/run-e2e.sh
+++ b/scripts/e2e/run-e2e.sh
@@ -118,7 +118,10 @@ cat > "$FAKE_HOME/.config/opencode/acp.jsonc" <<'ACPJSON'
     "experimental": { "allowSubAgents": true },
     "compress": {
         "minCompressRange": 0,
-        "maxSummaryLengthHard": 20000
+        "maxSummaryLengthHard": 20000,
+        "preserveRecentMessages": 0,
+        "preserveRecentTokens": 0,
+        "preserveLastUserMessage": false
     },
     "qualityGate": {
         "enabled": true,

--- a/tests/config-validation.test.ts
+++ b/tests/config-validation.test.ts
@@ -199,3 +199,67 @@ test("validateConfigTypes rejects percentage > 100 in emergencyThresholdPercent"
     assert.equal(result.length, 1)
     assert.equal(result[0].key, "compress.emergencyThresholdPercent")
 })
+
+test("validateConfigTypes catches wrong type for compress.lastSegmentSoftBlock", () => {
+    const result = validateConfigTypes({
+        compress: { lastSegmentSoftBlock: "yes" },
+    })
+    assert.equal(result.length, 1)
+    assert.equal(result[0].key, "compress.lastSegmentSoftBlock")
+    assert.equal(result[0].expected, "boolean")
+})
+
+test("validateConfigTypes catches wrong type for compress.preserveRecentMessages", () => {
+    const result = validateConfigTypes({
+        compress: { preserveRecentMessages: "20" },
+    })
+    assert.equal(result.length, 1)
+    assert.equal(result[0].key, "compress.preserveRecentMessages")
+    assert.equal(result[0].expected, "number")
+})
+
+test("validateConfigTypes rejects negative compress.preserveRecentMessages", () => {
+    const result = validateConfigTypes({
+        compress: { preserveRecentMessages: -5 },
+    })
+    assert.equal(result.length, 1)
+    assert.equal(result[0].key, "compress.preserveRecentMessages")
+})
+
+test("validateConfigTypes catches wrong type for compress.preserveRecentTokens", () => {
+    const result = validateConfigTypes({
+        compress: { preserveRecentTokens: true },
+    })
+    assert.equal(result.length, 1)
+    assert.equal(result[0].key, "compress.preserveRecentTokens")
+    assert.equal(result[0].expected, "number")
+})
+
+test("validateConfigTypes rejects negative compress.preserveRecentTokens", () => {
+    const result = validateConfigTypes({
+        compress: { preserveRecentTokens: -100 },
+    })
+    assert.equal(result.length, 1)
+    assert.equal(result[0].key, "compress.preserveRecentTokens")
+})
+
+test("validateConfigTypes catches wrong type for compress.preserveLastUserMessage", () => {
+    const result = validateConfigTypes({
+        compress: { preserveLastUserMessage: 1 },
+    })
+    assert.equal(result.length, 1)
+    assert.equal(result[0].key, "compress.preserveLastUserMessage")
+    assert.equal(result[0].expected, "boolean")
+})
+
+test("getInvalidConfigKeys accepts new preserveRecent* keys", () => {
+    const result = getInvalidConfigKeys({
+        compress: {
+            lastSegmentSoftBlock: true,
+            preserveRecentMessages: 20,
+            preserveRecentTokens: 20000,
+            preserveLastUserMessage: true,
+        },
+    })
+    assert.equal(result.length, 0)
+})

--- a/tests/e2e-blocks-nudges.test.ts
+++ b/tests/e2e-blocks-nudges.test.ts
@@ -51,6 +51,9 @@ function buildConfig(overrides: Partial<PluginConfig> = {}): PluginConfig {
             protectedTools: ["task"],
             protectTags: false,
             protectUserMessages: false,
+            preserveRecentMessages: 0,
+            preserveRecentTokens: 0,
+            preserveLastUserMessage: false,
         },
         strategies: {
             deduplication: { enabled: true, protectedTools: [] },

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -33,6 +33,7 @@ function buildConfig(mode: "message" | "range" = "range"): PluginConfig {
             minCompressRange: 5000, minNudgeGrowthRatio: 0.45,
             minNudgeGrowthFloor: 5000, emergencyThresholdPercent: "98%",
             maxVisibleSegments: 50, keepEmbedMaxChars: 2000,
+            preserveRecentMessages: 0, preserveRecentTokens: 0, preserveLastUserMessage: false,
         },
         strategies: {
             deduplication: { enabled: true, protectedTools: [] },

--- a/tests/preserve-recent.test.ts
+++ b/tests/preserve-recent.test.ts
@@ -97,6 +97,15 @@ function setupRefs(state: ReturnType<typeof createSessionState>, count: number) 
 
 const logger = new Logger(false)
 
+function suffixText(messages: WithParts[]): string | null {
+    const last = messages[messages.length - 1]
+    if (!last) return null
+    const parts = (last as any).parts as Array<{ type: string; text?: string }> | undefined
+    if (!parts) return null
+    const texts = parts.filter((p) => p.type === "text" && p.text).map((p) => p.text!)
+    return texts.length > 0 ? texts.join("") : null
+}
+
 // 50 msgs × 2000 chars = 500 tokens each
 // preserveRecentMessages=20 → last 20 protected (m00031–m00050)
 // preserveRecentTokens=20000 → 20000/500 = 40 msgs → last 40 protected (m00011–m00050)
@@ -179,4 +188,80 @@ test("nudge suppressed when all compressible ranges are in protected zone", () =
         false,
         "all 5 messages in protected zone (last 20) → nudge suppressed",
     )
+})
+
+test("growth hits protected zone only: nudge suppressed even with large growth", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 50_000
+    setupRefs(state, 10)
+
+    const config = buildConfig({ maxContextLimit: 500_000, minContextLimit: 50_000 })
+
+    const messages = buildMessages(10, 20_000)
+
+    injectCompressNudges(state, config, logger, messages, {} as any)
+
+    assert.equal(
+        state.nudges.shouldInjectThisTurn,
+        false,
+        "10 messages × 5K tok = 50K context, all in last 20 → nudge suppressed despite growth",
+    )
+})
+
+test("partial protection: few unprotected messages → very small compressible list", () => {
+    const state = createSessionState()
+    setupRefs(state, 25)
+
+    const messages = buildMessages(25, 2000)
+
+    const compress = buildCompress({ preserveRecentMessages: 20, preserveRecentTokens: 0 })
+    const protectedRefs = computeProtectedRefs(messages, state, compress)
+
+    assert.equal(protectedRefs.size, 20, "20 of 25 messages protected")
+    assert.ok(!protectedRefs.has("m00001"), "msg-1 NOT protected")
+    assert.ok(!protectedRefs.has("m00005"), "msg-5 NOT protected")
+    assert.ok(protectedRefs.has("m00006"), "msg-6 protected (within last 20)")
+})
+
+test("partial protection: all messages protected → empty compressible after filtering", () => {
+    const state = createSessionState()
+    setupRefs(state, 10)
+
+    const messages = buildMessages(10, 2000)
+
+    const compress = buildCompress()
+    const protectedRefs = computeProtectedRefs(messages, state, compress)
+
+    const allRanges: CompressibleRange[] = [
+        { startRef: "m00001", endRef: "m00005", count: 5, tokens: 2500, toolPct: 0, textPct: 100 },
+        { startRef: "m00006", endRef: "m00010", count: 5, tokens: 2500, toolPct: 0, textPct: 100 },
+    ]
+
+    const filtered = excludeProtectedRanges(allRanges, protectedRefs)
+    assert.equal(filtered.length, 0, "all ranges filtered when all messages are protected")
+})
+
+test("edge case: preserveRecentMessages=5 with 8 msgs → only 3 compressible", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 0
+    setupRefs(state, 8)
+
+    const config = buildConfig({
+        maxContextLimit: 500_000,
+        minContextLimit: 50_000,
+        preserveRecentMessages: 5,
+        preserveRecentTokens: 0,
+        preserveLastUserMessage: false,
+    })
+
+    const messages = buildMessages(8, 30_000)
+
+    injectCompressNudges(state, config, logger, messages, {} as any)
+
+    const protectedRefs = computeProtectedRefs(messages, state, config.compress)
+    assert.equal(protectedRefs.size, 5, "exactly 5 messages protected (msg-4 through msg-8)")
+    assert.ok(!protectedRefs.has("m00003"), "msg-3 NOT protected")
+    assert.ok(protectedRefs.has("m00004"), "msg-4 protected (within last 5)")
 })

--- a/tests/preserve-recent.test.ts
+++ b/tests/preserve-recent.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { createSessionState, type WithParts } from "../lib/state"
+import type { PluginConfig } from "../lib/config"
+import { Logger } from "../lib/logger"
+import { computeProtectedRefs, excludeProtectedRanges, type CompressibleRange } from "../lib/messages/inject/utils"
+import { injectCompressNudges } from "../lib/messages/inject/inject"
+
+const SID = "ses-preserve-test"
+
+function buildCompress(p: Partial<PluginConfig["compress"]> = {}): PluginConfig["compress"] {
+    return {
+        mode: "range",
+        permission: "allow",
+        showCompression: false,
+        summaryBuffer: true,
+        maxContextLimit: 150000,
+        minContextLimit: 50000,
+        nudgeFrequency: 5,
+        iterationNudgeThreshold: 15,
+        nudgeForce: "soft",
+        protectedTools: [],
+        protectTags: false,
+        protectUserMessages: false,
+        minNudgeContextPercent: 15,
+        maxSummaryLengthHard: 10000,
+        minCompressRange: 5000,
+        minNudgeGrowthRatio: 0.45,
+        minNudgeGrowthFloor: 5000,
+        emergencyThresholdPercent: "98%",
+        maxVisibleSegments: 50,
+        keepEmbedMaxChars: 2000,
+        preserveRecentMessages: 20,
+        preserveRecentTokens: 20000,
+        preserveLastUserMessage: true,
+        ...p,
+    }
+}
+
+function buildConfig(compressOverrides: Partial<PluginConfig["compress"]> = {}): PluginConfig {
+    return {
+        enabled: true,
+        autoUpdate: true,
+        debug: false,
+        pruneNotification: "off",
+        pruneNotificationType: "chat",
+        commands: { enabled: true, protectedTools: [] },
+        manualMode: { enabled: false, automaticStrategies: true },
+        turnProtection: { enabled: false, turns: 4 },
+        experimental: { allowSubAgents: false, customPrompts: false },
+        protectedFilePatterns: [],
+        compress: buildCompress(compressOverrides),
+        strategies: {
+            deduplication: { enabled: true, protectedTools: [] },
+            purgeErrors: { enabled: true, turns: 4, protectedTools: [] },
+        },
+        gc: {
+            algorithm: "truncate",
+            promotionThreshold: 5,
+            maxBlockAge: 15,
+            maxOldGenSummaryLength: 3000,
+            majorGcThresholdPercent: "100%",
+            batchCleanup: { lowThreshold: "60%", highThreshold: "75%", forceThreshold: "90%" },
+        },
+    }
+}
+
+function msg(id: string, role: "user" | "assistant", text: string): WithParts {
+    return {
+        info: {
+            id,
+            role,
+            sessionID: SID,
+            agent: "assistant",
+            ...(role === "user" ? { model: { providerID: "anthropic", modelID: "claude-test" } } : {}),
+            time: { created: 1 },
+        } as WithParts["info"],
+        parts: [{ id: `p-${id}`, messageID: id, sessionID: SID, type: "text" as const, text }],
+    }
+}
+
+function buildMessages(count: number, charPerMsg: number): WithParts[] {
+    const messages: WithParts[] = []
+    for (let i = 1; i <= count; i++) {
+        const id = `msg-${i}`
+        const role: "user" | "assistant" = i % 2 === 1 ? "user" : "assistant"
+        messages.push(msg(id, role, "x".repeat(charPerMsg)))
+    }
+    return messages
+}
+
+function setupRefs(state: ReturnType<typeof createSessionState>, count: number) {
+    for (let i = 1; i <= count; i++) {
+        state.messageIds.byRawId.set(`msg-${i}`, `m${String(i).padStart(5, "0")}`)
+    }
+}
+
+const logger = new Logger(false)
+
+// 50 msgs × 2000 chars = 500 tokens each
+// preserveRecentMessages=20 → last 20 protected (m00031–m00050)
+// preserveRecentTokens=20000 → 20000/500 = 40 msgs → last 40 protected (m00011–m00050)
+// Combined: m00011–m00050 (token rule is broader)
+test("computeProtectedRefs: default config protects last 40 msgs (token rule broader than count)", () => {
+    const state = createSessionState()
+    setupRefs(state, 50)
+    const messages = buildMessages(50, 2000)
+    const protectedRefs = computeProtectedRefs(messages, state, buildCompress())
+    assert.ok(protectedRefs.has("m00050"), "last message protected")
+    assert.ok(protectedRefs.has("m00011"), "msg-11 protected (token rule reaches here)")
+    assert.ok(!protectedRefs.has("m00010"), "msg-10 NOT protected (outside token window)")
+})
+
+test("computeProtectedRefs: last user message always protected even with count=1", () => {
+    const state = createSessionState()
+    setupRefs(state, 50)
+    const messages = buildMessages(50, 2000)
+    const compress = buildCompress({ preserveRecentMessages: 1, preserveRecentTokens: 0 })
+    const protectedRefs = computeProtectedRefs(messages, state, compress)
+    assert.ok(protectedRefs.has("m00050"), "last message protected by count")
+    assert.ok(protectedRefs.has("m00049"), "last user message (msg-49) protected by user-msg rule")
+    assert.ok(!protectedRefs.has("m00048"), "msg-48 NOT protected")
+})
+
+test("computeProtectedRefs: token-only protection (count=0)", () => {
+    const state = createSessionState()
+    setupRefs(state, 50)
+    const messages = buildMessages(50, 2000)
+    const compress = buildCompress({ preserveRecentMessages: 0, preserveRecentTokens: 10000 })
+    const protectedRefs = computeProtectedRefs(messages, state, compress)
+    assert.ok(protectedRefs.has("m00050"), "last message protected by tokens")
+    assert.ok(protectedRefs.has("m00031"), "msg-31 protected (10K tokens / 500 = 20 msgs back)")
+    assert.ok(!protectedRefs.has("m00030"), "msg-30 NOT protected (outside 10K window)")
+})
+
+test("computeProtectedRefs: all disabled returns empty set", () => {
+    const state = createSessionState()
+    setupRefs(state, 10)
+    const messages = buildMessages(10, 2000)
+    const compress = buildCompress({ preserveRecentMessages: 0, preserveRecentTokens: 0, preserveLastUserMessage: false })
+    const protectedRefs = computeProtectedRefs(messages, state, compress)
+    assert.equal(protectedRefs.size, 0)
+})
+
+test("excludeProtectedRanges: removes ranges starting in protected zone, keeps others", () => {
+    const ranges: CompressibleRange[] = [
+        { startRef: "m00001", endRef: "m00010", count: 10, tokens: 5000, toolPct: 50, textPct: 50 },
+        { startRef: "m00035", endRef: "m00045", count: 11, tokens: 5500, toolPct: 50, textPct: 50 },
+        { startRef: "m00046", endRef: "m00050", count: 5, tokens: 2500, toolPct: 50, textPct: 50 },
+    ]
+    const protectedRefs = new Set(["m00031", "m00032", "m00033", "m00034", "m00035", "m00046", "m00047", "m00048", "m00049", "m00050"])
+    const result = excludeProtectedRanges(ranges, protectedRefs)
+    assert.equal(result.length, 1, "only m00001-m00010 should survive (others start in protected zone)")
+    assert.equal(result[0]!.startRef, "m00001")
+})
+
+test("excludeProtectedRanges: empty protected set returns all ranges", () => {
+    const ranges: CompressibleRange[] = [
+        { startRef: "m00001", endRef: "m00010", count: 10, tokens: 5000, toolPct: 50, textPct: 50 },
+    ]
+    const result = excludeProtectedRanges(ranges, new Set())
+    assert.equal(result.length, 1)
+})
+
+test("nudge suppressed when all compressible ranges are in protected zone", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 50_000
+    setupRefs(state, 5)
+
+    const config = buildConfig({ maxContextLimit: 500_000, minContextLimit: 50_000 })
+
+    const messages = buildMessages(5, 80_000)
+
+    injectCompressNudges(state, config, logger, messages, {} as any)
+
+    assert.equal(
+        state.nudges.shouldInjectThisTurn,
+        false,
+        "all 5 messages in protected zone (last 20) → nudge suppressed",
+    )
+})

--- a/tests/preserve-recent.test.ts
+++ b/tests/preserve-recent.test.ts
@@ -190,13 +190,16 @@ test("nudge suppressed when all compressible ranges are in protected zone", () =
     )
 })
 
-test("growth hits protected zone only: nudge suppressed even with large growth", () => {
+test("growth hits protected zone only: nudge suppressed even with real growth", () => {
     const state = createSessionState()
     state.modelContextLimit = 1_000_000
-    state.nudges.lastPerMessageNudgeTokens = 50_000
+    state.nudges.lastPerMessageNudgeTokens = 0
     setupRefs(state, 10)
 
-    const config = buildConfig({ maxContextLimit: 500_000, minContextLimit: 50_000 })
+    // maxContextLimit=100K → growth threshold = max(5000, 100K * 0.45) = 45K
+    // 10 msgs × 20K chars = ~50K tok total → growth = 50K > 45K threshold (passes growth gate)
+    // But all 10 msgs are in last-20 protected zone → no compressible ranges → nudge suppressed
+    const config = buildConfig({ maxContextLimit: 100_000, minContextLimit: 50_000 })
 
     const messages = buildMessages(10, 20_000)
 
@@ -205,7 +208,7 @@ test("growth hits protected zone only: nudge suppressed even with large growth",
     assert.equal(
         state.nudges.shouldInjectThisTurn,
         false,
-        "10 messages × 5K tok = 50K context, all in last 20 → nudge suppressed despite growth",
+        "growth passes threshold (50K > 45K) but all msgs in protected zone → suppressed by protection",
     )
 })
 
@@ -264,4 +267,20 @@ test("edge case: preserveRecentMessages=5 with 8 msgs → only 3 compressible", 
     assert.equal(protectedRefs.size, 5, "exactly 5 messages protected (msg-4 through msg-8)")
     assert.ok(!protectedRefs.has("m00003"), "msg-3 NOT protected")
     assert.ok(protectedRefs.has("m00004"), "msg-4 protected (within last 5)")
+})
+
+test("excludeProtectedRanges: range extending INTO protected zone is filtered", () => {
+    const protectedRefs = new Set(["m00008", "m00009", "m00010"])
+
+    const ranges: CompressibleRange[] = [
+        { startRef: "m00001", endRef: "m00005", count: 5, tokens: 2500, toolPct: 0, textPct: 100 },
+        { startRef: "m00001", endRef: "m00008", count: 8, tokens: 4000, toolPct: 0, textPct: 100 },
+        { startRef: "m00006", endRef: "m00010", count: 5, tokens: 2500, toolPct: 0, textPct: 100 },
+        { startRef: "m00008", endRef: "m00010", count: 3, tokens: 1500, toolPct: 0, textPct: 100 },
+    ]
+
+    const filtered = excludeProtectedRanges(ranges, protectedRefs)
+    assert.equal(filtered.length, 1, "only fully-unprotected range survives")
+    assert.equal(filtered[0].startRef, "m00001")
+    assert.equal(filtered[0].endRef, "m00005")
 })

--- a/tests/soft-block.test.ts
+++ b/tests/soft-block.test.ts
@@ -37,6 +37,9 @@ function buildConfig(): PluginConfig {
             protectTags: false,
             protectUserMessages: false,
             lastSegmentSoftBlock: true,
+            preserveRecentMessages: 20,
+            preserveRecentTokens: 20000,
+            preserveLastUserMessage: true,
         },
         strategies: {
             deduplication: { enabled: true, protectedTools: [] },
@@ -57,41 +60,23 @@ function textPart(messageID: string, sessionID: string, id: string, text: string
     return { id, messageID, sessionID, type: "text" as const, text }
 }
 
-function buildMessages(sessionID: string): WithParts[] {
-    return [
-        {
+function buildMessages(sessionID: string, count = 50): WithParts[] {
+    const msgs: WithParts[] = []
+    for (let i = 1; i <= count; i++) {
+        const role = i % 2 === 1 ? "user" : "assistant"
+        msgs.push({
             info: {
-                id: "msg-user-1",
-                role: "user",
+                id: `msg-${i}`,
+                role,
                 sessionID,
                 agent: "assistant",
-                model: { providerID: "anthropic", modelID: "claude-test" },
-                time: { created: 1 },
+                ...(role === "user" ? { model: { providerID: "anthropic", modelID: "claude-test" } } : {}),
+                time: { created: i },
             } as WithParts["info"],
-            parts: [textPart("msg-user-1", sessionID, "p1", "x".repeat(6000))],
-        },
-        {
-            info: {
-                id: "msg-assistant-1",
-                role: "assistant",
-                sessionID,
-                agent: "assistant",
-                time: { created: 2 },
-            } as WithParts["info"],
-            parts: [textPart("msg-assistant-1", sessionID, "p2", "x".repeat(6000))],
-        },
-        {
-            info: {
-                id: "msg-user-2",
-                role: "user",
-                sessionID,
-                agent: "assistant",
-                model: { providerID: "anthropic", modelID: "claude-test" },
-                time: { created: 3 },
-            } as WithParts["info"],
-            parts: [textPart("msg-user-2", sessionID, "p3", "x".repeat(6000))],
-        },
-    ]
+            parts: [textPart(`msg-${i}`, sessionID, `p${i}`, "x".repeat(2000))],
+        })
+    }
+    return msgs
 }
 
 function createTool(state: any, rawMessages: WithParts[], sessionID: string, configOverrides?: Partial<PluginConfig>) {
@@ -121,8 +106,10 @@ const toolCtx = {
     messageID: "msg-compress",
 }
 
-test("dangerous: compressing last segment without dangerous flag fails", async () => {
-    const sessionID = `ses_dangerous_1_${Date.now()}`
+const ref = (n: number) => `m${String(n).padStart(5, "0")}`
+
+test("protected: compressing recent messages fails without dangerous", async () => {
+    const sessionID = `ses_protected_1_${Date.now()}`
     const rawMessages = buildMessages(sessionID)
     const state = createSessionState()
     const tool = createTool(state, rawMessages, sessionID)
@@ -133,20 +120,20 @@ test("dangerous: compressing last segment without dangerous flag fails", async (
                 {
                     topic: "Test",
                     content: [
-                        { startId: "m00001", endId: "m00003", summary: "x".repeat(2000) },
+                        { startId: ref(25), endId: ref(30), summary: "x".repeat(2000) },
                     ],
                 },
                 { ...toolCtx, sessionID },
             ),
         (err: Error) => {
-            assert.ok(err.message.includes("dangerous"), `error should mention dangerous, got: ${err.message}`)
+            assert.ok(err.message.includes("protected"), `error should mention protected, got: ${err.message}`)
             return true
         },
     )
 })
 
-test("dangerous: compressing last segment WITH dangerous: true succeeds", async () => {
-    const sessionID = `ses_dangerous_2_${Date.now()}`
+test("protected: compressing recent messages WITH dangerous: true succeeds", async () => {
+    const sessionID = `ses_protected_2_${Date.now()}`
     const rawMessages = buildMessages(sessionID)
     const state = createSessionState()
     const tool = createTool(state, rawMessages, sessionID)
@@ -154,7 +141,7 @@ test("dangerous: compressing last segment WITH dangerous: true succeeds", async 
     const result = await tool.execute(
         {
             topic: "Test",
-            content: [{ startId: "m00001", endId: "m00003", summary: "x".repeat(2000) }],
+            content: [{ startId: ref(25), endId: ref(30), summary: "x".repeat(2000) }],
             dangerous: true,
         },
         { ...toolCtx, sessionID },
@@ -162,8 +149,8 @@ test("dangerous: compressing last segment WITH dangerous: true succeeds", async 
     assert.ok(typeof result === "string" && result.includes("Compressed"), "dangerous: true should succeed")
 })
 
-test("dangerous: range not covering last message succeeds without dangerous", async () => {
-    const sessionID = `ses_dangerous_3_${Date.now()}`
+test("protected: compressing old messages (outside 20-msg window) succeeds without dangerous", async () => {
+    const sessionID = `ses_protected_3_${Date.now()}`
     const rawMessages = buildMessages(sessionID)
     const state = createSessionState()
     const tool = createTool(state, rawMessages, sessionID)
@@ -171,15 +158,15 @@ test("dangerous: range not covering last message succeeds without dangerous", as
     const result = await tool.execute(
         {
             topic: "Test",
-            content: [{ startId: "m00001", endId: "m00002", summary: "x".repeat(2000) }],
+            content: [{ startId: ref(1), endId: ref(5), summary: "x".repeat(2000) }],
         },
         { ...toolCtx, sessionID },
     )
-    assert.ok(typeof result === "string" && result.includes("Compressed"), "non-tail range should succeed without dangerous")
+    assert.ok(typeof result === "string" && result.includes("Compressed"), "old range should succeed without dangerous")
 })
 
-test("dangerous: lastSegmentSoftBlock disabled bypasses the check entirely", async () => {
-    const sessionID = `ses_dangerous_4_${Date.now()}`
+test("protected: lastSegmentSoftBlock disabled bypasses protection entirely", async () => {
+    const sessionID = `ses_protected_4_${Date.now()}`
     const rawMessages = buildMessages(sessionID)
     const state = createSessionState()
     const tool = createTool(state, rawMessages, sessionID, {
@@ -189,15 +176,15 @@ test("dangerous: lastSegmentSoftBlock disabled bypasses the check entirely", asy
     const result = await tool.execute(
         {
             topic: "Test",
-            content: [{ startId: "m00001", endId: "m00003", summary: "x".repeat(2000) }],
+            content: [{ startId: ref(25), endId: ref(30), summary: "x".repeat(2000) }],
         },
         { ...toolCtx, sessionID },
     )
-    assert.ok(typeof result === "string" && result.includes("Compressed"), "disabled check should succeed without dangerous")
+    assert.ok(typeof result === "string" && result.includes("Compressed"), "disabled protection should succeed")
 })
 
-test("dangerous: error message mentions the specific last message id", async () => {
-    const sessionID = `ses_dangerous_5_${Date.now()}`
+test("protected: error message mentions protected message IDs", async () => {
+    const sessionID = `ses_protected_5_${Date.now()}`
     const rawMessages = buildMessages(sessionID)
     const state = createSessionState()
     const tool = createTool(state, rawMessages, sessionID)
@@ -207,13 +194,88 @@ test("dangerous: error message mentions the specific last message id", async () 
             tool.execute(
                 {
                     topic: "Test",
-                    content: [{ startId: "m00001", endId: "m00003", summary: "x".repeat(2000) }],
+                    content: [{ startId: ref(28), endId: ref(30), summary: "x".repeat(2000) }],
                 },
                 { ...toolCtx, sessionID },
             ),
         (err: Error) => {
-            assert.ok(err.message.includes("msg-user-2"), "error should reference the last message id")
+            assert.ok(err.message.includes("msg-28"), "error should reference a protected message id")
             return true
         },
     )
+})
+
+test("protected: last user message is always protected even outside message window", async () => {
+    const sessionID = `ses_protected_6_${Date.now()}`
+    const rawMessages = buildMessages(sessionID, 30)
+    const state = createSessionState()
+    const tool = createTool(state, rawMessages, sessionID, {
+        compress: {
+            ...buildConfig().compress,
+            preserveRecentMessages: 1,
+            preserveRecentTokens: 100,
+            preserveLastUserMessage: true,
+        },
+    })
+
+    await assert.rejects(
+        () =>
+            tool.execute(
+                {
+                    topic: "Test",
+                    content: [{ startId: ref(28), endId: ref(29), summary: "x".repeat(2000) }],
+                },
+                { ...toolCtx, sessionID },
+            ),
+        (err: Error) => {
+            assert.ok(err.message.includes("msg-29"), `should be blocked by user message protection: ${err.message}`)
+            return true
+        },
+    )
+})
+
+test("protected: custom preserveRecentMessages=5 only protects last 5", async () => {
+    const sessionID = `ses_protected_7_${Date.now()}`
+    const rawMessages = buildMessages(sessionID, 30)
+    const state = createSessionState()
+    const tool = createTool(state, rawMessages, sessionID, {
+        compress: {
+            ...buildConfig().compress,
+            preserveRecentMessages: 5,
+            preserveRecentTokens: 100,
+            preserveLastUserMessage: false,
+        },
+    })
+
+    const result = await tool.execute(
+        {
+            topic: "Test",
+            content: [{ startId: ref(1), endId: ref(20), summary: "x".repeat(2000) }],
+        },
+        { ...toolCtx, sessionID },
+    )
+    assert.ok(typeof result === "string" && result.includes("Compressed"), "range ending before last 5 should succeed")
+})
+
+test("protected: lastSegmentSoftBlock=true with preserveRecentMessages=0 disables message-count protection", async () => {
+    const sessionID = `ses_protected_8_${Date.now()}`
+    const rawMessages = buildMessages(sessionID, 30)
+    const state = createSessionState()
+    const tool = createTool(state, rawMessages, sessionID, {
+        compress: {
+            ...buildConfig().compress,
+            preserveRecentMessages: 0,
+            preserveRecentTokens: 0,
+            preserveLastUserMessage: false,
+        },
+    })
+
+    const result = await tool.execute(
+        {
+            topic: "Test",
+            content: [{ startId: ref(25), endId: ref(30), summary: "x".repeat(2000) }],
+        },
+        { ...toolCtx, sessionID },
+    )
+    assert.ok(typeof result === "string" && result.includes("Compressed"), "no protection should allow recent compression")
 })


### PR DESCRIPTION
## Summary

- Replace single-message protection (`checkLastSegmentDangerous`) with multi-rule `checkProtectedRange`
- Protect last N messages (20) + last N tokens (20K) + last user message
- Exclude protected zone from nudge recommendations + auto-suppress nudge when all ranges protected
- Fix `preserveN=0` bug: `slice(-0)` returns all elements in JavaScript

## Problem

The old `checkLastSegmentDangerous` only protected the **last 1 visible message**. The model could bypass it by leaving just 1 message after the compress range. This caused task context loss: the model compressed its own active work history, then lost track of what it was doing and pivoted to unrelated tasks.

## Changes

| File | Change |
|------|--------|
| `lib/config.ts` | 3 new config fields with defaults |
| `lib/compress/pipeline.ts` | `checkLastSegmentDangerous` → `checkProtectedRange` + `computeProtectedRawIds` |
| `lib/compress/range.ts` + `message.ts` | Updated callers |
| `lib/messages/inject/utils.ts` | `computeProtectedRefs` + `excludeProtectedRanges` |
| `lib/messages/inject/inject.ts` | Wire protection filtering before recommendation |
| `tests/soft-block.test.ts` | 8 E2E tests (rewritten for broader protection) |
| `tests/preserve-recent.test.ts` | 7 unit tests (new) |
| `tests/inject.test.ts` + `e2e-blocks-nudges.test.ts` | Config updates |

## Config

```jsonc
{
    "compress": {
        "preserveRecentMessages": 20,
        "preserveRecentTokens": 20000,
        "preserveLastUserMessage": true
    }
}
```

All optional with defaults. `lastSegmentSoftBlock: false` disables everything (master switch).

## Test Results

861 tests pass, 0 fail. typecheck ✅ | build ✅