### PR TITLE
release: v1.14.3 — soften protected zone + reduce defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.3 — Soften Protected Zone + Reduce Defaults (PR #212)
+
+**Problem**: `checkProtectedRange` hard-rejected any compress call covering protected recent messages (last N messages + last N tokens). The model got an error and had to retry with a different range or use `dangerous: true`. Additionally, the default `preserveRecentMessages: 20` and `preserveRecentTokens: 20000` (≈40 messages) were too aggressive — protecting nearly half the conversation in autonomous sessions.
+
+**Fix**: (1) Converted `checkProtectedRange` hard-reject to `filterProtectedRecentMessages` soft-filter — protected messages are filtered from the compress plan (same pattern as `filterLastUserMessage` and `filterProtectedToolMessages`), non-protected messages compress normally. Compress always succeeds unless ALL messages are protected. (2) Reduced `preserveRecentMessages` default 20 → 5 and `preserveRecentTokens` default 20000 → 5000. (3) `dangerous` parameter is now a no-op (no hard-reject to bypass; stays in schema for backward compat). 922 tests pass.
+
+Files: `lib/config.ts`, `lib/compress/{protected-content,pipeline,range,message}.ts`, `lib/messages/inject/utils.ts`. Tests: `tests/soft-block.test.ts`. No persisted-state schema changes. Config defaults changed; existing configs with explicit values are unaffected.
+
 ### v1.14.2 — Split Protected Ranges + Soften Last-User-Message (PR #210)
 
 **Problem**: In autonomous agentic sessions (1 user message + many assistant/tool messages), `buildCompressibleRanges` created one giant compressible group because grouping only breaks on user messages — and tool results are `assistant` role in OpenCode. The giant group's endRef fell in the protected zone → `excludeProtectedRanges` removed the entire range → zero recommendations → nudge suppressed → model could never compress. Additionally, `preserveLastUserMessage` hard-rejected any compress call covering the last user message, blocking deliberate compressions of surrounding tool output.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -482,6 +482,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.14.3 — 软化保护区 + 减小默认值（PR #212）
+
+**问题**：`checkProtectedRange` 硬拒绝任何覆盖保护区最近消息的压缩调用（最后 N 条消息 + 最后 N tokens）。模型收到错误后必须换范围重试或使用 `dangerous: true`。此外，默认 `preserveRecentMessages: 20` 和 `preserveRecentTokens: 20000`（约 40 条消息）过于激进 —— 在自主会话中保护了近一半的对话。
+
+**修复**：(1) 将 `checkProtectedRange` 硬拒绝转为 `filterProtectedRecentMessages` 软过滤 —— 保护区消息从压缩计划中过滤掉（与 `filterLastUserMessage` 和 `filterProtectedToolMessages` 同模式），非保护区消息正常压缩。除非所有消息都在保护区内，压缩总能成功。(2) 减小 `preserveRecentMessages` 默认值 20 → 5，`preserveRecentTokens` 默认值 20000 → 5000。(3) `dangerous` 参数现在无实际效果（没有硬拒绝了，不需要 bypass；保留在 schema 中向后兼容）。922 项测试通过。
+
+文件：`lib/config.ts`、`lib/compress/{protected-content,pipeline,range,message}.ts`、`lib/messages/inject/utils.ts`。测试：`tests/soft-block.test.ts`。无持久化状态 schema 变更。配置默认值改变；已设置显式值的配置不受影响。
+
 ### v1.14.2 — 拆分保护区范围 + 软化最后用户消息保护（PR #210）
 
 **问题**：在自主代理会话中（1 条用户消息 + 多条 assistant/tool 消息），`buildCompressibleRanges` 创建了一个巨型可压缩组，因为分组只在用户消息处断开 —— 而 OpenCode 中 tool 结果是 `assistant` 角色。巨型组的 endRef 落在保护区内 → `excludeProtectedRanges` 移除整个范围 → 零推荐 → nudge 被抑制 → 模型永远无法压缩。此外，`preserveLastUserMessage` 硬拒绝任何覆盖最后用户消息的压缩调用，阻塞了对周围 tool 输出的有意压缩。

--- a/devlog/2026-07-27_release-v1.14.3/REQ.md
+++ b/devlog/2026-07-27_release-v1.14.3/REQ.md
@@ -1,0 +1,13 @@
+# REQ — Release v1.14.3
+
+## Purpose
+
+Hotfix release for PR #212: soften protected zone (filter instead of reject) + reduce defaults.
+
+## Scope
+
+- **PR #212**: `checkProtectedRange` hard-reject → `filterProtectedRecentMessages` soft-filter. `preserveRecentMessages` 20→5, `preserveRecentTokens` 20000→5000.
+
+## Version
+
+1.14.2 → 1.14.3 (patch — hotfix)

--- a/devlog/2026-07-27_release-v1.14.3/WORKLOG.md
+++ b/devlog/2026-07-27_release-v1.14.3/WORKLOG.md
@@ -1,0 +1,17 @@
+# WORKLOG — Release v1.14.3
+
+1. Fetched master → confirmed PR #212 merged (`e77fb4e`)
+2. Created release worktree
+3. Bumped version 1.14.2 → 1.14.3
+4. Added changelog entries
+5. Created devlog
+6. Committed, pushed, created PR
+
+## Content
+
+### PR #212 — Soften Protected Zone + Reduce Defaults
+- `checkProtectedRange` hard-reject → `filterProtectedRecentMessages` soft-filter
+- `preserveRecentMessages` default 20 → 5
+- `preserveRecentTokens` default 20000 → 5000
+- `dangerous` parameter now no-op
+- 922/922 tests pass

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.2",
+    "version": "1.14.3",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Hotfix release containing PR #212.

### PR #212 — Soften Protected Zone + Reduce Defaults
- `checkProtectedRange` hard-reject → `filterProtectedRecentMessages` soft-filter
- `preserveRecentMessages` default 20 → 5
- `preserveRecentTokens` default 20000 → 5000
- `dangerous` parameter now no-op
- 922/922 tests pass

### Merge → Auto-publish
Merging triggers `release.yml` → auto-tag `v1.14.3` → npm publish → GitHub Release.