### PR TITLE
release: v1.14.7 — deduplicate HOW_TO_COMPRESS_RULES

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,14 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.7 — Deduplicate HOW_TO_COMPRESS_RULES (PR #228)
+
+**Problem**: `HOW_TO_COMPRESS_RULES` (~1.2K tokens) was injected 3-4 times per nudge turn — once in the system prompt, 1-2 times in nudge templates (turn/iteration/context-limit), and again in the breakdown block. In non-maxLimit scenarios the suffix message alone contained the rules 2-3 times. This wasted 2.4-3.6K tokens per nudge turn. The duplication became visible in v1.14.6 which persists debug nudge text to chat UI.
+
+**Fix**: Removed `HOW_TO_COMPRESS_RULES` from the breakdown block (`inject.ts:535-537`) and all 3 nudge templates (`turn-nudge.ts`, `iteration-nudge.ts`, `context-limit-nudge.ts`). Kept in `system.ts` (single source of truth — injected every turn per v1.8.2 invariant) and `quality-gate/rejection.ts` (retry guidance). Oracle-verified: no scenario loses compression guidance.
+
+Files: `lib/messages/inject/inject.ts`, `lib/prompts/{turn,iteration,context-limit}-nudge.ts`. 917 tests pass.
+
 ### v1.14.6 — Debug Nudge Chat Visibility (PR #226)
 
 **Problem**: With `debug: true`, ACP nudge injections (compression suggestions, context breakdown, tier triggers) were only visible via a 5-second toast and log files. The nudge suffix message is ephemeral — injected by the message-transform hook but never persisted to the conversation DB — so users could not see what the model was actually seeing in the chat UI. This made debugging nudge behavior very difficult.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -463,6 +463,14 @@ ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将
 
 ## 更新日志
 
+### v1.14.7 — 去重 HOW_TO_COMPRESS_RULES（PR #228）
+
+**问题**：`HOW_TO_COMPRESS_RULES`（~1.2K tokens）每次 nudge 注入重复 3-4 次——系统提示词 1 次、nudge 模板 1-2 次、breakdown 块 1 次。非 maxLimit 场景下 suffix 消息单独就包含 2-3 份规则。每次 nudge 浪费 2.4-3.6K tokens。v1.14.6 让 debug 模式持久化 nudge 文本到聊天界面后，重复变得可见。
+
+**修复**：从 breakdown 块（`inject.ts:535-537`）和全部 3 个 nudge 模板（`turn-nudge.ts`、`iteration-nudge.ts`、`context-limit-nudge.ts`）移除 `HOW_TO_COMPRESS_RULES`。保留在 `system.ts`（单一可信源——每轮注入，v1.8.2 不变量）和 `quality-gate/rejection.ts`（重试指导）。Oracle 验证：无任何场景丢失压缩指导。
+
+文件：`lib/messages/inject/inject.ts`、`lib/prompts/{turn,iteration,context-limit}-nudge.ts`。917 项测试通过。
+
 ### v1.14.6 — Debug Nudge 聊天界面可见性（PR #226）
 
 **问题**：开启 `debug: true` 时，ACP nudge 注入（压缩建议、上下文分类、分层触发器）只能通过 5 秒 toast 和日志文件查看。nudge 后缀消息是临时的——由消息变换 hook 注入但从未持久化到会话数据库——因此用户无法在聊天界面看到模型实际看到的内容。这使得调试 nudge 行为非常困难。

--- a/devlog/2026-07-28_release-v1.14.7/REQ.md
+++ b/devlog/2026-07-28_release-v1.14.7/REQ.md
@@ -1,0 +1,12 @@
+# REQ: Release v1.14.7
+
+## Purpose
+Bundle PR #228 (deduplicate HOW_TO_COMPRESS_RULES) into a stable release.
+
+## Changes
+- `package.json`: version 1.14.6 → 1.14.7
+- `README.md`: add v1.14.7 changelog entry
+- `README.zh-CN.md`: add v1.14.7 changelog entry
+
+## Bundled PR
+- PR #228: fix: deduplicate HOW_TO_COMPRESS_RULES in nudge injection

--- a/devlog/2026-07-28_release-v1.14.7/WORKLOG.md
+++ b/devlog/2026-07-28_release-v1.14.7/WORKLOG.md
@@ -1,0 +1,11 @@
+# WORKLOG: Release v1.14.7
+
+## Steps
+1. Created release branch `2026-07-28_release-v1.14.7` from master (`49e041a`)
+2. Bumped `package.json` version: 1.14.6 → 1.14.7
+3. Added changelog entry to `README.md` (v1.14.7 section)
+4. Added changelog entry to `README.zh-CN.md` (v1.14.7 section)
+5. Created devlog entry
+
+## Bundled
+- PR #228: Deduplicate HOW_TO_COMPRESS_RULES — removed from breakdown block + 3 nudge templates, kept in system prompt + rejection message. Saves 2.4-3.6K tokens per nudge turn. Oracle-verified no regression.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.6",
+    "version": "1.14.7",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Release v1.14.7

Bundles PR #228: Deduplicate HOW_TO_COMPRESS_RULES in nudge injection.

- Removed redundant `HOW_TO_COMPRESS_RULES` (~1.2K tokens) from breakdown block + 3 nudge templates
- Kept in system prompt (single source of truth) + quality-gate rejection message
- Saves 2.4-3.6K tokens per nudge turn
- Oracle-verified: no scenario loses compression guidance
- 917 tests pass, typecheck clean, build clean