### PR TITLE
feat(log): add ACP version to daily logs and context logs

### DIFF
--- a/devlog/2026-07-26_log-version-info/REQ.md
+++ b/devlog/2026-07-26_log-version-info/REQ.md
@@ -1,0 +1,13 @@
+# Add ACP Version Info to Logs
+
+## Problem
+Daily logs and context logs had no ACP version info. When investigating issues across sessions that ran different ACP versions, there was no way to determine which version produced each log entry.
+
+## Solution
+- **Daily log**: Append `| v={VERSION}` to every log line
+- **Context log**: Write `_version` file in each session's context directory (first-write only)
+- Version injected at build time via tsup `define` from `package.json`
+
+## Changes
+- `tsup.config.ts`: Added `define: { ACP_VERSION: pkg.version }`
+- `lib/logger.ts`: `LOG_VERSION` constant + daily log suffix + context `_version` file

--- a/devlog/2026-07-26_log-version-info/WORKLOG.md
+++ b/devlog/2026-07-26_log-version-info/WORKLOG.md
@@ -1,0 +1,13 @@
+# Worklog: Log Version Info
+
+## Implementation
+1. `tsup.config.ts`: Import `package.json`, add `define: { ACP_VERSION: JSON.stringify(pkg.version) }`
+2. `lib/logger.ts`:
+   - `declare const ACP_VERSION` (build-time injected)
+   - `LOG_VERSION` constant (falls back to `"dev"` when not bundled, e.g. tsx tests)
+   - Daily log line: append `| v={LOG_VERSION}`
+   - Context log: write `_version` file on first snapshot per session
+
+## Verification
+- typecheck ✅ | build ✅ | 919 tests pass ✅
+- Bundle verified: `LOG_VERSION` × 4 occurrences in dist/index.js

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -3,6 +3,11 @@ import { join } from "path"
 import { existsSync } from "fs"
 import { homedir } from "os"
 
+/** ACP version, injected at build time by tsup define */
+declare const ACP_VERSION: string | undefined
+
+const LOG_VERSION = typeof ACP_VERSION !== "undefined" ? ACP_VERSION : "dev"
+
 export class Logger {
     private logDir: string
     public enabled: boolean
@@ -76,7 +81,7 @@ export class Logger {
             const timestamp = new Date().toISOString()
             const dataStr = this.formatData(data)
 
-            const logLine = `${timestamp} ${level.padEnd(5)} ${component}: ${message}${dataStr ? " | " + dataStr : ""}\n`
+            const logLine = `${timestamp} ${level.padEnd(5)} ${component}: ${message}${dataStr ? " | " + dataStr : ""} | v=${LOG_VERSION}\n`
 
             const dailyLogDir = join(this.logDir, "daily")
             if (!existsSync(dailyLogDir)) {
@@ -225,6 +230,11 @@ export class Logger {
             const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
             const contextFile = join(contextDir, `${timestamp}.json`)
             await writeFile(contextFile, JSON.stringify(minimized, null, 2))
+
+            const versionFile = join(contextDir, "_version")
+            if (!existsSync(versionFile)) {
+                await writeFile(versionFile, LOG_VERSION)
+            }
         } catch (error) {}
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-acp",
-    "version": "1.13.9-dev.1",
+    "version": "1.14.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-acp",
-            "version": "1.13.9-dev.1",
+            "version": "1.14.0",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@anthropic-ai/tokenizer": "^0.0.4",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsup"
+import pkg from "./package.json" with { type: "json" }
 
 export default defineConfig({
     entry: ["index.ts"],
@@ -10,4 +11,7 @@ export default defineConfig({
     //   - jsonc-parser: broken ESM imports when external
     //   - context-compress-algorithms: published tarball must be self-contained (file: dep does not survive pack)
     noExternal: ["jsonc-parser", "context-compress-algorithms"],
+    define: {
+        ACP_VERSION: JSON.stringify(pkg.version),
+    },
 })


### PR DESCRIPTION
## Summary

Add ACP version info to logs so we can determine which version produced each entry when investigating issues across sessions.

## Changes (3 files)

- **`tsup.config.ts`**: Inject `ACP_VERSION` at build time via `define` from `package.json`
- **`lib/logger.ts`**:
  - Daily log: append `| v={VERSION}` to every log line
  - Context log: write `_version` file in each session's context directory (first-write only, non-breaking for existing parsers)
- Devlog: REQ + WORKLOG

## Verification

- typecheck ✅ | build ✅ | 919 tests pass ✅
- Bundle contains `LOG_VERSION` × 4 references

## Non-breaking

- Daily log format: `v=X.Y.Z` appended at end of line (existing parsers that split on `|` may see extra field)
- Context log format: unchanged (JSON array as before), `_version` is a separate plaintext file