### PR TITLE
fix: deduplicate HOW_TO_COMPRESS_RULES in nudge injection

### DIFF
--- a/devlog/2026-07-28_dedup-compress-rules/REQ.md
+++ b/devlog/2026-07-28_dedup-compress-rules/REQ.md
@@ -1,0 +1,32 @@
+# REQ: Deduplicate HOW_TO_COMPRESS_RULES
+
+## Problem
+
+`HOW_TO_COMPRESS_RULES` (~1.2K tokens) was injected **multiple times per nudge turn**:
+
+1. **System prompt** (`prompts/system.ts:58`) — always present (1x)
+2. **Nudge templates** (`turn-nudge.ts`, `iteration-nudge.ts`, `context-limit-nudge.ts`) — each containing `${HOW_TO_COMPRESS_RULES}`, appended to suffix message via `applyAnchoredNudges` (1-2x)
+3. **Breakdown block** (`inject.ts:535-537`) — appended `HOW_TO_COMPRESS_RULES` to the same suffix message when `effectiveTipsVariant !== "maxLimit"` (1x)
+
+In non-maxLimit scenarios, the suffix message contained `HOW_TO_COMPRESS_RULES` **2-3 times** (from nudge templates + breakdown). Combined with the system prompt copy, the model saw the same ~1.2K-token rules block **3-4 times per turn** — wasting **2.4-3.6K tokens per nudge**.
+
+The duplication became visible in v1.14.6 which persists debug nudge text to the chat UI (PR #227).
+
+## Fix
+
+Remove `HOW_TO_COMPRESS_RULES` from:
+- `lib/messages/inject/inject.ts:535-537` — breakdown duplication (redundant with nudge templates)
+- `lib/prompts/turn-nudge.ts` — template copy
+- `lib/prompts/iteration-nudge.ts` — template copy
+- `lib/prompts/context-limit-nudge.ts` — template copy
+
+Keep in:
+- `lib/prompts/system.ts:58` — system prompt always has the full rules (single source of truth)
+- `lib/compress/quality-gate/rejection.ts:68` — rejection message needs full rules for retry guidance
+
+## Acceptance Criteria
+
+- [x] `HOW_TO_COMPRESS_RULES` appears exactly once per turn (in system prompt)
+- [x] No type errors
+- [x] All 917 tests pass
+- [x] Build succeeds

--- a/devlog/2026-07-28_dedup-compress-rules/WORKLOG.md
+++ b/devlog/2026-07-28_dedup-compress-rules/WORKLOG.md
@@ -1,0 +1,25 @@
+# WORKLOG: Deduplicate HOW_TO_COMPRESS_RULES
+
+## Changes
+
+### `lib/messages/inject/inject.ts`
+- Removed `HOW_TO_COMPRESS_RULES` from import (line 45)
+- Removed breakdown duplication block (lines 535-537): `if (effectiveTipsVariant !== "maxLimit") { breakdown += HOW_TO_COMPRESS_RULES }`
+
+### `lib/prompts/turn-nudge.ts`
+- Removed `import { HOW_TO_COMPRESS_RULES }` 
+- Removed `${HOW_TO_COMPRESS_RULES}` from template
+
+### `lib/prompts/iteration-nudge.ts`
+- Removed `import { HOW_TO_COMPRESS_RULES }`
+- Removed `${HOW_TO_COMPRESS_RULES}` from template
+
+### `lib/prompts/context-limit-nudge.ts`
+- Removed `import { HOW_TO_COMPRESS_RULES }`
+- Removed `${HOW_TO_COMPRESS_RULES}` from template
+
+## Verification
+- TypeScript typecheck: clean
+- Build: 427.93 KB (same as before — string constant was inlined)
+- Tests: 917 pass, 0 fail
+- Bundle grep confirms only `system.ts` retains the reference

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -42,7 +42,7 @@ import {
     resolveAdaptiveNudgeGrowth,
 } from "./utils"
 import { buildCompressedBlockGuidance } from "../../prompts/extensions/nudge"
-import { HOW_TO_COMPRESS_RULES, COMPRESS_PHILOSOPHY, TIER2_DISTILL_RULES, TIER3_CONDENSE_RULES } from "context-compress-algorithms/prompts"
+import { COMPRESS_PHILOSOPHY, TIER2_DISTILL_RULES, TIER3_CONDENSE_RULES } from "context-compress-algorithms/prompts"
 import { getTierTokenUsage } from "../../state/utils"
 
 /**
@@ -532,9 +532,6 @@ export const injectCompressNudges = (
             }
             breakdown += `\nUse \`acp_status({scope:"uncompressed"})\` to re-fetch compressible ranges after compressing, or \`acp_status\` for compressed block details.`
 
-            if (effectiveTipsVariant !== "maxLimit") {
-                breakdown += `\n\n${HOW_TO_COMPRESS_RULES}`
-            }
             appendToLastTextPart(suffixMessage, breakdown)
         }
 

--- a/lib/prompts/context-limit-nudge.ts
+++ b/lib/prompts/context-limit-nudge.ts
@@ -1,5 +1,3 @@
-import { HOW_TO_COMPRESS_RULES } from "context-compress-algorithms/prompts"
-
 export const CONTEXT_LIMIT_NUDGE = `
 <system-reminder>
 ⚠️ Context limit reached — time to compress the largest ranges you no longer need. Prioritize completed tool outputs and resolved work. You can decompress specific blocks later if you need details. Keeping context lean helps you stay accurate.
@@ -23,8 +21,6 @@ HOW TO CALL COMPRESS:
 - Do NOT copy IDs from this example. Do NOT invent IDs.
 - Do NOT use IDs from compressed block summaries — they are stale.
 - startId must appear BEFORE endId in the conversation.
-
-${HOW_TO_COMPRESS_RULES}
 
 RANGE STRATEGY:
 - Prefer one large range over multiple small ones.

--- a/lib/prompts/iteration-nudge.ts
+++ b/lib/prompts/iteration-nudge.ts
@@ -1,5 +1,3 @@
-import { HOW_TO_COMPRESS_RULES } from "context-compress-algorithms/prompts"
-
 export const ITERATION_NUDGE = `
 <system-reminder>
 You've been iterating for a while. If any earlier work is closed and unlikely to be referenced, compress it now.
@@ -9,8 +7,6 @@ You've been iterating for a while. If any earlier work is closed and unlikely to
   "content": [{ "startId": "<visible message ID>", "endId": "<visible message ID>", "summary": "..." }]
 }
 
-⚠️ ONLY use IDs from <dcp-message-id> tags visible above. Do NOT invent or copy example IDs.
-
-${HOW_TO_COMPRESS_RULES}
+⚠️ ONLY use IDs from  tags visible above. Do NOT invent or copy example IDs.
 </system-reminder>
 `

--- a/lib/prompts/turn-nudge.ts
+++ b/lib/prompts/turn-nudge.ts
@@ -1,5 +1,3 @@
-import { HOW_TO_COMPRESS_RULES } from "context-compress-algorithms/prompts"
-
 export const TURN_NUDGE = `
 <system-reminder>
 Context is getting full. If you've finished reading tool outputs or exploration results, compress them — you can decompress later if needed. This keeps your focus on the current task and improves accuracy.
@@ -10,7 +8,5 @@ Context is getting full. If you've finished reading tool outputs or exploration 
 }
 
 ⚠️ ONLY use IDs from  tags visible above. Do NOT invent or copy example IDs.
-
-${HOW_TO_COMPRESS_RULES}
 </system-reminder>
 `


### PR DESCRIPTION
## Summary

- **Problem**: `HOW_TO_COMPRESS_RULES` (~1.2K tokens) was injected **3-4 times per nudge turn** — once in system prompt, 1-2 times in nudge templates, and again in the breakdown block. In non-maxLimit scenarios, the suffix message alone contained the rules **2-3 times**.
- **Fix**: Removed `HOW_TO_COMPRESS_RULES` from breakdown block (`inject.ts:535-537`) and all 3 nudge templates. Kept in `system.ts` (single source of truth) and `quality-gate/rejection.ts` (retry guidance).
- **Impact**: Saves **2.4-3.6K tokens per nudge turn**. The duplication became visible in v1.14.6 which persists debug nudge text to chat UI.

## Test Plan

- [x] TypeScript typecheck clean
- [x] Build succeeds (427.93 KB)
- [x] 917 tests pass, 0 failures
- [x] `grep -rn 'HOW_TO_COMPRESS_RULES' lib/` confirms only `system.ts` and `rejection.ts` retain references