### PR TITLE
feat(debug): persist full nudge text to chat UI in debug mode

### DIFF
--- a/devlog/2026-07-28_debug-nudge-chat/REQ.md
+++ b/devlog/2026-07-28_debug-nudge-chat/REQ.md
@@ -1,0 +1,14 @@
+# REQ: Debug Nudge Chat Visibility
+
+## Goal
+In debug mode, persist the full ACP nudge text (compression prompts, ranges, tips, breakdown) to the chat UI via `sendIgnoredMessage`, so users can see exactly what ACP injected for debugging.
+
+## Problem
+Currently, debug mode only shows nudge text via:
+- Logger debug file (not visible in UI)
+- 5-second toast popup (ephemeral, not persisted)
+
+The nudge suffix message is ephemeral (transform hook only, not persisted to DB), so users cannot inspect what ACP actually injected.
+
+## Solution
+In the `debugNotify` callback in `hooks.ts`, call `sendIgnoredMessage` with the full nudge text prefixed with `[ACP Debug Nudge]`. This persists to the conversation database as `ignored: true` (user-visible, model-invisible).

--- a/devlog/2026-07-28_debug-nudge-chat/WORKLOG.md
+++ b/devlog/2026-07-28_debug-nudge-chat/WORKLOG.md
@@ -1,0 +1,6 @@
+# WORKLOG: Debug Nudge Chat Visibility
+
+1. Created branch `2026-07-28_debug-nudge-chat` from master
+2. Imported `sendIgnoredMessage` from `./ui/notification` in hooks.ts
+3. Modified `debugNotify` callback to call `sendIgnoredMessage` with full nudge text prefixed `[ACP Debug Nudge]`
+4. Verified: typecheck ✅, build ✅, 917 tests ✅

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -40,6 +40,7 @@ import { compressPermission, syncCompressPermissionState } from "./compress-perm
 import { hideConsumedCompressCalls } from "./compress/hide-consumed"
 import { createSessionState, saveSessionState, syncToolCache, updatePerTurnState, type SessionStateRegistry } from "./state"
 import { cacheSystemPromptTokens } from "./ui/utils"
+import { sendIgnoredMessage } from "./ui/notification"
 import { runBatchCleanup } from "./gc/merge"
 import { getCurrentTokenUsage } from "./token-utils"
 
@@ -202,6 +203,21 @@ export function createChatMessageTransformHandler(
             config.debug
                 ? (text: string) => {
                       logger.debug(`[ACP Debug] Nudge injected:\n${text}`)
+                      if (state.sessionId && lastUserMessage) {
+                          const userInfo = lastUserMessage.info as any
+                          sendIgnoredMessage(
+                              client,
+                              state.sessionId,
+                              `[ACP Debug Nudge]\n${text}`,
+                              {
+                                  providerId: userInfo.model?.providerID,
+                                  modelId: userInfo.model?.modelID,
+                                  agent: userInfo.agent,
+                                  variant: userInfo.variant,
+                              },
+                              logger,
+                          ).catch(() => {})
+                      }
                       client.tui
                           .showToast({
                               body: {


### PR DESCRIPTION
## Summary

In debug mode, the full ACP nudge text (compression ranges, tips, breakdown) is now persisted to the chat UI via `sendIgnoredMessage`.

**Before**: Debug mode only showed nudge text via a 5-second toast popup + debug log file. The nudge suffix message is ephemeral (transform hook only, not persisted to DB), so users couldn't inspect what ACP actually injected.

**After**: Debug mode also calls `sendIgnoredMessage` with the complete nudge text prefixed `[ACP Debug Nudge]`. This persists to the conversation database as `ignored: true` (user-visible, model-invisible).

## Changes
- `lib/hooks.ts`: Import `sendIgnoredMessage`, add call in `debugNotify` callback
- The toast (500-char truncated) is still shown alongside for immediate popup feedback

## Verification
- typecheck ✅
- build ✅ (428KB)
- 917 tests ✅