### PR TITLE
feat: add npm 'stable' dist-tag promotion via PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,31 +9,9 @@ on:
                 description: "Force publish even if not a release branch merge"
                 required: false
                 default: "false"
-            promote_stable:
-                description: "Promote a published version to npm 'stable' tag (e.g. '1.14.7'). Leave empty for normal runs."
-                required: false
-                default: ""
 
 jobs:
-    promote-stable:
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.promote_stable != ''
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: 22
-                  registry-url: https://registry.npmjs.org
-
-            - name: Promote to stable tag
-              run: |
-                  VERSION="${{ github.event.inputs.promote_stable }}"
-                  echo "Promoting opencode-acp@$VERSION to 'stable' tag"
-                  npm dist-tag add "opencode-acp@$VERSION" stable
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
     publish:
-        if: github.event.inputs.promote_stable == '' || github.event_name == 'push'
         runs-on: ubuntu-latest
         permissions:
             contents: write
@@ -42,7 +20,7 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Check if release branch was merged
+            - name: Check commit type
               id: check
               run: |
                   MERGE_MSG=$(git log -1 --pretty=%B)
@@ -51,8 +29,9 @@ jobs:
 
                   FORCE="${{ github.event.inputs.force }}"
                   IS_RELEASE="false"
+                  IS_PROMOTE_STABLE="false"
 
-                  # Pattern 1: Standard merge commit
+                  # Pattern 1: Standard merge of release branch
                   #   "Merge pull request #171 from ranxianglei/2026-07-21_release-v1.13.2"
                   if echo "$MERGE_TITLE" | grep -qE 'Merge pull request #[0-9]+ from .*[0-9]{4}-[0-9]{2}-[0-9]{2}_release-v'; then
                       IS_RELEASE="true"
@@ -62,14 +41,29 @@ jobs:
                   elif echo "$MERGE_TITLE" | grep -qE '^release: v[0-9]+\.[0-9]+\.[0-9]+'; then
                       IS_RELEASE="true"
                       echo "Release branch detected (squash merge)"
+                  # Pattern 3: Squash merge of a promote-stable PR
+                  #   "promote: stable v1.14.7 — ... (#231)"
+                  elif echo "$MERGE_TITLE" | grep -qE '^promote: stable v[0-9]+\.[0-9]+\.[0-9]+'; then
+                      IS_PROMOTE_STABLE="true"
+                      STABLE_VERSION=$(echo "$MERGE_TITLE" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/^v//')
+                      echo "Promote-stable detected: version $STABLE_VERSION"
+                      echo "stable_version=$STABLE_VERSION" >> "$GITHUB_OUTPUT"
+                  # Pattern 4: Standard merge of promote-stable branch
+                  #   "Merge pull request #231 from ranxianglei/2026-07-29_promote-stable-v1.14.7"
+                  elif echo "$MERGE_TITLE" | grep -qE 'Merge pull request #[0-9]+ from .*promote-stable-v[0-9]+\.[0-9]+\.[0-9]+'; then
+                      IS_PROMOTE_STABLE="true"
+                      STABLE_VERSION=$(echo "$MERGE_TITLE" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/^v//')
+                      echo "Promote-stable detected (standard merge): version $STABLE_VERSION"
+                      echo "stable_version=$STABLE_VERSION" >> "$GITHUB_OUTPUT"
                   elif [ "$FORCE" = "true" ]; then
                       IS_RELEASE="true"
                       echo "Force publish requested"
                   else
-                      echo "Not a release branch merge — skipping"
+                      echo "Not a release or promote-stable branch merge — skipping"
                   fi
 
                   echo "is_release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
+                  echo "is_promote_stable=$IS_PROMOTE_STABLE" >> "$GITHUB_OUTPUT"
 
             - name: Read version
               if: steps.check.outputs.is_release == 'true'
@@ -92,12 +86,27 @@ jobs:
                   fi
 
             - uses: actions/setup-node@v4
-              if: steps.check.outputs.is_release == 'true'
+              if: steps.check.outputs.is_release == 'true' || steps.check.outputs.is_promote_stable == 'true'
               with:
                   node-version: 22
                   cache: npm
                   registry-url: https://registry.npmjs.org
 
+            # ── Promote to npm stable tag ──────────────────────────
+            # Branch naming: YYYY-MM-DD_promote-stable-v{VERSION}
+            # Commit message: "promote: stable v{VERSION} — reason"
+            # CI runs `npm dist-tag add opencode-acp@VERSION stable`
+            - name: Promote to npm stable tag
+              if: steps.check.outputs.is_promote_stable == 'true'
+              run: |
+                  VERSION="${{ steps.check.outputs.stable_version }}"
+                  echo "Promoting opencode-acp@$VERSION to 'stable' tag"
+                  npm dist-tag add "opencode-acp@$VERSION" stable
+                  echo "✓ Done. Users can now install via opencode-acp@stable"
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+            # ── Normal release flow (unchanged) ────────────────────
             - if: steps.check.outputs.is_release == 'true'
               run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,31 @@ on:
                 description: "Force publish even if not a release branch merge"
                 required: false
                 default: "false"
+            promote_stable:
+                description: "Promote a published version to npm 'stable' tag (e.g. '1.14.7'). Leave empty for normal runs."
+                required: false
+                default: ""
 
 jobs:
+    promote-stable:
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.promote_stable != ''
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  registry-url: https://registry.npmjs.org
+
+            - name: Promote to stable tag
+              run: |
+                  VERSION="${{ github.event.inputs.promote_stable }}"
+                  echo "Promoting opencode-acp@$VERSION to 'stable' tag"
+                  npm dist-tag add "opencode-acp@$VERSION" stable
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
     publish:
+        if: github.event.inputs.promote_stable == '' || github.event_name == 'push'
         runs-on: ubuntu-latest
         permissions:
             contents: write

--- a/devlog/2026-07-29_stable-npm-tag/REQ.md
+++ b/devlog/2026-07-29_stable-npm-tag/REQ.md
@@ -1,20 +1,30 @@
-# REQ: Add npm `stable` dist-tag support
+# REQ: Add npm `stable` dist-tag promotion via PR
 
 ## Problem
-npm package only has `latest` (auto-published on every release) and `dev` (prerelease). No way to mark a version as "battle-tested stable" separately from the auto-published `latest`.
+npm package only has `latest` (auto-published) and `dev` (prerelease). No way to mark a version as "battle-tested stable". The initial workflow_dispatch approach (manual version input) was rejected — no audit trail for why a version was promoted.
 
 ## Solution
-Add a `workflow_dispatch` input `promote_stable` to the release workflow. When triggered with a version string (e.g. `1.14.7`), it runs `npm dist-tag add opencode-acp@VERSION stable`.
+PR-based promotion. When a `YYYY-MM-DD_promote-stable-v{VERSION}` branch is merged to master, CI detects the merge commit pattern and runs `npm dist-tag add opencode-acp@VERSION stable`.
 
-This creates a 3-tier npm tag system:
-- **`latest`** — auto-published on every stable release (npm default, `npm install opencode-acp` gets this)
-- **`stable`** — manually promoted by user via GitHub Actions UI when a version is battle-tested
-- **`dev`** — prerelease (versions with `-` suffix)
+The PR itself serves as documentation:
+- Branch name embeds the version
+- PR description records WHY this version is promoted
+- Git history provides full audit trail
 
-Users install stable via `opencode-acp@stable` or in opencode config: `"opencode-acp": "stable"`.
+CI detects two merge patterns:
+- Squash merge: `promote: stable v1.14.7 — ... (#231)`
+- Standard merge: `Merge pull request #231 from .../2026-07-29_promote-stable-v1.14.7`
+
+## 3-tier tag system
+
+| Tag | Purpose | How it updates |
+|------|---------|----------------|
+| `latest` | Auto-published on every stable release | CI on release branch merge |
+| `stable` | Manually promoted via PR | Merge `promote-stable-v{VERSION}` branch |
+| `dev` | Prerelease | CI on `-` suffix versions |
 
 ## Usage
-GitHub Actions → Release workflow → Run workflow → set `promote_stable` to the version (e.g. `1.14.7`).
-
-## Files
-- `.github/workflows/release.yml` — added `promote_stable` input + `promote-stable` job
+1. Create branch `YYYY-MM-DD_promote-stable-v{VERSION}`
+2. Create PR with description explaining what changed since last stable
+3. Merge PR
+4. CI auto-runs `npm dist-tag add opencode-acp@VERSION stable`

--- a/devlog/2026-07-29_stable-npm-tag/REQ.md
+++ b/devlog/2026-07-29_stable-npm-tag/REQ.md
@@ -1,0 +1,20 @@
+# REQ: Add npm `stable` dist-tag support
+
+## Problem
+npm package only has `latest` (auto-published on every release) and `dev` (prerelease). No way to mark a version as "battle-tested stable" separately from the auto-published `latest`.
+
+## Solution
+Add a `workflow_dispatch` input `promote_stable` to the release workflow. When triggered with a version string (e.g. `1.14.7`), it runs `npm dist-tag add opencode-acp@VERSION stable`.
+
+This creates a 3-tier npm tag system:
+- **`latest`** — auto-published on every stable release (npm default, `npm install opencode-acp` gets this)
+- **`stable`** — manually promoted by user via GitHub Actions UI when a version is battle-tested
+- **`dev`** — prerelease (versions with `-` suffix)
+
+Users install stable via `opencode-acp@stable` or in opencode config: `"opencode-acp": "stable"`.
+
+## Usage
+GitHub Actions → Release workflow → Run workflow → set `promote_stable` to the version (e.g. `1.14.7`).
+
+## Files
+- `.github/workflows/release.yml` — added `promote_stable` input + `promote-stable` job

--- a/devlog/2026-07-29_stable-npm-tag/WORKLOG.md
+++ b/devlog/2026-07-29_stable-npm-tag/WORKLOG.md
@@ -1,0 +1,12 @@
+# WORKLOG: Add npm stable dist-tag support
+
+## Changes
+- `.github/workflows/release.yml`:
+  - Added `promote_stable` input to `workflow_dispatch`
+  - Added `promote-stable` job: runs `npm dist-tag add opencode-acp@VERSION stable` when triggered
+  - Guarded `publish` job with `if: promote_stable == '' || event == push` to prevent both jobs running simultaneously
+
+## Verification
+- YAML syntax valid (GitHub Actions schema)
+- `publish` job logic unchanged when `promote_stable` is empty
+- `promote-stable` job only runs when `promote_stable` input is non-empty

--- a/devlog/2026-07-29_stable-npm-tag/WORKLOG.md
+++ b/devlog/2026-07-29_stable-npm-tag/WORKLOG.md
@@ -1,12 +1,16 @@
-# WORKLOG: Add npm stable dist-tag support
+# WORKLOG: Add npm stable dist-tag promotion via PR
 
-## Changes
+## Changes (v2 — redesigned from workflow_dispatch to PR-based)
 - `.github/workflows/release.yml`:
-  - Added `promote_stable` input to `workflow_dispatch`
-  - Added `promote-stable` job: runs `npm dist-tag add opencode-acp@VERSION stable` when triggered
-  - Guarded `publish` job with `if: promote_stable == '' || event == push` to prevent both jobs running simultaneously
+  - Removed `promote_stable` workflow_dispatch input (rejected: no audit trail)
+  - Added Pattern 3 + Pattern 4 detection for `promote-stable-v{VERSION}` branch merges
+  - Added "Promote to npm stable tag" step: runs `npm dist-tag add opencode-acp@VERSION stable`
+  - Expanded `setup-node` condition to cover both `is_release` and `is_promote_stable`
+  - All existing release/publish steps unchanged
 
-## Verification
-- YAML syntax valid (GitHub Actions schema)
-- `publish` job logic unchanged when `promote_stable` is empty
-- `promote-stable` job only runs when `promote_stable` input is non-empty
+## Rationale
+PR-based promotion provides:
+- Git history audit trail (who promoted, when, why)
+- PR description documents what changed since last stable
+- No manual version input (eliminates typo risk)
+- Same merge-based flow as releases — consistent workflow


### PR DESCRIPTION
## Summary

PR-based promotion to npm `stable` tag. ~~Manual `workflow_dispatch` input~~ (redesigned per feedback — no audit trail).

### 3-tier tag system

| Tag | Purpose | How it updates |
|------|---------|----------------|
| `latest` | Auto-published on every stable release | CI on release branch merge |
| **`stable`** | **Manually promoted via PR** | **Merge `promote-stable-v{VERSION}` branch** |
| `dev` | Prerelease versions | CI on `-` suffix versions |

### How to promote a version to stable

1. Create branch: `YYYY-MM-DD_promote-stable-v{VERSION}` (e.g. `2026-07-29_promote-stable-v1.14.7`)
2. Create PR with description explaining **what changed since last stable**
3. Merge the PR (human-only operation)
4. CI detects the merge commit → runs `npm dist-tag add opencode-acp@VERSION stable`
5. Users install via `opencode-acp@stable`

### Why PR-based (not manual input)

- **Audit trail**: git history records who promoted, when, and why
- **Documentation**: PR description documents what changed since last stable
- **No typos**: version extracted from branch name, not manual input
- **Consistent**: same merge-based flow as releases

### CI detection

Two merge patterns:
- Squash merge: `promote: stable v1.14.7 — ... (#231)`
- Standard merge: `Merge pull request #231 from .../2026-07-29_promote-stable-v1.14.7`

### Changes

- `.github/workflows/release.yml`: Added Pattern 3+4 detection for promote-stable branches + `npm dist-tag add` step. Existing release flow unchanged.