### PR TITLE
feat: inject compression notification into chat when debug is on

### DIFF
--- a/devlog/2026-07-27_debug-chat-notification/REQ.md
+++ b/devlog/2026-07-27_debug-chat-notification/REQ.md
@@ -1,0 +1,13 @@
+# REQ: Debug Mode — Inject Compression Notification into Chat Session
+
+## Problem
+
+When `debug: true`, compression notifications only appear as transient toast popups (5s duration). Developers cannot scroll back to review what was compressed — the notification disappears.
+
+## Requirement
+
+When debug is on, ALSO inject the compression notification into the user's chat session via `sendIgnoredMessage` (user-visible, model-invisible). Keep the toast for immediate popup feedback alongside the persistent chat record.
+
+## Background
+
+FIX #20 disabled `sendIgnoredMessage` for compress notifications because opencode strips `ignored: true` parts before the LLM call, leaving an empty user message → provider 400 (zhipuai code 1214). The `dropEmptyMessages` backstop (`lib/messages/utils.ts:238`) now catches these empty messages in the transform pipeline before they reach the provider. This makes debug-mode chat injection safe.

--- a/devlog/2026-07-27_debug-chat-notification/WORKLOG.md
+++ b/devlog/2026-07-27_debug-chat-notification/WORKLOG.md
@@ -1,0 +1,15 @@
+# WORKLOG: Debug Mode — Inject Compression Notification into Chat Session
+
+## Change
+
+`lib/ui/notification.ts` — `sendCompressNotification()` (line 309-321):
+
+Added `if (config.debug)` block that calls `sendIgnoredMessage()` to inject the notification text into the chat session BEFORE the toast. This gives a persistent, user-visible, model-invisible record of each compression event when debug mode is active.
+
+The `dropEmptyMessages` backstop in `lib/messages/utils.ts:238` (called at the end of the transform pipeline in `hooks.ts:267`) strips the ignored-only message before the next LLM call, preventing the FIX #20 provider 400 error.
+
+Non-debug behavior is unchanged — toast only.
+
+## Verification
+
+- Build ✅ | Typecheck ✅ | 929 unit tests ✅

--- a/lib/ui/notification.ts
+++ b/lib/ui/notification.ts
@@ -299,6 +299,13 @@ export async function sendCompressNotification(
     // leaving an empty user message that triggers provider 400 (zhipuai code
     // 1214, isRetryable: false) and freezes the session. Toast bypasses the
     // message stream entirely.
+    //
+    // [DEBUG] When config.debug is on, ALSO inject into the chat session via
+    // sendIgnoredMessage so the notification persists in the transcript (user-
+    // visible, model-invisible). The dropEmptyMessages backstop in the message
+    // transform pipeline strips the ignored-only message before the next LLM
+    // call, preventing the FIX #20 400 error. Toast is still shown alongside
+    // for immediate popup feedback.
     if (config.pruneNotificationType === "chat") {
         logger.warn(
             "compress.pruneNotificationType 'chat' is no longer supported (it injects an empty user message that causes provider 400 errors); falling back to toast. Set pruneNotificationType to 'toast' (or pruneNotification to 'off') to silence this warning.",
@@ -309,6 +316,12 @@ export async function sendCompressNotification(
     let toastMessage = message
     toastMessage =
         config.pruneNotification === "minimal" ? toastMessage : truncateToastBody(toastMessage)
+
+    if (config.debug) {
+        const chatMessage =
+            config.pruneNotification === "minimal" ? message : truncateToastBody(message)
+        await sendIgnoredMessage(client, sessionId, chatMessage, params, logger)
+    }
 
     await client.tui.showToast({
         body: {


### PR DESCRIPTION
## Summary

When `debug: true`, compression notifications now appear in the chat transcript (persistent, user-visible, model-invisible) in addition to the toast popup.

## Problem

Debug mode previously only showed compression notifications as transient toast popups (5s). Developers couldn't scroll back to review what was compressed.

## Change

`lib/ui/notification.ts` — `sendCompressNotification()`:

```typescript
if (config.debug) {
    await sendIgnoredMessage(client, sessionId, chatMessage, params, logger)
}
await client.tui.showToast({ ... })
```

The `sendIgnoredMessage` call persists the notification as a user message with `ignored: true` text — visible in the chat UI, stripped by opencode before the LLM call.

## Safety

FIX #20 originally disabled this path because opencode's stripping left an empty user message → provider 400 (zhipuai code 1214). The `dropEmptyMessages` backstop (`lib/messages/utils.ts:238`) now catches these empty messages in the transform pipeline before they reach the provider. This makes debug-mode chat injection safe.

Non-debug behavior is unchanged — toast only.

## Verification

Build ✅ | Typecheck ✅ | 929 unit tests ✅