### PR TITLE
promote: stable v1.14.7 — first stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The model decides <em>when</em> and <em>what</em> to compress — not a hard lim
 </p>
 
 <p align="center">
-<code>opencode plugin opencode-acp@latest --global</code>
+<code>opencode plugin opencode-acp@stable --global</code>
 </p>
 
 ---
@@ -70,7 +70,7 @@ across all other sessions.
 ## Installation
 
 ```bash
-opencode plugin opencode-acp@latest --global
+opencode plugin opencode-acp@stable --global
 ```
 
 Or add to your opencode config:
@@ -78,7 +78,7 @@ Or add to your opencode config:
 ```json
 {
     "plugin": {
-        "opencode-acp": "latest"
+        "opencode-acp": "stable"
     }
 }
 ```
@@ -446,7 +446,7 @@ For the `compress` tool, `compress.protectedTools` ensures specific tool outputs
 ACP is a drop-in replacement for DCP. To migrate:
 
 1. Remove the old DCP plugin from your `opencode.json`
-2. Install ACP: `opencode plugin install opencode-acp@latest --global`
+2. Install ACP: `opencode plugin install opencode-acp@stable --global`
 3. Restart OpenCode
 
 **What's preserved:**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-<code>opencode plugin opencode-acp@latest --global</code>
+<code>opencode plugin opencode-acp@stable --global</code>
 </p>
 
 ---
@@ -57,7 +57,7 @@ ACP 将上下文管理的所有权限全部交给模型自己，而不依靠外�
 ## 安装
 
 ```bash
-opencode plugin opencode-acp@latest --global
+opencode plugin opencode-acp@stable --global
 ```
 
 或者添加到你的 opencode 配置中：
@@ -65,7 +65,7 @@ opencode plugin opencode-acp@latest --global
 ```json
 {
     "plugin": {
-        "opencode-acp": "latest"
+        "opencode-acp": "stable"
     }
 }
 ```
@@ -400,7 +400,7 @@ ACP 暴露六个可编辑的 prompt：
 ACP 是 DCP 的直接替代品。迁移步骤：
 
 1. 从 `opencode.json` 中移除旧的 DCP 插件
-2. 安装 ACP：`opencode plugin install opencode-acp@latest --global`
+2. 安装 ACP：`opencode plugin install opencode-acp@stable --global`
 3. 重启 OpenCode
 
 **保留的内容：**

--- a/devlog/2026-07-29_promote-stable-v1.14.7/REQ.md
+++ b/devlog/2026-07-29_promote-stable-v1.14.7/REQ.md
@@ -1,0 +1,53 @@
+# REQ: Promote v1.14.7 to npm stable tag
+
+## Purpose
+First stable promotion. Marks v1.14.7 as the battle-tested `stable` release.
+
+## Version: 1.14.7
+
+## What changed since initial release (key milestones in v1.14.x series):
+
+### v1.14.7
+- Deduplicate HOW_TO_COMPRESS_RULES — saves 2.4-3.6K tokens per nudge turn
+
+### v1.14.6
+- Debug nudge chat visibility — debug mode persists nudge text to chat UI
+
+### v1.14.5
+- GC module removal (4 data-loss bugs fixed) + emergency tool output truncation
+- Dead code removal (~2309 lines: prune tool, sweep, strategies)
+- Property-based tests (10 invariants, ~1400 random inputs)
+- Issue #176 fix: nudge permanently stops after compress in autonomous sessions
+- Config documentation (CONFIGURATION.md + zh-CN)
+
+### v1.14.4
+- Tier detection fix (PR #215)
+- E2E test expansion (8 scenarios, CI)
+- Debug notification (PR #217)
+- Nudge loop fix (Issue #216, PR #218)
+
+### v1.14.3
+- Soften protected zone — convert hard-reject to soft-filter
+- Reduce defaults: preserveRecentMessages 20→5, preserveRecentTokens 20000→5000
+
+### v1.14.2
+- Split protected ranges at boundary
+- Soften last-user-message from hard-reject to soft-filter
+
+### v1.14.1
+- Log version info in debug logs
+- Growth baseline fix (nothingToCompress feedback loop)
+
+### v1.14.0
+- Three-tier LSM-tree compression (T1 capture → T2 distill → T3 condense)
+- Preserve-recent messages/tokens protection
+- Summary visibility fix (summaryBuffer over-counting)
+
+## Why stable
+v1.14.x series has been tested across multiple real engineering sessions with:
+- 917+ unit tests, 0 failures
+- 10 E2E scenarios in CI
+- Property-based testing (fast-check, ~1400 random inputs)
+- Dual-agent review on all source changes
+- GC data-loss bugs eliminated
+- Autonomous session nudge loop fixed

--- a/devlog/2026-07-29_promote-stable-v1.14.7/WORKLOG.md
+++ b/devlog/2026-07-29_promote-stable-v1.14.7/WORKLOG.md
@@ -1,0 +1,11 @@
+# WORKLOG: Promote v1.14.7 to npm stable tag
+
+## Steps
+1. Created branch `2026-07-29_promote-stable-v1.14.7` from master (`8ba7948`)
+2. Created devlog with v1.14.x changelog summary
+3. On merge, CI will detect `promote: stable v1.14.7` pattern and run `npm dist-tag add opencode-acp@1.14.7 stable`
+
+## Expected CI behavior
+- Merge commit: `promote: stable v1.14.7 (#NNN)` (squash) or `Merge pull request #NNN from .../2026-07-29_promote-stable-v1.14.7` (standard)
+- CI Pattern 3/4 detection triggers `npm dist-tag add opencode-acp@1.14.7 stable`
+- Result: `stable` tag points to 1.14.7


### PR DESCRIPTION
## Promote v1.14.7 to npm `stable` tag

First stable promotion. On merge, CI runs `npm dist-tag add opencode-acp@1.14.7 stable`.

## What's in v1.14.7 (since v1.14.0)

| Version | Key Change |
|---------|-----------|
| **v1.14.7** | Deduplicate HOW_TO_COMPRESS_RULES — saves 2.4-3.6K tokens/nudge |
| v1.14.6 | Debug nudge chat visibility |
| v1.14.5 | GC removal (4 data-loss bugs) + Issue #176 fix + property tests + config docs |
| v1.14.4 | Tier detection fix + E2E expansion + nudge loop fix (Issue #216) |
| v1.14.3 | Soften protected zone (hard-reject → soft-filter) |
| v1.14.2 | Split protected ranges at boundary |
| v1.14.1 | Version logging + growth baseline fix |
| v1.14.0 | Three-tier LSM-tree compression + preserve-recent protection |

## Why stable

- 917+ unit tests, 0 failures
- 10 E2E scenarios in CI
- Property-based testing (fast-check, ~1400 random inputs)
- Dual-agent review on all source changes
- GC data-loss bugs eliminated
- Autonomous session nudge loop fixed

## After merge

```
npm view opencode-acp dist-tags
→ { "latest": "1.14.7", "stable": "1.14.7", "dev": "1.13.9-dev.1" }
```

Users install: `opencode plugin opencode-acp@stable --global`