### PR TITLE
release: v1.14.2 — split protected ranges + soften last-user-message

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.2 — Split Protected Ranges + Soften Last-User-Message (PR #210)
+
+**Problem**: In autonomous agentic sessions (1 user message + many assistant/tool messages), `buildCompressibleRanges` created one giant compressible group because grouping only breaks on user messages — and tool results are `assistant` role in OpenCode. The giant group's endRef fell in the protected zone → `excludeProtectedRanges` removed the entire range → zero recommendations → nudge suppressed → model could never compress. Additionally, `preserveLastUserMessage` hard-rejected any compress call covering the last user message, blocking deliberate compressions of surrounding tool output.
+
+**Fix**: (1) `buildCompressibleRanges` now accepts `protectedZoneRefs` and splits groups at the protected-zone boundary — the unprotected head survives as a recommended range while the protected tail is excluded. (2) `preserveLastUserMessage` moved from hard-reject (`checkProtectedRange` throw) to soft-filter (`filterLastUserMessage` excludes from compress plan, following Bug 39's `filterProtectedToolMessages` pattern). The last user message survives in visible context; surrounding tool output compresses normally. (3) Added `allInProtectedZone` condition to `nothingToCompress` to cover the case where all messages are in the protected zone. (4) Fixed stale error messages and added empty-plan guard in both range and message modes. Dual-agent reviewed (both APPROVE with minor fixes; all WARNINGs addressed in follow-up commit). 922 tests pass.
+
+Files: `lib/messages/inject/{utils,inject}.ts`, `lib/compress/{pipeline,protected-content,range,message,status}.ts`. Tests: `tests/{preserve-recent,soft-block,protected-tool-exclusion}.test.ts`. No persisted-state schema changes. `preserveLastUserMessage` config semantics changed from hard-reject to soft-filter (intentional fix; `lastSegmentSoftBlock: false` disables all protection including the new soft filter).
+
 ### v1.14.1 — Log Version Info + Growth Baseline Fix (PRs #205, #207)
 
 **Problem**: Two issues since v1.14.0. (1) **Unidentifiable logs** (PR #205): ACP daily logs and per-request context logs carried no version marker, so when users shared debug logs it was impossible to tell which ACP version produced them — making regression triage across versions guesswork. (2) **Growth-baseline feedback loop in short sessions** (PR #207): When the growth threshold was met (`nudgeAllowed`) but every compressible range was filtered out (`nothingToCompress`, e.g. all ranges inside the protected zone in a short session or subagent), the code reset `state.nudges.lastPerMessageNudgeTokens = currentTokens`. This ate the accumulated growth every cycle, so the baseline chased the current context and the model never saw a nudge even though context had grown well past the threshold.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -482,6 +482,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.14.2 — 拆分保护区范围 + 软化最后用户消息保护（PR #210）
+
+**问题**：在自主代理会话中（1 条用户消息 + 多条 assistant/tool 消息），`buildCompressibleRanges` 创建了一个巨型可压缩组，因为分组只在用户消息处断开 —— 而 OpenCode 中 tool 结果是 `assistant` 角色。巨型组的 endRef 落在保护区内 → `excludeProtectedRanges` 移除整个范围 → 零推荐 → nudge 被抑制 → 模型永远无法压缩。此外，`preserveLastUserMessage` 硬拒绝任何覆盖最后用户消息的压缩调用，阻塞了对周围 tool 输出的有意压缩。
+
+**修复**：(1) `buildCompressibleRanges` 现在接受 `protectedZoneRefs` 参数，在保护区边界处拆分组 —— 非保护区头部保留为推荐范围，保护区尾部被排除。(2) `preserveLastUserMessage` 从硬拒绝（`checkProtectedRange` 抛错）改为软过滤（`filterLastUserMessage` 从压缩计划中排除，遵循 Bug 39 的 `filterProtectedToolMessages` 模式）。最后用户消息保留在可见上下文中；周围的 tool 输出正常压缩。(3) 在 `nothingToCompress` 中添加了 `allInProtectedZone` 条件，覆盖所有消息都在保护区内的情况。(4) 修复了过时的错误消息，在 range 和 message 模式中都添加了空计划守卫。双 agent 审查通过（均 APPROVE WITH MINOR FIXES；所有 WARNING 在后续 commit 中解决）。922 项测试通过。
+
+文件：`lib/messages/inject/{utils,inject}.ts`、`lib/compress/{pipeline,protected-content,range,message,status}.ts`。测试：`tests/{preserve-recent,soft-block,protected-tool-exclusion}.test.ts`。无持久化状态 schema 变更。`preserveLastUserMessage` 配置语义从硬拒绝变为软过滤（有意的修复；`lastSegmentSoftBlock: false` 禁用所有保护包括新的软过滤）。
+
 ### v1.14.1 — 日志版本信息 + 增长基线修复（PR #205, #207）
 
 **问题**：v1.14.0 之后的两个问题。(1) **日志无法识别版本**（PR #205）：ACP daily 日志和每请求 context 日志没有任何版本标记，用户分享调试日志时无法判断是哪个 ACP 版本产生的 —— 跨版本回归排查只能靠猜。(2) **短会话中的增长基线反馈循环**（PR #207）：当增长阈值已满足（`nudgeAllowed`）但所有可压缩范围都被过滤掉时（`nothingToCompress`，例如短会话或子代理中所有范围都在保护区内），旧代码会重置 `state.nudges.lastPerMessageNudgeTokens = currentTokens`。这会每轮吃掉累积增长，基线一路追逐当前上下文，即使上下文早已远超阈值，模型也永远等不到 nudge。

--- a/devlog/2026-07-27_release-v1.14.2/REQ.md
+++ b/devlog/2026-07-27_release-v1.14.2/REQ.md
@@ -1,0 +1,23 @@
+# REQ — Release v1.14.2
+
+## Purpose
+
+Release v1.14.2 containing PR #210 (split protected ranges + soften last-user-message) and PR #208 (AGENTS.md §5.7 docs).
+
+## Scope
+
+- **PR #210**: In autonomous sessions, `buildCompressibleRanges` created one giant group whose endRef fell in the protected zone → zero recommendations → model could never compress. Fixed by splitting groups at the protected-zone boundary and softening `preserveLastUserMessage` from hard-reject to soft-filter.
+- **PR #208**: Docs-only — AGENTS.md §5.7 nudge/growth test requirements + Docker E2E verification requirements.
+
+## Version
+
+1.14.1 → 1.14.2 (patch — bug fix release)
+
+## Deliverables
+
+- [x] Bump `package.json` version
+- [x] Changelog entries in `README.md` and `README.zh-CN.md`
+- [x] Devlog (this file + WORKLOG.md)
+- [ ] Verify: typecheck + test + build + ci check
+- [ ] Commit, push, create PR
+- [ ] Human merges PR → CI auto-publishes

--- a/devlog/2026-07-27_release-v1.14.2/WORKLOG.md
+++ b/devlog/2026-07-27_release-v1.14.2/WORKLOG.md
@@ -1,0 +1,36 @@
+# WORKLOG — Release v1.14.2
+
+## Timeline
+
+1. Fetched master → confirmed PR #210 merged (`5b91c3e`)
+2. Created release worktree from `github/master`
+3. Bumped `package.json`: 1.14.1 → 1.14.2
+4. Added changelog entries to README.md and README.zh-CN.md
+5. Created devlog REQ.md + WORKLOG.md
+6. (pending) Verify + commit + push + PR
+
+## Content
+
+### PR #210 — Split Protected Ranges + Soften Last-User-Message
+
+**Root cause**: In autonomous sessions (1 user msg + many assistant msgs), `buildCompressibleRanges` grouping only breaks on user messages. Tool results are `assistant` role in OpenCode → one giant group whose endRef falls in protected zone → `excludeProtectedRanges` removes entire range → zero recommendations → nudge suppressed.
+
+**Fix**:
+1. `buildCompressibleRanges` gains `protectedZoneRefs` param → splits groups at protected-zone boundary
+2. `preserveLastUserMessage` moves from hard-reject (`checkProtectedRange`) to soft-filter (`filterLastUserMessage`)
+3. `allInProtectedZone` added to `nothingToCompress`
+4. Review fixes: stale error messages + empty-plan guard (commit `08dc4a5`)
+
+**Verification**: 922/922 tests pass, typecheck clean, dual-agent review (both APPROVE)
+
+### PR #208 — Docs Only
+
+AGENTS.md §5.7: nudge/growth testing requirements (multi-turn, side-effect assertions, production config, growth cycle) + Docker E2E requirements. No source code changes.
+
+## Files Changed
+
+- `package.json` — version bump
+- `README.md` — v1.14.2 changelog entry
+- `README.zh-CN.md` — v1.14.2 changelog entry
+- `devlog/2026-07-27_release-v1.14.2/REQ.md` — this release ticket
+- `devlog/2026-07-27_release-v1.14.2/WORKLOG.md` — this file

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.1",
+    "version": "1.14.2",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Release v1.14.2 containing PR #210 (split protected ranges + soften last-user-message) and PR #208 (docs-only).

### What's in this release

**PR #210 — Split Protected Ranges + Soften Last-User-Message**:
- In autonomous sessions, `buildCompressibleRanges` created one giant group whose endRef fell in the protected zone → zero recommendations → model could never compress
- Fixed by splitting groups at the protected-zone boundary (unprotected head survives)
- `preserveLastUserMessage` moved from hard-reject to soft-filter (following Bug 39 pattern)
- Dual-agent reviewed (both APPROVE with minor fixes; all WARNINGs addressed)
- 922 tests pass

**PR #208 — Docs only**: AGENTS.md §5.7 nudge/growth test requirements

### Merge → Auto-publish

Merging this PR triggers `release.yml` CI workflow automatically:
1. Detects release branch merge → creates `v1.14.2` tag
2. Runs `npm ci` → `npm run check:package` → `npm test`
3. Publishes to npm `latest` tag
4. Creates GitHub Release

No manual `npm publish` or `git tag` needed.

### Checklist

- [x] `package.json` version bumped: 1.14.1 → 1.14.2
- [x] Changelog entries in `README.md` and `README.zh-CN.md`
- [x] Devlog: `devlog/2026-07-27_release-v1.14.2/{REQ,WORKLOG}.md`
- [x] CI check: `./scripts/ci/check-pr.sh` — all pass
- [x] 922/922 tests pass
- [x] Typecheck clean
- [x] Dual-agent review complete (PR #210)