### PR TITLE
fix: split protected ranges + soften last-user-message protection

### DIFF
--- a/devlog/2026-07-27_split-protected-ranges/REQ.md
+++ b/devlog/2026-07-27_split-protected-ranges/REQ.md
@@ -1,0 +1,60 @@
+# REQ - Split Protected Ranges + Soften Last-User-Message Protection
+
+- Task ID: `2026-07-27_split-protected-ranges`
+- Home Repo: `opencode-acp`
+- Created: 2026-07-27
+- Status: Done
+- Priority: P0
+- Owner: awork
+- References: dog/opencode-acp#37, PR #207 (growth baseline fix)
+
+## 1. Background & Problem Statement
+
+- **Context**: PR #201 (preserve-recent) added a protected zone (last N messages + last user message) to prevent compressing active work. This introduced two mechanisms: `excludeProtectedRanges` (filter recommendations) and `checkProtectedRange` (hard-reject compress calls covering protected messages).
+- **Current behavior (symptom)**: In autonomous agentic sessions (1 user message + many assistant/tool messages), `buildCompressibleRanges` creates ONE giant group because grouping only breaks on user messages — and tool results are `assistant` role in OpenCode. The giant group's endRef falls in the protected zone → `excludeProtectedRanges` removes the ENTIRE range → no recommendations → nudge suppressed → model can never compress. Additionally, `preserveLastUserMessage` causes `checkProtectedRange` to hard-reject any compress covering the last user message, even when the model deliberately wants to compress surrounding tool output.
+- **Expected behavior**: (1) Giant groups split at the protected-zone boundary — the unprotected head becomes a recommended range. (2) The last user message is soft-filtered (excluded from compress plan, like Bug 39 protected tools) instead of hard-rejecting the entire compress call.
+- **Impact**: Autonomous sessions reaching 500K+ context with zero successful compressions. Model gets no guidance on what to compress.
+
+## 2. Reproduction (if applicable)
+
+- **Environment**: OpenCode with ACP v1.14.1, any model
+- **Minimal reproduction steps**:
+  1. Send 1 user message
+  2. Let the model work autonomously (tool calls, reasoning) until 100+ messages
+  3. Observe: no compression nudge fires, context grows unboundedly
+- **Root cause confirmed via real session data**: tool results in OpenCode storage are `role="assistant"` (verified from 411-message session: 96 user / 315 assistant; tool results appear as `parts=('tool',)` within assistant messages).
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+  - Backward compatibility: `preserveLastUserMessage` config field kept (semantics changes from hard-reject to soft-filter)
+  - `lastSegmentSoftBlock: false` must disable ALL protection including the new soft filter
+  - Last 20 messages stay hard-protected (active working set)
+- **Non-Goals**:
+  - First user message protection (handled elsewhere per user)
+  - Changing `preserveRecentMessages` / `preserveRecentTokens` behavior
+  - Changing `checkProtectedRange` behavior for last-N messages
+
+## 4. Acceptance Criteria (must be testable)
+
+- **Correctness**:
+  - [x] `buildCompressibleRanges` splits groups at protected-zone boundary when `protectedZoneRefs` is passed
+  - [x] Unprotected head appears as a recommended range; protected tail excluded
+  - [x] Last user message soft-filtered from compress plan (not hard-rejected)
+  - [x] `checkProtectedRange` no longer rejects based on last user message
+  - [x] `lastSegmentSoftBlock: false` disables soft filter too
+- **Regression**:
+  - [x] All 922 tests pass (920 existing + 2 new)
+
+## 5. Proposed Approach
+
+- **Affected modules & entry files**:
+  - `lib/messages/inject/utils.ts` — `buildCompressibleRanges` (add `protectedZoneRefs` param), `computeProtectedRefs` (remove `preserveLastUser`)
+  - `lib/messages/inject/inject.ts` — reorder `computeProtectedRefs` before `buildCompressibleRanges`, add `allInProtectedZone` to `nothingToCompress`
+  - `lib/compress/pipeline.ts` — `computeProtectedRawIds` (remove `preserveLastUser`)
+  - `lib/compress/protected-content.ts` — new `filterLastUserMessage` function
+  - `lib/compress/range.ts` — apply `filterLastUserMessage` in pipeline
+  - `lib/compress/message.ts` — apply `filterLastUserMessage` in pipeline
+  - `lib/compress/status.ts` — pass `protectedRefs` to `buildCompressibleRanges`
+- **Risks**: Behavioral change — last user message no longer hard-rejected. Users relying on this will see different behavior (soft filter instead). This is intentional and correct.
+- **Rollback strategy**: Revert all commits on this branch.

--- a/devlog/2026-07-27_split-protected-ranges/WORKLOG.md
+++ b/devlog/2026-07-27_split-protected-ranges/WORKLOG.md
@@ -1,0 +1,61 @@
+# WORKLOG - Split Protected Ranges + Soften Last-User-Message Protection
+
+- Task ID: `2026-07-27_split-protected-ranges`
+- Home Repo: `opencode-acp`
+- Status: Done
+- Updated: 2026-07-27 13:30
+
+## 1. Summary
+
+- **What was done**: Two changes — (1) `buildCompressibleRanges` now splits giant groups at the protected-zone boundary so the unprotected head survives as a recommended range; (2) `preserveLastUserMessage` moved from hard-reject (`checkProtectedRange` throw) to soft-filter (`filterLastUserMessage` excludes from compress plan, like Bug 39).
+- **Why**: In autonomous agentic sessions (1 user message + many assistant messages), the giant group was entirely filtered out by `excludeProtectedRanges`, leaving zero recommendations and suppressing the nudge — the model could never compress. The hard-reject on last user message additionally blocked deliberate compressions.
+- **Behavior / compatibility changes**: Yes — `preserveLastUserMessage` semantics change from hard-reject to soft-filter. Config field kept; `lastSegmentSoftBlock: false` disables all protection including the new soft filter.
+- **Risk level**: Medium
+
+## 2. Change Log
+
+### Key Files
+
+- `lib/messages/inject/utils.ts` — `buildCompressibleRanges`: added `protectedZoneRefs` param; grouping loop skips protected messages (closes current group before skipping). `computeProtectedRefs`: removed `preserveLastUser` block (moved to pipeline).
+- `lib/messages/inject/inject.ts` — moved `computeProtectedRefs` before `buildCompressibleRanges`; added `allInProtectedZone` condition to `nothingToCompress` (covers case where all messages are protected → no compressible ranges at all).
+- `lib/compress/pipeline.ts` — `computeProtectedRawIds`: removed `preserveLastUser` block.
+- `lib/compress/protected-content.ts` — new `filterLastUserMessage` function (follows Bug 39 `filterProtectedToolMessages` pattern; respects `lastSegmentSoftBlock` and `preserveLastUserMessage`).
+- `lib/compress/range.ts` — applied `filterLastUserMessage` after `filterProtectedToolMessages` in plan pipeline.
+- `lib/compress/message.ts` — applied `filterLastUserMessage` after `resolveMessages`; updated `plans` → `filteredPlans` references.
+- `lib/compress/status.ts` — both `buildCompressibleRanges` call sites now compute `protectedRefs` and pass it; defensive `ctx.config?.compress` guard for test compatibility.
+
+## 3. Design & Implementation Notes
+
+- **Change 1 (group splitting)**: The protected zone is always a contiguous tail. When `buildCompressibleRanges` encounters a message in `protectedZoneRefs`, it closes the current group (pushing the unprotected head) and skips the protected message. This naturally splits the giant group with correct `count`/`tokens`/`toolPct`/`textPct` for the head — no post-hoc recalculation needed.
+- **Change 2 (soft filter)**: `filterLastUserMessage` finds the last real user message (scan backward, skip synthetic/ignored/pruned) and removes it from `selection.messageIds` if present. The user message survives in visible context; surrounding tool output compresses normally. Consistent with Bug 39's `filterProtectedToolMessages`.
+- **`nothingToCompress` fix**: Added `allInProtectedZone = protectedRefs.size > 0 && unprotectedCompressible.length === 0` to cover the new case where all messages are in the protected zone (group splitting produces zero compressible ranges). Without this, the nudge would fire with no recommendations.
+
+## 4. Testing & Verification
+
+### Test Coverage
+
+- New test files: none (added to existing files)
+- New/modified test files:
+  - `tests/preserve-recent.test.ts` — 2 new tests (group splitting + all-protected), 1 updated test (last user message no longer in hard-protected set)
+  - `tests/soft-block.test.ts` — 1 updated test (last user message soft-filtered, not hard-rejected)
+- Test count: 922 total, 922 pass, 0 fail
+- Key scenarios verified:
+  - Giant group (1 user + 49 assistant) splits at protected boundary → unprotected head recommended
+  - All messages in protected zone → no compressible ranges (short session protection)
+  - Last user message soft-filtered from compress plan → compress succeeds, user message survives
+  - `lastSegmentSoftBlock: false` disables soft filter (backward compat)
+
+### Results
+
+- **PASS**: typecheck 0 errors, build success, 922/922 tests pass
+
+## 5. Risk Assessment & Rollback
+
+- **Risk points**: Behavioral change in `preserveLastUserMessage` (hard→soft). If any user workflow depends on the hard rejection, they'll see compressions proceed where they previously failed. This is the intended fix.
+- **Rollback method**: Revert all commits on branch `2026-07-27_split-protected-ranges`.
+- **Compatibility notes**: Config schema unchanged. `preserveLastUserMessage` field kept with new semantics. Persisted state format unchanged.
+
+## 6. Follow-ups
+
+- [ ] Deploy + test in real opencode session to verify autonomous agentic scenario
+- [ ] Consider adding per-message grouping breaks (every N messages) as a secondary defense against giant groups

--- a/lib/compress/message.ts
+++ b/lib/compress/message.ts
@@ -12,7 +12,7 @@ import {
     checkPhantomBlock,
     type NotificationEntry,
 } from "./pipeline"
-import { appendProtectedPromptInfo, appendProtectedTools } from "./protected-content"
+import { appendProtectedPromptInfo, appendProtectedTools, filterLastUserMessage } from "./protected-content"
 import {
     allocateBlockId,
     allocateRunId,
@@ -107,7 +107,19 @@ export function createCompressMessageTool(factoryCtx: ToolFactoryContext): Retur
                 ctx.config,
             )
 
-            if (plans.length === 0 && skippedCount > 0) {
+            const filteredPlans = plans
+                .map((plan) => ({
+                    ...plan,
+                    selection: filterLastUserMessage(
+                        plan.selection,
+                        searchContext,
+                        ctx.state,
+                        ctx.config.compress,
+                    ),
+                }))
+                .filter((plan) => plan.selection.messageIds.length > 0)
+
+            if (filteredPlans.length === 0 && skippedCount > 0) {
                 throw new Error(formatIssues(skippedIssues, skippedCount))
             }
 
@@ -115,7 +127,7 @@ export function createCompressMessageTool(factoryCtx: ToolFactoryContext): Retur
             if (minCompressRange > 0) {
                 let totalChars = 0
                 const counted = new Set<string>()
-                for (const plan of plans) {
+                for (const plan of filteredPlans) {
                     for (const messageId of plan.selection.messageIds) {
                         if (counted.has(messageId)) continue
                         counted.add(messageId)
@@ -140,7 +152,7 @@ export function createCompressMessageTool(factoryCtx: ToolFactoryContext): Retur
 
             const lastSegmentError = checkProtectedRange(
                 ctx,
-                plans.map((p) => p.selection.messageIds),
+                filteredPlans.map((p) => p.selection.messageIds),
                 rawMessages,
                 dangerous,
             )
@@ -149,11 +161,11 @@ export function createCompressMessageTool(factoryCtx: ToolFactoryContext): Retur
             const notifications: NotificationEntry[] = []
 
             const preparedPlans: Array<{
-                plan: (typeof plans)[number]
+                plan: (typeof filteredPlans)[number]
                 summaryWithTools: string
             }> = []
 
-            for (const plan of plans) {
+            for (const plan of filteredPlans) {
                 const summaryWithPromptInfo = appendProtectedPromptInfo(
                     plan.entry.summary,
                     plan.selection,
@@ -276,7 +288,7 @@ export function createCompressMessageTool(factoryCtx: ToolFactoryContext): Retur
                 throw error
             }
 
-            return formatResult(plans.length, skippedIssues, skippedCount)
+            return formatResult(filteredPlans.length, skippedIssues, skippedCount)
         },
     })
 }

--- a/lib/compress/message.ts
+++ b/lib/compress/message.ts
@@ -119,8 +119,12 @@ export function createCompressMessageTool(factoryCtx: ToolFactoryContext): Retur
                 }))
                 .filter((plan) => plan.selection.messageIds.length > 0)
 
-            if (filteredPlans.length === 0 && skippedCount > 0) {
-                throw new Error(formatIssues(skippedIssues, skippedCount))
+            if (filteredPlans.length === 0) {
+                throw new Error(
+                    skippedCount > 0
+                        ? formatIssues(skippedIssues, skippedCount)
+                        : "All selected messages were filtered out (protected tool outputs and/or the last user message). They must remain in visible context.",
+                )
             }
 
             const minCompressRange = ctx.config.compress.minCompressRange

--- a/lib/compress/pipeline.ts
+++ b/lib/compress/pipeline.ts
@@ -236,9 +236,12 @@ export function checkPhantomBlock(
 }
 
 /**
- * Compute the set of protected message raw IDs based on recent-message,
- * recent-token, and last-user-message rules. These IDs cannot be included
- * in a compression plan unless the caller passes `dangerous: true`.
+ * Compute the set of protected message raw IDs based on recent-message and
+ * recent-token rules. These IDs cannot be included in a compression plan
+ * unless the caller passes `dangerous: true`.
+ *
+ * Note: preserveLastUserMessage is handled by soft filtering in the compress
+ * pipeline (filterLastUserMessage), not here.
  */
 export function computeProtectedRawIds(
     rawMessages: WithParts[],
@@ -247,7 +250,6 @@ export function computeProtectedRawIds(
 ): Set<string> {
     const preserveN = compress.preserveRecentMessages ?? 20
     const preserveTokens = compress.preserveRecentTokens ?? 20000
-    const preserveLastUser = compress.preserveLastUserMessage ?? true
 
     const result = new Set<string>()
 
@@ -280,15 +282,6 @@ export function computeProtectedRawIds(
         for (let i = visible.length - 1; i >= 0 && tokenAccum < preserveTokens; i--) {
             result.add(visible[i]!.id)
             tokenAccum += visible[i]!.tokens
-        }
-    }
-
-    if (preserveLastUser) {
-        for (let i = visible.length - 1; i >= 0; i--) {
-            if (visible[i]!.isUser) {
-                result.add(visible[i]!.id)
-                break
-            }
         }
     }
 

--- a/lib/compress/pipeline.ts
+++ b/lib/compress/pipeline.ts
@@ -289,10 +289,9 @@ export function computeProtectedRawIds(
 }
 
 /**
- * Reject compression plans that cover protected messages (last N messages,
- * last N tokens, or the most recent user message). The caller must pass
- * `dangerous: true` to proceed. Returns an Error to throw if the caller
- * did not opt in.
+ * Reject compression plans that cover protected messages (last N messages
+ * or last N tokens). The caller must pass `dangerous: true` to proceed.
+ * Returns an Error to throw if the caller did not opt in.
  */
 export function checkProtectedRange(
     ctx: ToolContext,
@@ -323,7 +322,7 @@ export function checkProtectedRange(
     return new Error(
         `This range includes ${coveredProtected.length} protected recent message(s) (${sample}), ` +
             "which are likely still needed for the current task step.\n\n" +
-            `Protected zone: last ${nMsgs} messages + last ${nToks >= 1000 ? `${nToks / 1000}K` : nToks} tokens + most recent user message.\n` +
+            `Protected zone: last ${nMsgs} messages + last ${nToks >= 1000 ? `${nToks / 1000}K` : nToks} tokens.\n` +
             "If you are certain this content is genuinely consumed and must be compressed, " +
             "re-issue the call with `dangerous: true`.\n" +
             "Otherwise, compress older ranges that do not include the tail of the conversation.",

--- a/lib/compress/protected-content.ts
+++ b/lib/compress/protected-content.ts
@@ -1,5 +1,6 @@
 import type { SessionState, WithParts } from "../state"
-import { isIgnoredUserMessage } from "../messages/query"
+import type { CompressConfig } from "../config"
+import { isIgnoredUserMessage, isSyntheticMessage } from "../messages/query"
 import {
     getFilePathsFromParameters,
     isFilePathProtected,
@@ -229,5 +230,48 @@ export function filterProtectedToolMessages(
         messageIds: filteredMessageIds,
         messageTokenById: filteredMessageTokenById,
         toolIds: filteredToolIds,
+    }
+}
+
+export function filterLastUserMessage(
+    selection: SelectionResolution,
+    searchContext: SearchContext,
+    state: SessionState,
+    compress: CompressConfig,
+): SelectionResolution {
+    if (compress.lastSegmentSoftBlock === false) return selection
+    if (!(compress.preserveLastUserMessage ?? true)) return selection
+
+    let lastUserMessageId: string | null = null
+    for (let i = searchContext.rawMessages.length - 1; i >= 0; i--) {
+        const msg = searchContext.rawMessages[i]
+        const id = msg?.info?.id
+        if (!id || typeof id !== "string") continue
+        if (isSyntheticMessage(msg)) continue
+        if (isIgnoredUserMessage(msg)) continue
+        if (state.prune.messages.byMessageId.has(id)) continue
+        if (msg.info.role === "user") {
+            lastUserMessageId = id
+            break
+        }
+    }
+
+    if (!lastUserMessageId || !selection.messageIds.includes(lastUserMessageId)) {
+        return selection
+    }
+
+    const filteredMessageIds = selection.messageIds.filter((id) => id !== lastUserMessageId)
+    const filteredMessageTokenById = new Map<string, number>()
+    for (const id of filteredMessageIds) {
+        const tokens = selection.messageTokenById.get(id)
+        if (tokens !== undefined) {
+            filteredMessageTokenById.set(id, tokens)
+        }
+    }
+
+    return {
+        ...selection,
+        messageIds: filteredMessageIds,
+        messageTokenById: filteredMessageTokenById,
     }
 }

--- a/lib/compress/range.ts
+++ b/lib/compress/range.ts
@@ -15,6 +15,7 @@ import {
     appendProtectedPromptInfo,
     appendProtectedTools,
     appendProtectedUserMessages,
+    filterLastUserMessage,
     filterProtectedToolMessages,
 } from "./protected-content"
 import {
@@ -136,6 +137,15 @@ export function createCompressRangeTool(factoryCtx: ToolFactoryContext): ReturnT
                         searchContext,
                         ctx.config.compress.protectedTools,
                         ctx.config.protectedFilePatterns,
+                    ),
+                }))
+                .map((plan) => ({
+                    ...plan,
+                    selection: filterLastUserMessage(
+                        plan.selection,
+                        searchContext,
+                        ctx.state,
+                        ctx.config.compress,
                     ),
                 }))
                 .filter((plan) => plan.selection.messageIds.length > 0)

--- a/lib/compress/range.ts
+++ b/lib/compress/range.ts
@@ -152,7 +152,7 @@ export function createCompressRangeTool(factoryCtx: ToolFactoryContext): ReturnT
 
             if (filteredPlans.length === 0) {
                 throw new Error(
-                    "All selected messages contain protected tool outputs and cannot be compressed. Protected tools (task, skill, todowrite, etc.) must remain in visible context.",
+                    "All selected messages were filtered out (protected tool outputs and/or the last user message). They must remain in visible context.",
                 )
             }
 

--- a/lib/compress/status.ts
+++ b/lib/compress/status.ts
@@ -5,6 +5,7 @@ import type { CompressionBlock, WithParts } from "../state/types"
 import {
     estimateContextComposition,
     buildCompressibleRanges,
+    computeProtectedRefs,
     formatCompressibleRanges,
 } from "../messages/inject/utils"
 import { fetchSessionMessages } from "./search"
@@ -255,11 +256,15 @@ function renderOverview(
             const entry = pruneMap.get(msgId)
             return !entry || entry.activeBlockIds.length === 0
         })
+        const protectedRefs = ctx.config?.compress
+            ? computeProtectedRefs(visibleRaw, ctx.state, ctx.config.compress)
+            : new Set<string>()
         const contextRanges = buildCompressibleRanges(
             visibleRaw,
             ctx.state,
             ctx.config?.compress?.protectedTools ?? [],
             ctx.config?.protectedFilePatterns ?? [],
+            protectedRefs,
         )
         if (contextRanges.compressible.length > 0 || contextRanges.protected.length > 0) {
             lines.push("")
@@ -287,11 +292,15 @@ function renderUncompressedRanges(rawMessages: WithParts[], ctx: ToolContext): s
         return !entry || entry.activeBlockIds.length === 0
     })
 
+    const protectedRefs = ctx.config?.compress
+        ? computeProtectedRefs(visibleMessages, ctx.state, ctx.config.compress)
+        : new Set<string>()
     const contextRanges = buildCompressibleRanges(
         visibleMessages,
         ctx.state,
         ctx.config?.compress?.protectedTools ?? [],
         ctx.config?.protectedFilePatterns ?? [],
+        protectedRefs,
     )
     const compressible = contextRanges.compressible
     const totalTokens = compressible.reduce((s, r) => s + r.tokens, 0)

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -320,15 +320,19 @@ export const injectCompressNudges = (
         config.protectedFilePatterns,
     )
 
+    // Compute protected zone first — buildCompressibleRanges uses it to split
+    // groups at the boundary so the unprotected head survives as a range.
+    const protectedRefs = computeProtectedRefs(messages, state, config.compress)
+
     // Compute recommendation filter early — the result gates the nudge below.
     const contextRanges = buildCompressibleRanges(
         messages,
         state,
         config.compress.protectedTools,
         config.protectedFilePatterns,
+        protectedRefs,
     )
 
-    const protectedRefs = computeProtectedRefs(messages, state, config.compress)
     const unprotectedCompressible = excludeProtectedRanges(contextRanges.compressible, protectedRefs)
 
     const recommendedRanges = filterRecommendedRanges(
@@ -362,7 +366,8 @@ export const injectCompressNudges = (
 
     const filterSuppressed = contextRanges.compressible.length > 0 && !hasRecommendations
     const allProtected = contextRanges.compressible.length === 0 && contextRanges.protected.length > 0
-    const nothingToCompress = filterSuppressed || allProtected
+    const allInProtectedZone = protectedRefs.size > 0 && unprotectedCompressible.length === 0
+    const nothingToCompress = filterSuppressed || allProtected || allInProtectedZone
     let shouldInject = nudgeAllowed && (!nothingToCompress || emergencyOverride)
 
     // [FIX baseline-reset] Do NOT reset the growth baseline when nothingToCompress

--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -727,6 +727,7 @@ export function buildCompressibleRanges(
     state: SessionState,
     protectedTools: string[] = [],
     protectedFilePatterns: string[] = [],
+    protectedZoneRefs?: Set<string>,
 ): ContextRanges {
     const msgInfo: {
         ref: string
@@ -797,6 +798,17 @@ export function buildCompressibleRanges(
     let cur: CompressibleRange | null = null
     let prevRefNum = -2
     for (const info of msgInfo) {
+        // Split groups at the protected-zone boundary: close the current group
+        // before skipping protected messages, so the unprotected head survives
+        // as its own range instead of being swallowed by excludeProtectedRanges.
+        if (protectedZoneRefs?.has(info.ref)) {
+            if (cur) {
+                groups.push(cur)
+                cur = null
+            }
+            prevRefNum = info.refNum
+            continue
+        }
         const hasGap = info.refNum > prevRefNum + 1
         if (cur && ((info.isUser && cur.count >= 3) || hasGap)) {
             groups.push(cur)
@@ -1064,10 +1076,14 @@ export function formatCompressibleRanges(
 
 /**
  * Compute the set of protected message refs (mNNNNN) that should be excluded
- * from compression recommendations. Combines three rules:
+ * from compression recommendations. Combines two rules:
  *   1. Last N messages (preserveRecentMessages, default 20)
  *   2. Last N tokens expanding backward (preserveRecentTokens, default 20000)
- *   3. Most recent user message (preserveLastUserMessage, default true)
+ *
+ * Note: preserveLastUserMessage is no longer handled here (moved to soft
+ * filtering in the compress pipeline — see filterLastUserMessage). The last
+ * user message is filtered from the compress plan instead of causing a hard
+ * rejection.
  *
  * Only considers visible, non-synthetic, non-pruned messages.
  */
@@ -1080,7 +1096,6 @@ export function computeProtectedRefs(
 
     const preserveN = compress.preserveRecentMessages ?? 20
     const preserveTokens = compress.preserveRecentTokens ?? 20000
-    const preserveLastUser = compress.preserveLastUserMessage ?? true
 
     const result = new Set<string>()
 
@@ -1114,15 +1129,6 @@ export function computeProtectedRefs(
         for (let i = visible.length - 1; i >= 0 && tokenAccum < preserveTokens; i--) {
             result.add(visible[i]!.ref)
             tokenAccum += visible[i]!.tokens
-        }
-    }
-
-    if (preserveLastUser) {
-        for (let i = visible.length - 1; i >= 0; i--) {
-            if (visible[i]!.isUser) {
-                result.add(visible[i]!.ref)
-                break
-            }
         }
     }
 

--- a/tests/preserve-recent.test.ts
+++ b/tests/preserve-recent.test.ts
@@ -3,7 +3,7 @@ import test from "node:test"
 import { createSessionState, type WithParts } from "../lib/state"
 import type { PluginConfig } from "../lib/config"
 import { Logger } from "../lib/logger"
-import { computeProtectedRefs, excludeProtectedRanges, type CompressibleRange } from "../lib/messages/inject/utils"
+import { buildCompressibleRanges, computeProtectedRefs, excludeProtectedRanges, type CompressibleRange } from "../lib/messages/inject/utils"
 import { injectCompressNudges } from "../lib/messages/inject/inject"
 
 const SID = "ses-preserve-test"
@@ -120,14 +120,14 @@ test("computeProtectedRefs: default config protects last 40 msgs (token rule bro
     assert.ok(!protectedRefs.has("m00010"), "msg-10 NOT protected (outside token window)")
 })
 
-test("computeProtectedRefs: last user message always protected even with count=1", () => {
+test("computeProtectedRefs: last user message NOT in hard-protected set (soft-filtered in pipeline)", () => {
     const state = createSessionState()
     setupRefs(state, 50)
     const messages = buildMessages(50, 2000)
     const compress = buildCompress({ preserveRecentMessages: 1, preserveRecentTokens: 0 })
     const protectedRefs = computeProtectedRefs(messages, state, compress)
     assert.ok(protectedRefs.has("m00050"), "last message protected by count")
-    assert.ok(protectedRefs.has("m00049"), "last user message (msg-49) protected by user-msg rule")
+    assert.ok(!protectedRefs.has("m00049"), "last user message (msg-49) NOT in hard-protected set — soft-filtered by filterLastUserMessage in compress pipeline")
     assert.ok(!protectedRefs.has("m00048"), "msg-48 NOT protected")
 })
 
@@ -283,4 +283,56 @@ test("excludeProtectedRanges: range extending INTO protected zone is filtered", 
     assert.equal(filtered.length, 1, "only fully-unprotected range survives")
     assert.equal(filtered[0].startRef, "m00001")
     assert.equal(filtered[0].endRef, "m00005")
+})
+
+test("buildCompressibleRanges: splits giant group at protected-zone boundary (autonomous session)", () => {
+    const state = createSessionState()
+    const messages: WithParts[] = []
+    for (let i = 1; i <= 50; i++) {
+        const id = `msg-${i}`
+        state.messageIds.byRawId.set(id, `m${String(i).padStart(5, "0")}`)
+        const role: "user" | "assistant" = i === 1 ? "user" : "assistant"
+        messages.push(msg(id, role, "x".repeat(2000)))
+    }
+
+    const compress = buildCompress({ preserveRecentMessages: 20, preserveRecentTokens: 0 })
+    const protectedRefs = computeProtectedRefs(messages, state, compress)
+    assert.ok(protectedRefs.has("m00031"), "msg-31 is first protected (last 20)")
+    assert.ok(protectedRefs.has("m00050"), "msg-50 is protected")
+
+    const withoutZone = buildCompressibleRanges(messages, state, [], [])
+    const lastRangeWithout = withoutZone.compressible[withoutZone.compressible.length - 1]
+    assert.ok(
+        lastRangeWithout && protectedRefs.has(lastRangeWithout.endRef),
+        "without protectedZoneRefs, last range extends into protected zone (the bug)",
+    )
+
+    const withZone = buildCompressibleRanges(messages, state, [], [], protectedRefs)
+    for (const r of withZone.compressible) {
+        assert.ok(!protectedRefs.has(r.endRef), `range endRef ${r.endRef} must NOT be in protected zone after splitting`)
+        assert.ok(!protectedRefs.has(r.startRef), `range startRef ${r.startRef} must NOT be in protected zone after splitting`)
+    }
+    assert.ok(withZone.compressible.length > 0, "unprotected head produces at least one range")
+    assert.ok(
+        withZone.compressible.some((r) => r.count >= 10),
+        "unprotected head contains a substantial range (10+ msgs)",
+    )
+})
+
+test("buildCompressibleRanges: all messages in protected zone → no compressible ranges", () => {
+    const state = createSessionState()
+    const messages: WithParts[] = []
+    for (let i = 1; i <= 10; i++) {
+        const id = `msg-${i}`
+        state.messageIds.byRawId.set(id, `m${String(i).padStart(5, "0")}`)
+        const role: "user" | "assistant" = i === 1 ? "user" : "assistant"
+        messages.push(msg(id, role, "x".repeat(2000)))
+    }
+
+    const compress = buildCompress({ preserveRecentMessages: 20, preserveRecentTokens: 0 })
+    const protectedRefs = computeProtectedRefs(messages, state, compress)
+    assert.equal(protectedRefs.size, 10, "all 10 messages in protected zone (last 20)")
+
+    const result = buildCompressibleRanges(messages, state, [], [], protectedRefs)
+    assert.equal(result.compressible.length, 0, "no compressible ranges when all messages protected")
 })

--- a/tests/protected-tool-exclusion.test.ts
+++ b/tests/protected-tool-exclusion.test.ts
@@ -501,7 +501,7 @@ test("range mode throws when ALL messages in range contain protected tools", asy
             },
             mockToolCtx(sessionID),
         ),
-        /All selected messages contain protected tool outputs/,
+        /All selected messages were filtered out/,
     )
 
     assert.equal(

--- a/tests/soft-block.test.ts
+++ b/tests/soft-block.test.ts
@@ -205,7 +205,7 @@ test("protected: error message mentions protected message IDs", async () => {
     )
 })
 
-test("protected: last user message is always protected even outside message window", async () => {
+test("protected: last user message soft-filtered (not hard-rejected) even outside message window", async () => {
     const sessionID = `ses_protected_6_${Date.now()}`
     const rawMessages = buildMessages(sessionID, 30)
     const state = createSessionState()
@@ -218,20 +218,16 @@ test("protected: last user message is always protected even outside message wind
         },
     })
 
-    await assert.rejects(
-        () =>
-            tool.execute(
-                {
-                    topic: "Test",
-                    content: [{ startId: ref(28), endId: ref(29), summary: "x".repeat(2000) }],
-                },
-                { ...toolCtx, sessionID },
-            ),
-        (err: Error) => {
-            assert.ok(err.message.includes("msg-29"), `should be blocked by user message protection: ${err.message}`)
-            return true
+    const result = await tool.execute(
+        {
+            topic: "Test",
+            content: [{ startId: ref(28), endId: ref(29), summary: "x".repeat(2000) }],
         },
+        { ...toolCtx, sessionID },
     )
+    assert.ok(typeof result === "string" && result.includes("Compressed"), "compress should succeed — last user message soft-filtered, not hard-rejected")
+    assert.ok(state.prune.messages.byMessageId.has("msg-28"), "msg-28 compressed into block")
+    assert.ok(!state.prune.messages.byMessageId.has("msg-29"), "msg-29 (last user message) NOT compressed — soft-filtered, survives in visible context")
 })
 
 test("protected: custom preserveRecentMessages=5 only protects last 5", async () => {


### PR DESCRIPTION
## Summary

Fixes a bug where autonomous agentic sessions (1 user message + many assistant/tool messages) could never successfully compress. Root cause: `buildCompressibleRanges` created one giant group (no user-message breaks since tool results are `assistant` role), and `excludeProtectedRanges` removed the entire group because its endRef was in the protected zone — leaving zero recommendations and suppressing the nudge.

**Two changes:**

1. **Group splitting** (`buildCompressibleRanges`): now accepts `protectedZoneRefs` and splits groups at the protected-zone boundary. The unprotected head survives as a recommended range; the protected tail is excluded. This directly fixes the "can't compress in autonomous sessions" bug.

2. **Last-user-message softening** (`preserveLastUserMessage`): moved from hard-reject (`checkProtectedRange` throw) to soft-filter (`filterLastUserMessage` excludes from compress plan, following Bug 39's `filterProtectedToolMessages` pattern). The last user message survives in visible context; surrounding tool output compresses normally. No more hard rejection when the compress range happens to include the last user message.

Also added `allInProtectedZone` condition to `nothingToCompress` to cover the new case where all messages are in the protected zone (group splitting produces zero compressible ranges — previously this would incorrectly fire the nudge with no recommendations).

## Test plan
- [x] 922/922 tests pass (920 existing + 2 new)
- [x] Typecheck clean
- [x] Build clean
- [x] New test: giant group (1 user + 49 assistant) splits at protected boundary
- [x] New test: all messages in protected zone → no compressible ranges
- [x] Updated test: last user message soft-filtered (not hard-rejected)
- [x] Updated test: `computeProtectedRefs` no longer includes last user message