### PR TITLE
fix: nudge injection loop — gate anchored nudges + recognize failed compress

### DIFF
--- a/devlog/2026-07-27_fix-nudge-injection-loop/REQ.md
+++ b/devlog/2026-07-27_fix-nudge-injection-loop/REQ.md
@@ -1,0 +1,35 @@
+# REQ: Fix Nudge Injection Loop (Issue #216)
+
+## Problem
+
+Two defects in `lib/messages/inject/inject.ts` caused a nudge injection loop:
+
+1. **Defect 1 — Ordering**: `applyAnchoredNudges` fired at line 305 whenever `nudgeAllowed` was true, BEFORE `nothingToCompress` was computed (line 370). This meant nudge text was injected into the suffix message even when there was nothing to compress (all ranges in protected zone, or all filtered by recommendation filter). The suffix message then had content and was NOT dropped, so the model saw a nudge with no compressible ranges.
+
+2. **Defect 2 — Failed compress never resets nudge state**: `messageHasCompress` (query.ts:37) only recognized `status === "completed"`. When compress failed (status `"error"` — e.g., all messages filtered by protection), `currentTurnHasCompress` was false, so the nudge state was NOT reset. The halved threshold (`nudgeGrowthTokens / 2`) persisted indefinitely, causing the model to be re-nudged every turn even with minimal context growth.
+
+## Solution
+
+### Defect 1 Fix
+- Removed the unconditional `applyAnchoredNudges` call that fired when `nudgeAllowed`
+- Added a new `applyAnchoredNudges` call after `shouldInject` is computed (line 367), gated by `shouldInject`
+- This ensures anchored nudges only fire when there is actually something to compress (or emergency override)
+
+### Defect 2 Fix
+- Added `messageHasCompressAttempt` in `query.ts` — recognizes ANY compress tool call regardless of status
+- Changed `inject.ts` to use `currentTurnHasCompressAttempt` for the early-return block (clearing nudge state + anchors)
+- Baseline adjustment logic now gated by `currentTurnHasCompress` (completed only) within the attempt block
+- Result: failed compress clears the halved threshold (breaks loop) but does NOT adjust the baseline (nothing was actually compressed)
+
+## Scope
+
+| File | Change |
+|------|--------|
+| `lib/messages/query.ts` | Added `messageHasCompressAttempt` function |
+| `lib/messages/inject/inject.ts` | Use `messageHasCompressAttempt` for nudge state reset; move `applyAnchoredNudges` after `shouldInject` |
+| `tests/inject.test.ts` | 2 new tests: failed compress clears state without baseline change; no nudge when nothingToCompress |
+| `tests/query-pure.test.ts` | 6 new tests for `messageHasCompressAttempt` (completed, error, pending, no state, non-compress, user msg) |
+
+## Out of Scope
+
+- Defect 3 (nudge payload self-inflation): User explicitly rejected changing the payload — "改了以后效果会降低很多"

--- a/devlog/2026-07-27_fix-nudge-injection-loop/WORKLOG.md
+++ b/devlog/2026-07-27_fix-nudge-injection-loop/WORKLOG.md
@@ -1,0 +1,31 @@
+# WORKLOG: Fix Nudge Injection Loop
+
+## Branch
+`2026-07-27_fix-nudge-injection-loop` from `github/master` at `f61e42b`
+
+## Changes
+
+### lib/messages/query.ts
+- Added `messageHasCompressAttempt`: checks `part.type === "tool" && part.tool === "compress"` without status filter
+- Exported alongside existing `messageHasCompress`
+
+### lib/messages/inject/inject.ts
+- Imported `messageHasCompressAttempt` from `../query`
+- Replaced `messages.slice(currentTurnStart).some(...)` with `currentTurnMessages.some(...)` (extracted to variable)
+- Added `currentTurnHasCompressAttempt` computation alongside existing `currentTurnHasCompress`
+- Changed early-return condition from `if (currentTurnHasCompress)` to `if (currentTurnHasCompressAttempt)`
+- Nudge state clearing (anchors, `lastNudgeShownTokens`, etc.) now fires on ANY compress attempt
+- Baseline adjustment condition changed from `if (wasNudgeTriggered && !compressBaselineSet)` to `if (currentTurnHasCompress && wasNudgeTriggered && !compressBaselineSet)` — only successful compress adjusts baseline
+- Removed unconditional `applyAnchoredNudges` call at line ~305 (fired when `nudgeAllowed`)
+- Added `applyAnchoredNudges` call after `shouldInject` computation (line ~367), gated by `if (shouldInject)`
+
+### tests/inject.test.ts
+- "failed compress (status=error) clears nudge state but does NOT adjust baseline": Sets up failed compress with `status: "error"`, verifies `lastNudgeShownTokens` cleared, anchors cleared, but baseline unchanged
+- "no nudge text injected when nothingToCompress despite nudgeAllowed (defect 1)": All messages in protected zone, verifies no suffix message persists
+
+### tests/query-pure.test.ts
+- 6 new tests covering `messageHasCompressAttempt` for all status variants (completed, error, pending, no state, non-compress tool, user message)
+
+## Verification
+- TypeScript: 0 errors
+- Tests: 937/937 pass (929 baseline + 8 new)

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -11,6 +11,7 @@ import {
     isIgnoredUserMessage,
     isProtectedUserMessage,
     messageHasCompress,
+    messageHasCompressAttempt,
 } from "../query"
 import { saveSessionState } from "../../state/persistence"
 import {
@@ -101,11 +102,15 @@ export const injectCompressNudges = (
         (m) => m.info.role === "user" && !isIgnoredUserMessage(m),
     )
     const currentTurnStart = lastUserIdx >= 0 ? lastUserIdx + 1 : 0
-    const currentTurnHasCompress = messages
-        .slice(currentTurnStart)
-        .some((m) => m.info.role === "assistant" && messageHasCompress(m))
+    const currentTurnMessages = messages.slice(currentTurnStart)
+    const currentTurnHasCompress = currentTurnMessages.some(
+        (m) => m.info.role === "assistant" && messageHasCompress(m),
+    )
+    const currentTurnHasCompressAttempt = currentTurnMessages.some(
+        (m) => m.info.role === "assistant" && messageHasCompressAttempt(m),
+    )
 
-    if (currentTurnHasCompress) {
+    if (currentTurnHasCompressAttempt) {
         const wasNudgeTriggered = state.nudges.lastNudgeShownTokens !== undefined
 
         state.nudges.contextLimitAnchors.clear()
@@ -116,14 +121,7 @@ export const injectCompressNudges = (
         state.nudges.lastTier2NudgeTokens = undefined
         state.nudges.lastTier3NudgeTokens = undefined
 
-        // Proportional baseline adjustment: if nudge-triggered compress, adjust
-        // baseline by how much was actually compressed. >50% of growth compressed
-        // → full baseline update. 20-30% → partial update. This prevents both
-        // baseline leak (small compress → full reset → growth forgotten) and
-        // over-compression (model gets re-nudged too soon after a small compress).
-        //
-        // Voluntary compress (no nudge shown) keeps the original baseline entirely.
-        if (wasNudgeTriggered && !state.nudges.compressBaselineSet) {
+        if (currentTurnHasCompress && wasNudgeTriggered && !state.nudges.compressBaselineSet) {
             const baseline = state.nudges.lastPerMessageNudgeTokens
             const postCompress = currentTokens
             // preCompressTokens is captured in hooks.ts BEFORE prune() runs
@@ -302,10 +300,6 @@ export const injectCompressNudges = (
 
     const effectiveTipsVariant = emergencyOverride ? "maxLimit" : decision.tipsVariant
 
-    if (nudgeAllowed) {
-        applyAnchoredNudges(state, config, messages, prompts, compressionPriorities, currentTokens, modelContextLimit, suffixMessage)
-    }
-
     if (state.nudges.lastPerMessageNudgeTokens === undefined && currentTokens !== undefined) {
         // Growth is measured from the session's starting context — the system
         // prompt is always present and is NOT growth.
@@ -369,6 +363,10 @@ export const injectCompressNudges = (
     const allInProtectedZone = protectedRefs.size > 0 && unprotectedCompressible.length === 0
     const nothingToCompress = filterSuppressed || allProtected || allInProtectedZone
     let shouldInject = nudgeAllowed && (!nothingToCompress || emergencyOverride)
+
+    if (shouldInject) {
+        applyAnchoredNudges(state, config, messages, prompts, compressionPriorities, currentTokens, modelContextLimit, suffixMessage)
+    }
 
     // [FIX baseline-reset] Do NOT reset the growth baseline when nothingToCompress
     // is true. The old code reset lastPerMessageNudgeTokens = currentTokens here,

--- a/lib/messages/query.ts
+++ b/lib/messages/query.ts
@@ -40,6 +40,19 @@ export const messageHasCompress = (message: WithParts): boolean => {
     )
 }
 
+export const messageHasCompressAttempt = (message: WithParts): boolean => {
+    if (!isMessageWithInfo(message)) {
+        return false
+    }
+
+    if (message.info.role !== "assistant") {
+        return false
+    }
+
+    const parts = Array.isArray(message.parts) ? message.parts : []
+    return parts.some((part) => part.type === "tool" && part.tool === "compress")
+}
+
 export const isIgnoredUserMessage = (message: WithParts): boolean => {
     if (!isMessageWithInfo(message)) {
         return false

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -274,6 +274,50 @@ test("compress followed by continuation assistant sets baseline to continuation 
     assert.equal(state.nudges.contextLimitAnchors.size, 0, "anchors must be cleared")
 })
 
+test("failed compress (status=error) clears nudge state but does NOT adjust baseline", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 200_000
+    state.nudges.lastNudgeShownTokens = 200_000
+    state.nudges.contextLimitAnchors.add("anchor-1")
+    const config = buildConfig()
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "tried compress", { input: 200_000, output: 50_000 }, [
+            {
+                id: "a1-tool", messageID: "a1", sessionID: SID,
+                type: "tool", tool: "compress", callID: "compress-fail",
+                state: { status: "error", input: {}, output: "Error: all messages filtered" },
+            },
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, messages, {} as any)
+    assert.equal(state.nudges.lastNudgeShownTokens, undefined, "lastNudgeShownTokens must be cleared on failed compress")
+    assert.equal(state.nudges.contextLimitAnchors.size, 0, "anchors must be cleared on failed compress")
+    assert.equal(state.nudges.lastPerMessageNudgeTokens, 200_000, "baseline must NOT change on failed compress")
+    assert.equal(state.nudges.compressBaselineSet, false, "compressBaselineSet must NOT be set on failed compress")
+})
+
+test("no nudge text injected when nothingToCompress despite nudgeAllowed (defect 1)", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 50_000
+    state.messageIds.byRawId.set("u1", "m00001")
+    state.messageIds.byRef.set("m00001", "u1")
+    state.messageIds.byRawId.set("a1", "m00002")
+    state.messageIds.byRef.set("m00002", "a1")
+    const config = buildConfig()
+    config.compress.preserveRecentMessages = 100
+    config.compress.preserveRecentTokens = 1_000_000
+    const messages: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "response", { input: 200_000, output: 50_000 }),
+    ]
+    const originalLength = messages.length
+    injectCompressNudges(state, config, logger, messages, {} as any)
+    assert.equal(messages.length, originalLength, "no suffix message should persist when nothingToCompress")
+})
+
 test("formatMessageIdTag produces dcp-message-id tag", () => {
     const tag = formatMessageIdTag("m00001")
     assert.ok(tag.includes("m00001"))

--- a/tests/query-pure.test.ts
+++ b/tests/query-pure.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import test from "node:test"
-import { messageHasCompress, isIgnoredUserMessage } from "../lib/messages/query"
+import { messageHasCompress, messageHasCompressAttempt, isIgnoredUserMessage } from "../lib/messages/query"
 
 function makeAssistant(overrides: Record<string, any> = {}) {
     return {
@@ -64,6 +64,42 @@ test("messageHasCompress returns false for message with no parts", () => {
     const msg = makeAssistant()
     msg.parts = []
     assert.equal(messageHasCompress(msg as any), false)
+})
+
+test("messageHasCompressAttempt returns true for completed compress", () => {
+    const msg = makeAssistant()
+    msg.parts = [{ type: "tool", tool: "compress", state: { status: "completed" } }]
+    assert.equal(messageHasCompressAttempt(msg as any), true)
+})
+
+test("messageHasCompressAttempt returns true for errored compress", () => {
+    const msg = makeAssistant()
+    msg.parts = [{ type: "tool", tool: "compress", state: { status: "error" } }]
+    assert.equal(messageHasCompressAttempt(msg as any), true)
+})
+
+test("messageHasCompressAttempt returns true for pending compress", () => {
+    const msg = makeAssistant()
+    msg.parts = [{ type: "tool", tool: "compress", state: { status: "pending" } }]
+    assert.equal(messageHasCompressAttempt(msg as any), true)
+})
+
+test("messageHasCompressAttempt returns true for compress with no state", () => {
+    const msg = makeAssistant()
+    msg.parts = [{ type: "tool", tool: "compress" }]
+    assert.equal(messageHasCompressAttempt(msg as any), true)
+})
+
+test("messageHasCompressAttempt returns false for non-compress tool", () => {
+    const msg = makeAssistant()
+    msg.parts = [{ type: "tool", tool: "read", state: { status: "completed" } }]
+    assert.equal(messageHasCompressAttempt(msg as any), false)
+})
+
+test("messageHasCompressAttempt returns false for user message", () => {
+    const msg = makeUser()
+    msg.parts = [{ type: "tool", tool: "compress", state: { status: "completed" } }]
+    assert.equal(messageHasCompressAttempt(msg as any), false)
 })
 
 test("isIgnoredUserMessage returns true for user message with no parts", () => {


### PR DESCRIPTION
## Summary

Fixes two defects that caused a nudge injection loop (issue #216).

### Defect 1 — `applyAnchoredNudges` fired before `nothingToCompress` check

`applyAnchoredNudges` was called unconditionally when `nudgeAllowed` was true, BEFORE the recommendation filter computed `nothingToCompress`. This meant nudge text was injected into the suffix message even when all ranges were in the protected zone or filtered out. The suffix message then had content and was NOT dropped.

**Fix**: Moved `applyAnchoredNudges` after `shouldInject` computation, gated by `shouldInject`.

### Defect 2 — Failed compress never reset nudge state

`messageHasCompress` only recognized `status === "completed"`. When compress failed (status `"error"`), `currentTurnHasCompress` was false, so nudge state was NOT reset. The halved threshold (`nudgeGrowthTokens / 2`) persisted indefinitely, re-nudging the model every turn.

**Fix**: Added `messageHasCompressAttempt` (any status). Nudge state reset now fires on ANY compress attempt; baseline adjustment still gated by `completed`-only.

## Files Changed

- `lib/messages/query.ts` — Added `messageHasCompressAttempt`
- `lib/messages/inject/inject.ts` — Use attempt for state reset, completed for baseline; gate `applyAnchoredNudges` by `shouldInject`
- `tests/inject.test.ts` — 2 new tests
- `tests/query-pure.test.ts` — 6 new tests

## Test Results

937/937 pass (929 baseline + 8 new). TypeScript 0 errors.