### PR TITLE
release: v1.14.6 — debug nudge chat visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.6 — Debug Nudge Chat Visibility (PR #226)
+
+**Problem**: With `debug: true`, ACP nudge injections (compression suggestions, context breakdown, tier triggers) were only visible via a 5-second toast and log files. The nudge suffix message is ephemeral — injected by the message-transform hook but never persisted to the conversation DB — so users could not see what the model was actually seeing in the chat UI. This made debugging nudge behavior very difficult.
+
+**Fix**: When `config.debug` is on, the `debugNotify` callback in `hooks.ts` now also calls `sendIgnoredMessage()` to persist the full nudge text to the conversation DB as an `ignored: true` user message (user-visible, model-invisible). The message is prefixed with `[ACP Debug Nudge]` for easy identification. Toast notification still shown alongside for backward compat. Debug OFF: behavior unchanged (no persisted messages).
+
+Files: `lib/hooks.ts`. No source logic changes. No config changes. No persisted-state schema changes. 937 tests pass.
+
 ### v1.14.5 — GC Module Removal + Property-Based Tests + Issue #176 Fix + Config Docs (PRs #222, #206, #221, #223, #224)
 
 **Problem**: Five issues bundled. (1) **GC data-loss bugs** (PR #222): The `gc/truncate.ts` module had 4 confirmed bugs that could silently lose summaries — single-line truncation exceeded maxLength by 19 chars, barely-over-maxLength silently failed (longer than input), long-header output overrun, and off-by-one marker reservation. GC only triggered at 100% context (default), so it was rarely reached but catastrophic when it did. (2) **Dead code** (PR #206): Prune tool, sweep command, and strategies (~2309 lines) were never used — `prune` tool was replaced by `compress` tool, `sweep` was superseded by batch cleanup, strategies were vestigial. (3) **No property-based tests** (PR #221): All tests were targeted/unit tests — invariant violations across edge cases were undetectable. (4) **Missing config docs** (PR #223): No comprehensive config reference — users had to read source to discover parameters. (5) **Nudge permanently stops after compress** (PR #224, Issue #176): In autonomous sessions (single user message + many assistant/tool turns), `injectCompressNudges` had an unconditional early return when any compress was detected in the current turn. Since the entire session IS one turn, once compress happened, `currentTurnHasCompress` was always true → function always returned early → nudges never fired again → unbounded context growth.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -463,6 +463,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.14.6 — Debug Nudge 聊天界面可见性（PR #226）
+
+**问题**：开启 `debug: true` 时，ACP nudge 注入（压缩建议、上下文分类、分层触发器）只能通过 5 秒 toast 和日志文件查看。nudge 后缀消息是临时的——由消息变换 hook 注入但从未持久化到会话数据库——因此用户无法在聊天界面看到模型实际看到的内容。这使得调试 nudge 行为非常困难。
+
+**修复**：当 `config.debug` 开启时，`hooks.ts` 中的 `debugNotify` 回调现在额外调用 `sendIgnoredMessage()`，将完整 nudge 文本以 `ignored: true` 用户消息形式持久化到会话数据库（用户可见，模型不可见）。消息前缀为 `[ACP Debug Nudge]` 便于识别。Toast 通知仍同时显示以保持向后兼容。Debug 关闭：行为不变（无持久化消息）。
+
+文件：`lib/hooks.ts`。无源逻辑变更。无配置变更。无持久化状态架构变更。937 项测试通过。
+
 ### v1.14.5 — GC 模块移除 + 属性测试 + Issue #176 修复 + 配置文档（PRs #222, #206, #221, #223, #224）
 
 **问题**：打包修复 5 个问题。(1) **GC 数据丢失 Bug**（PR #222）：`gc/truncate.ts` 有 4 个已确认的 bug，可能静默丢失摘要——单行截断超过 maxLength 19 字符、刚好超过 maxLength 时静默失败（输出比输入更长）、长 header 输出溢出、标记预留 off-by-one。GC 默认只在 100% 上下文时触发，所以很少触发但触发时是灾难性的。(2) **死代码**（PR #206）：prune 工具、sweep 命令和策略（约 2309 行）从未被使用。(3) **无属性测试**（PR #221）：所有测试都是针对性/单元测试——不变量违反在边界情况下无法检测。(4) **缺少配置文档**（PR #223）：没有完整的配置参考——用户必须读源码才能发现参数。(5) **压缩后 nudge 永久停止**（PR #224，Issue #176）：在自治会话（单条用户消息 + 大量助手/工具消息）中，`injectCompressNudges` 在检测到当前 turn 有压缩时无条件 early return。由于整个会话就是一个 turn，一旦发生压缩，`currentTurnHasCompress` 永远为 true → 函数永远 early return → nudge 不再触发 → 上下文无限增长。

--- a/devlog/2026-07-28_release-v1.14.6/REQ.md
+++ b/devlog/2026-07-28_release-v1.14.6/REQ.md
@@ -1,0 +1,22 @@
+# REQ — v1.14.6 Release
+
+## Goal
+
+Release v1.14.6 bundling PR #226 (debug nudge chat visibility).
+
+## Context
+
+PR #226 was merged after v1.14.5. This is a small release to ship the single change.
+
+## Changes
+
+- PR #226: `lib/hooks.ts` — `debugNotify` callback now persists full nudge text to conversation DB via `sendIgnoredMessage()` when `config.debug` is on. User-visible, model-invisible (`ignored: true`). Prefix `[ACP Debug Nudge]`.
+
+## Acceptance Criteria
+
+- [x] Version bumped to 1.14.6
+- [x] Changelog entries added to README.md and README.zh-CN.md
+- [x] Devlog created
+- [x] Build + typecheck + tests pass
+- [ ] PR created
+- [ ] Human merge

--- a/devlog/2026-07-28_release-v1.14.6/WORKLOG.md
+++ b/devlog/2026-07-28_release-v1.14.6/WORKLOG.md
@@ -1,0 +1,15 @@
+# WORKLOG — v1.14.6 Release
+
+## 2026-07-28
+
+1. Created release branch `2026-07-28_release-v1.14.6` from master `becee35` (PR #226 merged)
+2. Bumped `package.json` version: `1.14.5 → 1.14.6`
+3. Added changelog entry to `README.md` (v1.14.6 section)
+4. Added changelog entry to `README.zh-CN.md` (v1.14.6 section)
+5. Created devlog entry
+6. Verified build + typecheck + tests
+7. Created PR
+
+## Bundled PR
+
+- PR #226: Debug nudge chat visibility — `lib/hooks.ts` `debugNotify` callback now persists full nudge text to conversation DB when `config.debug` is on, making nudge injections visible in the chat UI for debugging.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-acp",
-    "version": "1.14.5",
+    "version": "1.14.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-acp",
-            "version": "1.14.5",
+            "version": "1.14.6",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.5",
+    "version": "1.14.6",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Release v1.14.6 bundling PR #226 (debug nudge chat visibility).

**Changes**:
- PR #226: When `config.debug` is on, the `debugNotify` callback in `hooks.ts` now persists the full nudge text to the conversation DB via `sendIgnoredMessage()`. This makes ACP's nudge injections visible in the chat UI for debugging (user-visible, model-invisible via `ignored: true`). Message prefixed with `[ACP Debug Nudge]`.

## Verification

- [x] Typecheck: clean
- [x] Build: clean (428KB bundle)
- [x] Tests: 937 pass
- [x] Changelog updated (README.md + README.zh-CN.md)
- [x] Devlog created