### PR TITLE
fix: filter getActiveSummaryTokenUsage by visible message IDs

### DIFF
--- a/devlog/2026-07-26_summary-buffer-visibility/REQ.md
+++ b/devlog/2026-07-26_summary-buffer-visibility/REQ.md
@@ -1,0 +1,39 @@
+# REQ: summaryBuffer over-counting fix
+
+## Problem
+
+`getActiveSummaryTokenUsage()` counts ALL active compression blocks' summary tokens,
+regardless of whether those blocks' compress tool calls are still visible in the
+current context window.
+
+In long-running sessions (e.g., 448 blocks, 3683 messages), opencode's own
+compaction removes old messages — including old compress tool calls. ACP's state
+still marks those blocks as active. The function returns 151K tokens instead of
+the actual ~6K visible summaries.
+
+## Impact
+
+This inflation feeds into `summaryBuffer` (context limit extension) and nudge
+trigger growth computation:
+
+- **False nudge triggers**: Growth appears as 151K → nudge fires every turn
+- **False tier 2 triggers**: T1 summary tokens appear >> 50K threshold
+- **Misleading stats**: `/acp stats` shows "summary 146%" — impossible
+- **Misleading context %**: summaryBuffer extends max limit by 151K instead of 6K
+
+## Solution
+
+Add optional `visibleMessageIds: Set<string>` parameter to
+`getActiveSummaryTokenUsage`. When provided (by the inject hook which has the
+full message list), only blocks whose `compressMessageId` is in the set are
+counted.
+
+Call sites updated:
+- `lib/messages/inject/utils.ts` — `isContextOverLimits` passes message IDs
+- `lib/commands/stats.ts` — `handleStatsCommand` passes message IDs
+
+## Non-Goals
+
+- `getTierTokenUsage()` in PR #200 has the same bug pattern — will be fixed when
+  PR #200 rebases on this fix.
+- No behavioral change when `visibleMessageIds` is omitted (backward compat).

--- a/devlog/2026-07-26_summary-buffer-visibility/WORKLOG.md
+++ b/devlog/2026-07-26_summary-buffer-visibility/WORKLOG.md
@@ -1,0 +1,30 @@
+# WORKLOG: summaryBuffer over-counting fix
+
+## Changes
+
+### `lib/state/utils.ts`
+- `getActiveSummaryTokenUsage(state, visibleMessageIds?)`: Added optional filter.
+  When provided, only counts blocks whose `compressMessageId` is in the set.
+  Blocks without `compressMessageId` are counted regardless (backward compat).
+
+### `lib/messages/inject/utils.ts`
+- `isContextOverLimits`: Builds `new Set(messages.map(m => m.info.id))` and passes
+  to `getActiveSummaryTokenUsage`. This represents the messages opencode is about
+  to send to the API (after its own compaction).
+
+### `lib/commands/stats.ts`
+- `handleStatsCommand`: Builds visibleMessageIds from ctx.messages. Filters
+  `sessionSummaryTokens` to only count visible summaries.
+
+### `tests/summary-buffer-visibility.test.ts` (NEW)
+7 tests covering: no filter (backward compat), inactive skip, filter, empty set,
+all visible, missing compressMessageId, 448-block simulation.
+
+### `tests/token-usage.test.ts`
+Fixed 2 tests: block 7 `compressMessageId` set to `"msg-assistant-post-compaction"`
+(must be in visible messages for summaryBuffer to count after the fix).
+
+## Verification
+- typecheck: PASS
+- tests: 880 pass (873 original + 7 new)
+- build: PASS

--- a/lib/commands/stats.ts
+++ b/lib/commands/stats.ts
@@ -94,8 +94,12 @@ export async function handleStatsCommand(ctx: StatsCommandContext): Promise<void
 
     // Session stats from in-memory state
     const sessionTokens = state.stats.totalPruneTokens
+    const visibleMessageIds = new Set(messages.map((m) => m.info.id))
     const sessionSummaryTokens = Array.from(state.prune.messages.blocksById.values()).reduce(
-        (total, block) => (block.active ? total + block.summaryTokens : total),
+        (total, block) =>
+            block.active && visibleMessageIds.has(block.compressMessageId ?? "")
+                ? total + block.summaryTokens
+                : total,
         0,
     )
     const sessionDurationMs = getActiveCompressionTargets(state.prune.messages).reduce(

--- a/lib/compress/status.ts
+++ b/lib/compress/status.ts
@@ -75,11 +75,16 @@ function collectVisibleMessages(
     const result: VisibleMessageInfo[] = []
     let summaryTokens = 0
 
+    const visibleMessageIds = new Set(rawMessages.map((m) => m.info.id))
+
     const activeBlocks = Array.from(ctx.state.prune.messages.activeBlockIds)
         .map((id) => ctx.state.prune.messages.blocksById.get(id))
         .filter((b): b is NonNullable<typeof b> => b !== undefined && b.active)
 
     for (const block of activeBlocks) {
+        if (block.compressMessageId && !visibleMessageIds.has(block.compressMessageId)) {
+            continue
+        }
         summaryTokens += block.summaryTokens || 0
     }
 

--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -156,7 +156,10 @@ export function isContextOverLimits(
     messages: WithParts[],
 ) {
     const summaryTokenExtension = config.compress.summaryBuffer
-        ? getActiveSummaryTokenUsage(state)
+        ? getActiveSummaryTokenUsage(
+              state,
+              new Set(messages.map((m) => m.info.id)),
+          )
         : 0
     const resolvedMaxContextLimit = resolveContextTokenLimit(
         config,

--- a/lib/state/utils.ts
+++ b/lib/state/utils.ts
@@ -335,12 +335,26 @@ export function collectTurnNudgeAnchors(messages: WithParts[]): Set<string> {
     return anchors
 }
 
-export function getActiveSummaryTokenUsage(state: SessionState): number {
+/**
+ * Sum summary tokens of active blocks.
+ * When visibleMessageIds is provided, only counts blocks whose compressMessageId
+ * is still in the context (prevents over-counting from blocks whose compress
+ * calls scrolled out via opencode compaction).
+ */
+export function getActiveSummaryTokenUsage(
+    state: SessionState,
+    visibleMessageIds?: Set<string>,
+): number {
     let total = 0
     for (const blockId of state.prune.messages.activeBlockIds) {
         const block = state.prune.messages.blocksById.get(blockId)
         if (!block || !block.active) {
             continue
+        }
+        if (visibleMessageIds && block.compressMessageId) {
+            if (!visibleMessageIds.has(block.compressMessageId)) {
+                continue
+            }
         }
         total += block.summaryTokens
     }

--- a/tests/summary-buffer-visibility.test.ts
+++ b/tests/summary-buffer-visibility.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { getActiveSummaryTokenUsage, createPruneMessagesState } from "../lib/state/utils"
+import type { CompressionBlock, SessionState } from "../lib/state/types"
+
+function makeBlock(overrides: Partial<CompressionBlock> & { blockId: number }): CompressionBlock {
+    return {
+        runId: 1,
+        active: true,
+        deactivatedByUser: false,
+        compressedTokens: 1000,
+        summaryTokens: 100,
+        durationMs: 0,
+        mode: "range",
+        topic: "test",
+        batchTopic: "",
+        startId: "s1",
+        endId: "e1",
+        anchorMessageId: "anchor-1",
+        compressMessageId: "compress-1",
+        compressCallId: undefined,
+        includedBlockIds: [],
+        consumedBlockIds: [],
+        parentBlockIds: [],
+        directMessageIds: [],
+        directToolIds: [],
+        effectiveMessageIds: [],
+        effectiveToolIds: [],
+        createdAt: 0,
+        summary: "summary",
+        survivedCount: 0,
+        generation: "young",
+        ...overrides,
+    }
+}
+
+function buildSessionState(blocks: CompressionBlock[]): Pick<SessionState, "prune"> {
+    const pruneMessages = createPruneMessagesState()
+    for (const block of blocks) {
+        pruneMessages.blocksById.set(block.blockId, block)
+        if (block.active) {
+            pruneMessages.activeBlockIds.add(block.blockId)
+        }
+    }
+    return { prune: { tools: new Map(), messages: pruneMessages } }
+}
+
+test("getActiveSummaryTokenUsage: sums all active blocks without visibility filter", () => {
+    const state = buildSessionState([
+        makeBlock({ blockId: 1, summaryTokens: 100 }),
+        makeBlock({ blockId: 2, summaryTokens: 200 }),
+        makeBlock({ blockId: 3, summaryTokens: 300 }),
+    ])
+    assert.equal(getActiveSummaryTokenUsage(state as SessionState), 600)
+})
+
+test("getActiveSummaryTokenUsage: skips inactive blocks", () => {
+    const state = buildSessionState([
+        makeBlock({ blockId: 1, summaryTokens: 100, active: true }),
+        makeBlock({ blockId: 2, summaryTokens: 200, active: false }),
+    ])
+    assert.equal(getActiveSummaryTokenUsage(state as SessionState), 100)
+})
+
+test("getActiveSummaryTokenUsage: filters by visibleMessageIds", () => {
+    const state = buildSessionState([
+        makeBlock({ blockId: 1, summaryTokens: 100, compressMessageId: "msg-A" }),
+        makeBlock({ blockId: 2, summaryTokens: 200, compressMessageId: "msg-B" }),
+        makeBlock({ blockId: 3, summaryTokens: 300, compressMessageId: "msg-C" }),
+    ])
+    const visible = new Set(["msg-A", "msg-C"])
+    assert.equal(getActiveSummaryTokenUsage(state as SessionState, visible), 400)
+})
+
+test("getActiveSummaryTokenUsage: empty visibleMessageIds returns 0", () => {
+    const state = buildSessionState([
+        makeBlock({ blockId: 1, summaryTokens: 100, compressMessageId: "msg-A" }),
+        makeBlock({ blockId: 2, summaryTokens: 200, compressMessageId: "msg-B" }),
+    ])
+    const visible = new Set<string>()
+    assert.equal(getActiveSummaryTokenUsage(state as SessionState, visible), 0)
+})
+
+test("getActiveSummaryTokenUsage: all blocks visible returns same as unfiltered", () => {
+    const state = buildSessionState([
+        makeBlock({ blockId: 1, summaryTokens: 100, compressMessageId: "msg-A" }),
+        makeBlock({ blockId: 2, summaryTokens: 200, compressMessageId: "msg-B" }),
+    ])
+    const visible = new Set(["msg-A", "msg-B"])
+    assert.equal(getActiveSummaryTokenUsage(state as SessionState, visible), 300)
+})
+
+test("getActiveSummaryTokenUsage: blocks without compressMessageId counted when filter provided", () => {
+    const state = buildSessionState([
+        makeBlock({ blockId: 1, summaryTokens: 100, compressMessageId: undefined }),
+        makeBlock({ blockId: 2, summaryTokens: 200, compressMessageId: "msg-B" }),
+    ])
+    const visible = new Set(["msg-B"])
+    assert.equal(getActiveSummaryTokenUsage(state as SessionState, visible), 300)
+})
+
+test("getActiveSummaryTokenUsage: simulates 448-block session with only 26 visible", () => {
+    const blocks: CompressionBlock[] = []
+    for (let i = 1; i <= 448; i++) {
+        blocks.push(
+            makeBlock({
+                blockId: i,
+                summaryTokens: 340,
+                compressMessageId: `msg-${i}`,
+            }),
+        )
+    }
+    const state = buildSessionState(blocks)
+
+    const allVisible = new Set<string>()
+    for (let i = 1; i <= 448; i++) allVisible.add(`msg-${i}`)
+    const recentVisible = new Set<string>()
+    for (let i = 423; i <= 448; i++) recentVisible.add(`msg-${i}`)
+
+    const withoutFilter = getActiveSummaryTokenUsage(state as SessionState)
+    const withAllVisible = getActiveSummaryTokenUsage(state as SessionState, allVisible)
+    const withRecentOnly = getActiveSummaryTokenUsage(state as SessionState, recentVisible)
+
+    assert.equal(withoutFilter, 448 * 340)
+    assert.equal(withAllVisible, 448 * 340)
+    assert.equal(withRecentOnly, 26 * 340)
+    assert.ok(withRecentOnly < withoutFilter * 0.1)
+})

--- a/tests/token-usage.test.ts
+++ b/tests/token-usage.test.ts
@@ -253,7 +253,9 @@ test("isContextOverLimits extends the max threshold by active summary tokens", (
     state.lastCompaction = 2
 
     const storedSummary = wrapCompressedSummary(7, repeatedWord("summary", 120))
-    state.prune.messages.blocksById.set(7, createActiveBlock(7, storedSummary, 1000))
+    const block7 = createActiveBlock(7, storedSummary, 1000)
+    block7.compressMessageId = "msg-assistant-post-compaction"
+    state.prune.messages.blocksById.set(7, block7)
     state.prune.messages.activeBlockIds.add(7)
 
     const freshReportedTotal = 2400 + 600 + 150 + 300
@@ -287,7 +289,9 @@ test("isContextOverLimits does not extend the max threshold when summaryBuffer i
     state.lastCompaction = 2
 
     const storedSummary = wrapCompressedSummary(7, repeatedWord("summary", 120))
-    state.prune.messages.blocksById.set(7, createActiveBlock(7, storedSummary, 1000))
+    const block7b = createActiveBlock(7, storedSummary, 1000)
+    block7b.compressMessageId = "msg-assistant-post-compaction"
+    state.prune.messages.blocksById.set(7, block7b)
     state.prune.messages.activeBlockIds.add(7)
 
     const freshReportedTotal = 2400 + 600 + 150 + 300


### PR DESCRIPTION
## Summary

`getActiveSummaryTokenUsage()` counted ALL active blocks' summary tokens regardless of whether their compress calls scrolled out of context via opencode compaction. In 448-block sessions this inflated summary usage from ~6K (real) to ~151K, causing:

- **False nudge triggers** every turn (growth inflated to 151K)
- **False tier 2 triggers** (T1 tokens appear >> 50K threshold)
- **Misleading `/acp stats`** showing "summary 146%" — impossible
- **Misleading context %** (summaryBuffer extends by 151K instead of 6K)

## Fix

Added optional `visibleMessageIds?: Set<string>` parameter. When provided by the inject hook (which has the full message list), only blocks whose `compressMessageId` is in the set are counted.

### Changes
- `lib/state/utils.ts`: `getActiveSummaryTokenUsage(state, visibleMessageIds?)` — optional filter
- `lib/messages/inject/utils.ts`: `isContextOverLimits` passes message IDs from context
- `lib/commands/stats.ts`: `handleStatsCommand` filters by visible message IDs
- `tests/summary-buffer-visibility.test.ts`: 7 new tests including 448-block simulation
- `tests/token-usage.test.ts`: Fixed 2 tests (compressMessageId must be in visible messages)

## Verification
- typecheck: PASS
- tests: 880 pass (873 + 7 new)
- build: PASS