### PR TITLE
refactor: remove turnProtection + DCP migration code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,9 +253,7 @@ Three-layer config merging (later layers override earlier):
 1. Global:     ~/.config/opencode/acp.jsonc
 2. Config dir: $OPENCODE_CONFIG_DIR/acp.jsonc
 3. Project:    .opencode/acp.jsonc
-```
-
-Auto-migration: if `acp.jsonc` doesn't exist but `dcp.jsonc` does, automatically copies.
+ ```
 
 #### Default Configuration
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ opencode-acp/
 ├── index.ts                          # Plugin entry point — wires hooks, tools, commands, config
 ├── lib/
 │   ├── hooks.ts                      # Plugin hook handlers (system prompt, message transform, command, event, text-complete)
-│   ├── config.ts                     # Three-layer config: global → config-dir → project, with DCP migration
+│   ├── config.ts                     # Three-layer config: global → config-dir → project
 │   ├── logger.ts                     # Structured logging (logs/acp/)
 │   ├── auth.ts                       # Plugin authentication
 │   ├── token-utils.ts                # Token counting utilities
@@ -106,7 +106,7 @@ opencode-acp/
 │   │
 │   ├── state/                        # State management
 │   │   ├── state.ts                  # SessionState creation, session change detection
-│   │   ├── persistence.ts            # File persistence (plugin/acp/{sessionId}.json), DCP migration
+│   │   ├── persistence.ts            # File persistence (plugin/acp/{sessionId}.json)
 │   │   ├── tool-cache.ts             # Tool result caching
 │   │   ├── types.ts                  # Core types (SessionState, CompressionBlock, Prune, etc.)
 │   │   ├── utils.ts                  # State utility functions
@@ -250,9 +250,9 @@ State is persisted to `~/.local/share/opencode/storage/plugin/acp/{sessionId}.js
 Three-layer config merging (later layers override earlier):
 
 ```
-1. Global:     ~/.config/opencode/acp.jsonc    (fallback: dcp.jsonc)
-2. Config dir: $OPENCODE_CONFIG_DIR/acp.jsonc  (fallback: dcp.jsonc)
-3. Project:    .opencode/acp.jsonc             (fallback: dcp.jsonc)
+1. Global:     ~/.config/opencode/acp.jsonc
+2. Config dir: $OPENCODE_CONFIG_DIR/acp.jsonc
+3. Project:    .opencode/acp.jsonc
 ```
 
 Auto-migration: if `acp.jsonc` doesn't exist but `dcp.jsonc` does, automatically copies.
@@ -267,7 +267,6 @@ Auto-migration: if `acp.jsonc` doesn't exist but `dcp.jsonc` does, automatically
     pruneNotification: "detailed",
     pruneNotificationType: "toast",
     commands: { enabled: true, protectedTools: ["task", "skill", "todowrite", "todoread", "compress", "batch", "plan_enter", "plan_exit", "write", "edit"] },
-    turnProtection: { enabled: false, turns: 4 },
     experimental: { allowSubAgents: false, customPrompts: false },
     protectedFilePatterns: [],
     compress: {
@@ -296,12 +295,12 @@ Auto-migration: if `acp.jsonc` doesn't exist but `dcp.jsonc` does, automatically
 
 ### 2.5 Storage Paths
 
-| What              | ACP Path                          | Legacy DCP Path | Migration                 |
-| ----------------- | --------------------------------- | --------------- | ------------------------- |
-| State persistence | `plugin/acp/{sessionId}.json`     | `plugin/dcp/`   | Auto-copy on first access |
-| Config            | `~/.config/opencode/acp.jsonc`    | `dcp.jsonc`     | Auto-copy on first access |
-| Prompt overrides  | `~/.config/opencode/acp-prompts/` | `dcp-prompts/`  | Auto-copy on first access |
-| Debug logs        | `logs/acp/`                       | `logs/dcp/`     | Path change only          |
+| What              | ACP Path                          | Notes          |
+| ----------------- | --------------------------------- | -------------- |
+| State persistence | `plugin/acp/{sessionId}.json`     | JSON file I/O  |
+| Config            | `~/.config/opencode/acp.jsonc`    | JSONC          |
+| Prompt overrides  | `~/.config/opencode/acp-prompts/` | File-based     |
+| Debug logs        | `logs/acp/`                       | Per-request    |
 
 Base storage: `~/.local/share/opencode/storage/`
 
@@ -367,7 +366,7 @@ CI is configured via GitHub Actions (PR #2): typecheck + test + build on Node 22
 
 **Coverage gaps** (modules still without dedicated tests):
 
-- `state/persistence.ts` — state persistence, DCP migration
+- `state/persistence.ts` — state persistence
 - `messages/prune.ts` — prune replacement logic
 - `messages/sync.ts` — block synchronization
 - `messages/inject/inject.ts` — nudge injection
@@ -482,7 +481,6 @@ For reference when modifying code — these bugs were real and the fixes are loa
 | GC deactivation    | `gc/truncate.ts`                           | Age-based block deactivation (blocks were never deactivated)                                                                                                                                       |
 | Logger speedup     | `logger.ts`                                | 268x faster tokenization (was using sync API)                                                                                                                                                      |
 | Summary resolution | `compress/range.ts`                        | Block placeholder injection for nested compressions                                                                                                                                                |
-| Config migration   | `config.ts`                                | Auto-migrate dcp.jsonc → acp.jsonc at getConfig() entry point                                                                                                                                      |
 
 ---
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -14,8 +14,6 @@ ACP reads config from up to three layers (later layers override earlier):
 | **Config dir** | `$OPENCODE_CONFIG_DIR/acp.jsonc` | All sessions in this config dir |
 | **Project** | `.opencode/acp.jsonc` (searched upward from cwd) | Current project only |
 
-Legacy `dcp.jsonc` / `dcp.json` paths are auto-migrated on first load.
-
 > **Tip:** Add `"$schema": "https://raw.githubusercontent.com/ranxianglei/opencode-acp/master/dcp.schema.json"` for IDE autocompletion.
 
 ## Quick Start
@@ -102,25 +100,6 @@ Controls ACP slash commands (`/acp context`, `/acp stats`, etc.).
 - **Default:** `["task", "skill", "todowrite", "todoread", "compress", "decompress", "batch", "plan_enter", "plan_exit", "write", "edit"]`
 - **Status:** ACTIVE
 - **Description:** Tool outputs from these tools are protected from compression. These tools' outputs survive intact in visible context. An explicit array **replaces** the default (use `[]` to protect nothing).
-
----
-
-
-### `turnProtection`
-
-Protects the most recent turns from compression.
-
-#### `turnProtection.enabled`
-- **Type:** `boolean`
-- **Default:** `false`
-- **Status:** ACTIVE
-- **Description:** When `true`, messages from the last N turns are protected from compression.
-
-#### `turnProtection.turns`
-- **Type:** `number`
-- **Default:** `4`
-- **Status:** ACTIVE
-- **Description:** Number of recent turns to protect when `turnProtection.enabled` is `true`.
 
 ---
 

--- a/CONFIGURATION.zh-CN.md
+++ b/CONFIGURATION.zh-CN.md
@@ -14,8 +14,6 @@ ACP 从最多三层配置文件中读取（后加载的覆盖先加载的）：
 | **配置目录** | `$OPENCODE_CONFIG_DIR/acp.jsonc` | 该配置目录下的所有会话 |
 | **项目** | `.opencode/acp.jsonc`（从当前目录向上搜索） | 仅当前项目 |
 
-旧版 `dcp.jsonc` / `dcp.json` 路径会在首次加载时自动迁移。
-
 > **提示：** 在配置文件中添加 `"$schema": "https://raw.githubusercontent.com/ranxianglei/opencode-acp/master/dcp.schema.json"` 可获得 IDE 自动补全。
 
 ## 快速开始
@@ -102,25 +100,6 @@ ACP 从最多三层配置文件中读取（后加载的覆盖先加载的）：
 - **默认值：** `["task", "skill", "todowrite", "todoread", "compress", "decompress", "batch", "plan_enter", "plan_exit", "write", "edit"]`
 - **状态：** ACTIVE
 - **说明：** 这些工具的输出受保护，不会被压缩。受保护工具的输出完整保留在可见上下文中。显式数组会**替换**默认值（设 `[]` 表示不保护任何工具）。
-
----
-
-
-### `turnProtection`
-
-保护最近几轮对话不被压缩。
-
-#### `turnProtection.enabled`
-- **类型：** `boolean`
-- **默认值：** `false`
-- **状态：** ACTIVE
-- **说明：** 设为 `true` 时，最近 N 轮的消息受保护，不被压缩。
-
-#### `turnProtection.turns`
-- **类型：** `number`
-- **默认值：** `4`
-- **状态：** ACTIVE
-- **说明：** 当 `turnProtection.enabled` 为 `true` 时，保护的最近对话轮数。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -253,8 +253,6 @@ ACP uses its own config file, searched in order:
 2. **Custom config directory:** `$OPENCODE_CONFIG_DIR/acp.jsonc` (or `acp.json`), if `OPENCODE_CONFIG_DIR` is set
 3. **Project:** `.opencode/acp.jsonc` (or `acp.json`) in your project's `.opencode` directory
 
-If no `acp.jsonc` is found, ACP falls back to `dcp.jsonc` / `dcp.json` (for backward compatibility with existing DCP installations) and auto-migrates on first write.
-
 Each level overrides the previous, so project settings take priority over global. Restart OpenCode after making config changes.
 
 > **📖 Full parameter reference:** See [CONFIGURATION.md](./CONFIGURATION.md) for a complete reference of every configurable parameter with type, default value, and description.
@@ -300,11 +298,6 @@ Each level overrides the previous, so project settings take priority over global
     },
     // Manual mode: disables autonomous context management,
     // tools only run when explicitly triggered via /acp commands
-    // Protect from pruning for <turns> message turns past tool invocation
-    "turnProtection": {
-        "enabled": false,
-        "turns": 4,
-    },
     // Experimental settings
     "experimental": {
         // Allow ACP processing in subagent sessions
@@ -443,23 +436,17 @@ ACP is a drop-in replacement for DCP. To migrate:
 
 1. Remove the old DCP plugin from your `opencode.json`
 2. Install ACP: `opencode plugin install opencode-acp@stable --global`
-3. Restart OpenCode
-
-**What's preserved:**
-
-- Session state (compression blocks, message ID mappings) -- auto-migrated from `plugin/dcp/` to `~/.local/share/opencode/storage/plugin/acp/`
-- Config file `~/.config/opencode/dcp.jsonc` -- ACP auto-migrates to `acp.jsonc`
-- Prompt overrides in `~/.config/opencode/dcp-prompts/` -- auto-migrates to `acp-prompts/`
+3. Copy your config: `cp ~/.config/opencode/dcp.jsonc ~/.config/opencode/acp.jsonc`
+4. Copy prompt overrides (if any): `cp -r ~/.config/opencode/dcp-prompts ~/.config/opencode/acp-prompts`
+5. Copy session state (optional, preserves compression blocks): `cp -r ~/.local/share/opencode/storage/plugin/dcp ~/.local/share/opencode/storage/plugin/acp`
+6. Restart OpenCode
 
 **What changes:**
 
-- Storage directory: `plugin/dcp/` to `plugin/acp/` (auto-migrated on first launch)
 - Log directory: `logs/dcp/` to `logs/acp/`
 - Slash command: `/dcp` to `/acp` (both work for backward compatibility)
 - Notification headers: `DCP` to `ACP`
 - Context usage label: `DCP threshold` to `ACP threshold`
-
-ACP auto-migrates config from `dcp.jsonc` to `acp.jsonc` and prompts from `dcp-prompts/` to `acp-prompts/` on first launch.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -208,8 +208,6 @@ ACP 使用自己的配置文件，按以下顺序搜索：
 2. **自定义配置目录：** `$OPENCODE_CONFIG_DIR/acp.jsonc`（或 `acp.json`），当设置了 `OPENCODE_CONFIG_DIR` 时
 3. **项目级：** 项目 `.opencode` 目录下的 `.opencode/acp.jsonc`（或 `acp.json`）
 
-如果未找到 `acp.jsonc`，ACP 会回退到 `dcp.jsonc` / `dcp.json`（用于与现有 DCP 安装向后兼容），并在首次写入时自动迁移。
-
 每一层覆盖前一层，因此项目设置优先于全局设置。修改配置后请重启 OpenCode。
 
 > **📖 完整参数参考：** 请查看 [CONFIGURATION.zh-CN.md](./CONFIGURATION.zh-CN.md)（中文）或 [CONFIGURATION.md](./CONFIGURATION.md)（英文），包含每个可配置参数的类型、默认值和详细说明。
@@ -255,11 +253,6 @@ ACP 使用自己的配置文件，按以下顺序搜索：
     },
     // Manual mode: disables autonomous context management,
     // tools only run when explicitly triggered via /acp commands
-    // Protect from pruning for <turns> message turns past tool invocation
-    "turnProtection": {
-        "enabled": false,
-        "turns": 4,
-    },
     // Experimental settings
     "experimental": {
         // Allow ACP processing in subagent sessions
@@ -397,23 +390,17 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 1. 从 `opencode.json` 中移除旧的 DCP 插件
 2. 安装 ACP：`opencode plugin install opencode-acp@stable --global`
-3. 重启 OpenCode
-
-**保留的内容：**
-
-- 会话状态（压缩块、消息 ID 映射） — 自动从 `plugin/dcp/` 迁移到 `~/.local/share/opencode/storage/plugin/acp/`
-- 配置文件 `~/.config/opencode/dcp.jsonc` — ACP 自动迁移到 `acp.jsonc`
-- `~/.config/opencode/dcp-prompts/` 中的 prompt 覆盖 — 自动迁移到 `acp-prompts/`
+3. 复制配置：`cp ~/.config/opencode/dcp.jsonc ~/.config/opencode/acp.jsonc`
+4. 复制 prompt 覆盖（如有）：`cp -r ~/.config/opencode/dcp-prompts ~/.config/opencode/acp-prompts`
+5. 复制会话状态（可选，保留压缩块）：`cp -r ~/.local/share/opencode/storage/plugin/dcp ~/.local/share/opencode/storage/plugin/acp`
+6. 重启 OpenCode
 
 **变更的内容：**
 
-- 存储目录：`plugin/dcp/` → `plugin/acp/`（首次启动时自动迁移）
 - 日志目录：`logs/dcp/` → `logs/acp/`
 - 斜杠命令：`/dcp` → `/acp`（两者均可用于向后兼容）
 - 通知标题：`DCP` → `ACP`
 - 上下文用量标签：`DCP threshold` → `ACP threshold`
-
-ACP 在首次启动时自动将配置从 `dcp.jsonc` 迁移到 `acp.jsonc`，将 prompt 从 `dcp-prompts/` 迁移到 `acp-prompts/`。
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -117,8 +117,8 @@ Not yet implemented. Will test the complete message transform pipeline from `hoo
 
 | Source Module | Key Untested Functions | Complexity |
 |-------------|----------------------|------------|
-| `lib/config.ts` | Config merging, defaults, validation, DCP migration | ~1125 lines, largest file |
-| `lib/state/persistence.ts` | `saveSessionState`, `loadSessionState`, `ensureSessionInitialized`, DCP migration | ~295 lines, filesystem I/O |
+| `lib/config.ts` | Config merging, defaults, validation | ~1125 lines, largest file |
+| `lib/state/persistence.ts` | `saveSessionState`, `loadSessionState`, `ensureSessionInitialized` | ~295 lines, filesystem I/O |
 | `lib/state/utils.ts` (direct) | `isMessageCompacted`, `serializePruneMessagesState`, `deserializePruneMessagesState`, `getActiveSummaryTokenUsage` | ~358 lines |
 | `lib/messages/prune.ts` | `filterCompressedRanges`, `stripStepMarkers` (post-removal) | ~263 lines |
 | `lib/messages/sync.ts` | `syncCompressionBlocks` — deactivate orphaned blocks | ~130 lines |
@@ -152,7 +152,6 @@ function buildConfig(mode: "message" | "range" = "message"): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "toast",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         compress: {
@@ -444,7 +443,6 @@ function buildConfig(): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "toast",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         compress: {
@@ -530,8 +528,8 @@ Need temp directories, file I/O, or multi-module orchestration.
 
 | Module | Functions to Test | Why Hard |
 |--------|-------------------|----------|
-| `lib/config.ts` | Config loading, merging, validation, migration | Filesystem reads, JSONC parsing, DCP migration |
-| `lib/state/persistence.ts` | `saveSessionState`, `loadSessionState`, `ensureSessionInitialized` | File I/O, JSON serialization, DCP migration |
+| `lib/config.ts` | Config loading, merging, validation | Filesystem reads, JSONC parsing |
+| `lib/state/persistence.ts` | `saveSessionState`, `loadSessionState`, `ensureSessionInitialized` | File I/O, JSON serialization |
 | `lib/commands/*.ts` | Command handlers | Full client mock needed, output formatting |
 | `lib/ui/notification.ts` | `buildMinimalMessage`, `buildDetailedMessage` | Needs full `SessionState` with blocks and stats |
 | `lib/hooks.ts` | Full pipeline integration | Orchestrates all other modules |

--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -68,23 +68,6 @@
                 "protectedTools": []
             }
         },
-        "turnProtection": {
-            "type": "object",
-            "description": "Protect recent tool outputs from being pruned",
-            "additionalProperties": false,
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Enable turn-based protection"
-                },
-                "turns": {
-                    "type": "number",
-                    "default": 4,
-                    "description": "Number of recent turns to protect from pruning"
-                }
-            }
-        },
         "experimental": {
             "type": "object",
             "description": "Experimental settings that may change in future releases",

--- a/devlog/2026-07-29_slim-turnprotection-migration/REQ.md
+++ b/devlog/2026-07-29_slim-turnprotection-migration/REQ.md
@@ -1,0 +1,31 @@
+# REQ: Slim down — remove turnProtection + DCP migration code
+
+## Motivation
+
+ACP has accumulated dead/disabled features that add complexity without value. This PR removes two such features as part of a codebase slimming effort (Issue #30):
+
+1. **turnProtection** — A config option (`turnProtection.enabled: false` by default) that protected the first N turns from tool cache modifications. Fully redundant with `preserveRecentMessages` which already protects recent messages from compression.
+
+2. **DCP migration code** — Auto-migration paths (`dcp.jsonc → acp.jsonc`, `plugin/dcp/ → plugin/acp/`) that run on every startup. ACP has been the primary name for 8+ months; the migration window is closed.
+
+## Scope
+
+### turnProtection removal
+- `lib/config.ts` — Remove `TurnProtection` interface, `turnProtection` field from `PluginConfig`, default config, `deepCloneConfig`, `mergeLayer`
+- `lib/config-validation.ts` — Remove `turnProtection` from `VALID_CONFIG_KEYS`, type validation logic
+- `lib/state/tool-cache.ts` — Remove turnProtection guard logic
+- `dcp.schema.json` — Remove `turnProtection` schema section
+- All test files — Remove `turnProtection` from `buildConfig()` factories
+- `tests/config-validation.test.ts` — Delete turnProtection-specific validation tests
+- Docs — Remove from README, CONFIGURATION, AGENTS.md, TESTING.md
+
+### DCP migration removal
+- `lib/config.ts` — Remove `dcp.jsonc → acp.jsonc` migration block in `getConfig()`
+- `lib/state/persistence.ts` — Remove `dcp → acp` directory migration
+
+## Impact
+
+- ~50 lines of source code removed
+- ~100 lines of test config boilerplate removed
+- DCP-derived code reduced by ~45 lines
+- Config surface simplified (one fewer config section)

--- a/devlog/2026-07-29_slim-turnprotection-migration/WORKLOG.md
+++ b/devlog/2026-07-29_slim-turnprotection-migration/WORKLOG.md
@@ -1,0 +1,24 @@
+# WORKLOG: Slim down — remove turnProtection + DCP migration code
+
+## Changes
+
+### turnProtection removal
+- `lib/state/tool-cache.ts`: Removed turnProtection guard (turnProtectionEnabled/turnProtectionTurns/isProtectedByTurn, ~14 lines)
+- `lib/config.ts`: Removed TurnProtection interface, turnProtection from PluginConfig/defaultConfig/deepCloneConfig/mergeLayer
+- `lib/config-validation.ts`: Removed turnProtection from VALID_CONFIG_KEYS (3 entries) + type validation block (~30 lines)
+- `dcp.schema.json`: Removed turnProtection schema section
+- `tests/config-validation.test.ts`: Removed 4 turnProtection-specific test cases, updated 2 remaining tests to use other config sections
+- 28 other test files: Removed `turnProtection: { enabled: false, turns: 4 }` from buildConfig() factories
+- `AGENTS.md`, `CONFIGURATION.md`, `CONFIGURATION.zh-CN.md`, `README.md`, `README.zh-CN.md`, `TESTING.md`: Removed turnProtection documentation
+
+### DCP migration removal
+- `lib/config.ts`: Removed LEGACY_GLOBAL_CONFIG_PATH constants, dcp.jsonc/json fallback paths in getConfigPaths(), createDefaultConfig() migration block, getConfig() migration block. Removed unused `copyFileSync` import.
+- `lib/state/persistence.ts`: Removed getLegacyStorageDir(), migrateFromLegacyIfNeeded(), calls from ensureStorageDir() and writePersistedSessionState(). Removed unused cpSync/existsSyncSync import.
+- `lib/prompts/store.ts`: Removed dcp-prompts → acp-prompts migration block (`legacyGlobalRoot` + `cpSync`). Removed unused `cpSync` import.
+- Docs: Updated README.md "Migrating from DCP" section (removed auto-migration claims, added manual migration commands), README.zh-CN.md, CONFIGURATION.md/zh-CN (removed "auto-migrated on first load" line), AGENTS.md (removed migration from module map, config paths, storage paths table, bug fix history), TESTING.md (removed migration from module descriptions).
+
+## Verification
+- `tsc --noEmit`: PASS (0 errors)
+- `node --import tsx --test tests/*.test.ts`: 915/915 PASS (0 failures)
+- Zero remaining `turnProtection` references in lib/ or tests/
+- Zero remaining DCP migration references in lib/

--- a/lib/config-validation.ts
+++ b/lib/config-validation.ts
@@ -11,9 +11,6 @@ export const VALID_CONFIG_KEYS = new Set([
     "showUpdateToasts",
     "pruneNotification",
     "pruneNotificationType",
-    "turnProtection",
-    "turnProtection.enabled",
-    "turnProtection.turns",
     "experimental",
     "experimental.allowSubAgents",
     "experimental.customPrompts",
@@ -143,37 +140,6 @@ export function validateConfigTypes(config: Record<string, any>): ValidationErro
                 key: "protectedFilePatterns",
                 expected: "string[]",
                 actual: "non-string entries",
-            })
-        }
-    }
-
-    if (config.turnProtection) {
-        if (
-            config.turnProtection.enabled !== undefined &&
-            typeof config.turnProtection.enabled !== "boolean"
-        ) {
-            errors.push({
-                key: "turnProtection.enabled",
-                expected: "boolean",
-                actual: typeof config.turnProtection.enabled,
-            })
-        }
-
-        if (
-            config.turnProtection.turns !== undefined &&
-            typeof config.turnProtection.turns !== "number"
-        ) {
-            errors.push({
-                key: "turnProtection.turns",
-                expected: "number",
-                actual: typeof config.turnProtection.turns,
-            })
-        }
-        if (typeof config.turnProtection.turns === "number" && config.turnProtection.turns < 1) {
-            errors.push({
-                key: "turnProtection.turns",
-                expected: "positive number (>= 1)",
-                actual: `${config.turnProtection.turns}`,
             })
         }
     }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync, copyFileSync } from "fs"
+import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync } from "fs"
 import { join, dirname } from "path"
 import { homedir } from "os"
 import { parse } from "jsonc-parser/lib/esm/main.js"
@@ -46,11 +46,6 @@ export interface Commands {
     protectedTools: string[]
 }
 
-export interface TurnProtection {
-    enabled: boolean
-    turns: number
-}
-
 export interface ExperimentalConfig {
     allowSubAgents: boolean
     customPrompts: boolean
@@ -88,7 +83,6 @@ export interface PluginConfig {
     pruneNotification: "off" | "minimal" | "detailed"
     pruneNotificationType: "chat" | "toast"
     commands: Commands
-    turnProtection: TurnProtection
     experimental: ExperimentalConfig
     protectedFilePatterns: string[]
     compress: CompressConfig
@@ -183,10 +177,6 @@ const defaultConfig: PluginConfig = {
         enabled: true,
         protectedTools: [...DEFAULT_PROTECTED_TOOLS],
     },
-    turnProtection: {
-        enabled: false,
-        turns: 4,
-    },
     experimental: {
         allowSubAgents: false,
         customPrompts: false,
@@ -248,8 +238,6 @@ const GLOBAL_CONFIG_DIR = process.env.XDG_CONFIG_HOME
     : join(homedir(), ".config", "opencode")
 const GLOBAL_CONFIG_PATH_JSONC = join(GLOBAL_CONFIG_DIR, "acp.jsonc")
 const GLOBAL_CONFIG_PATH_JSON = join(GLOBAL_CONFIG_DIR, "acp.json")
-const LEGACY_GLOBAL_CONFIG_PATH_JSONC = join(GLOBAL_CONFIG_DIR, "dcp.jsonc")
-const LEGACY_GLOBAL_CONFIG_PATH_JSON = join(GLOBAL_CONFIG_DIR, "dcp.json")
 
 function findOpencodeDir(startDir: string): string | null {
     let current = startDir
@@ -276,28 +264,18 @@ function getConfigPaths(ctx?: PluginInput): {
         ? GLOBAL_CONFIG_PATH_JSONC
         : existsSync(GLOBAL_CONFIG_PATH_JSON)
           ? GLOBAL_CONFIG_PATH_JSON
-          : existsSync(LEGACY_GLOBAL_CONFIG_PATH_JSONC)
-            ? LEGACY_GLOBAL_CONFIG_PATH_JSONC
-            : existsSync(LEGACY_GLOBAL_CONFIG_PATH_JSON)
-              ? LEGACY_GLOBAL_CONFIG_PATH_JSON
-              : null
+          : null
 
     let configDir: string | null = null
     const opencodeConfigDir = process.env.OPENCODE_CONFIG_DIR
     if (opencodeConfigDir) {
         const configJsonc = join(opencodeConfigDir, "acp.jsonc")
         const configJson = join(opencodeConfigDir, "acp.json")
-        const legacyJsonc = join(opencodeConfigDir, "dcp.jsonc")
-        const legacyJson = join(opencodeConfigDir, "dcp.json")
         configDir = existsSync(configJsonc)
             ? configJsonc
             : existsSync(configJson)
               ? configJson
-              : existsSync(legacyJsonc)
-                ? legacyJsonc
-                : existsSync(legacyJson)
-                  ? legacyJson
-                  : null
+              : null
     }
 
     let project: string | null = null
@@ -306,17 +284,11 @@ function getConfigPaths(ctx?: PluginInput): {
         if (opencodeDir) {
             const projectJsonc = join(opencodeDir, "acp.jsonc")
             const projectJson = join(opencodeDir, "acp.json")
-            const legacyJsonc = join(opencodeDir, "dcp.jsonc")
-            const legacyJson = join(opencodeDir, "dcp.json")
             project = existsSync(projectJsonc)
                 ? projectJsonc
                 : existsSync(projectJson)
                   ? projectJson
-                  : existsSync(legacyJsonc)
-                    ? legacyJsonc
-                    : existsSync(legacyJson)
-                      ? legacyJson
-                      : null
+                  : null
         }
     }
 
@@ -329,19 +301,11 @@ function createDefaultConfig(): void {
     }
 
     if (!existsSync(GLOBAL_CONFIG_PATH_JSONC)) {
-        if (existsSync(LEGACY_GLOBAL_CONFIG_PATH_JSONC)) {
-            copyFileSync(LEGACY_GLOBAL_CONFIG_PATH_JSONC, GLOBAL_CONFIG_PATH_JSONC)
-            console.log("[ACP] Migrated config from dcp.jsonc to acp.jsonc")
-        } else if (existsSync(LEGACY_GLOBAL_CONFIG_PATH_JSON)) {
-            copyFileSync(LEGACY_GLOBAL_CONFIG_PATH_JSON, GLOBAL_CONFIG_PATH_JSONC)
-            console.log("[ACP] Migrated config from dcp.json to acp.jsonc")
-        } else {
-            const configContent = `{
+        const configContent = `{
   "$schema": "https://raw.githubusercontent.com/ranxianglei/opencode-acp/master/dcp.schema.json"
 }
 `
-            writeFileSync(GLOBAL_CONFIG_PATH_JSONC, configContent, "utf-8")
-        }
+        writeFileSync(GLOBAL_CONFIG_PATH_JSONC, configContent, "utf-8")
     }
 }
 
@@ -443,7 +407,6 @@ function deepCloneConfig(config: PluginConfig): PluginConfig {
             enabled: config.commands.enabled,
             protectedTools: [...config.commands.protectedTools],
         },
-        turnProtection: { ...config.turnProtection },
         experimental: { ...config.experimental },
         protectedFilePatterns: [...config.protectedFilePatterns],
         compress: {
@@ -496,10 +459,6 @@ function mergeLayer(config: PluginConfig, data: Record<string, any>): PluginConf
         pruneNotification: data.pruneNotification ?? config.pruneNotification,
         pruneNotificationType: data.pruneNotificationType ?? config.pruneNotificationType,
         commands: mergeCommands(config.commands, data.commands as any),
-        turnProtection: {
-            enabled: data.turnProtection?.enabled ?? config.turnProtection.enabled,
-            turns: data.turnProtection?.turns ?? config.turnProtection.turns,
-        },
         experimental: mergeExperimental(config.experimental, data.experimental as any),
         protectedFilePatterns: [
             ...new Set([...config.protectedFilePatterns, ...(data.protectedFilePatterns ?? [])]),
@@ -528,22 +487,6 @@ function scheduleParseWarning(ctx: PluginInput, title: string, message: string):
 export function getConfig(ctx: PluginInput): PluginConfig {
     let config = deepCloneConfig(defaultConfig)
     const configPaths = getConfigPaths(ctx)
-
-    // Migration: dcp.jsonc → acp.jsonc (must run before createDefaultConfig check)
-    if (!existsSync(GLOBAL_CONFIG_PATH_JSONC) && !existsSync(GLOBAL_CONFIG_PATH_JSON)) {
-        if (existsSync(GLOBAL_CONFIG_DIR) || existsSync(LEGACY_GLOBAL_CONFIG_PATH_JSONC) || existsSync(LEGACY_GLOBAL_CONFIG_PATH_JSON)) {
-            if (!existsSync(GLOBAL_CONFIG_DIR)) {
-                mkdirSync(GLOBAL_CONFIG_DIR, { recursive: true })
-            }
-            if (existsSync(LEGACY_GLOBAL_CONFIG_PATH_JSONC)) {
-                copyFileSync(LEGACY_GLOBAL_CONFIG_PATH_JSONC, GLOBAL_CONFIG_PATH_JSONC)
-                console.log("[ACP] Migrated config from dcp.jsonc to acp.jsonc")
-            } else if (existsSync(LEGACY_GLOBAL_CONFIG_PATH_JSON)) {
-                copyFileSync(LEGACY_GLOBAL_CONFIG_PATH_JSON, GLOBAL_CONFIG_PATH_JSONC)
-                console.log("[ACP] Migrated config from dcp.json to acp.jsonc")
-            }
-        }
-    }
 
     if (!configPaths.global && !existsSync(GLOBAL_CONFIG_PATH_JSONC)) {
         createDefaultConfig()

--- a/lib/prompts/store.ts
+++ b/lib/prompts/store.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync, statSync, cpSync } from "fs"
+import { existsSync, mkdirSync, readFileSync, writeFileSync, statSync } from "fs"
 import { join, dirname } from "path"
 import { homedir } from "os"
 import type { Logger } from "../logger"
@@ -160,16 +160,6 @@ function findOpencodeDir(startDir: string): string | null {
 function resolvePromptPaths(workingDirectory: string): PromptPaths {
     const configHome = process.env.XDG_CONFIG_HOME || join(homedir(), ".config")
     const globalRoot = join(configHome, "opencode", "acp-prompts")
-    const legacyGlobalRoot = join(configHome, "opencode", "dcp-prompts")
-
-    if (!existsSync(globalRoot) && existsSync(legacyGlobalRoot)) {
-        try {
-            cpSync(legacyGlobalRoot, globalRoot, { recursive: true })
-            console.log("[ACP] Migrated prompts from dcp-prompts to acp-prompts")
-        } catch (e: any) {
-            console.warn(`[ACP] Prompts migration failed: ${e.message}`)
-        }
-    }
 
     const defaultsDir = join(globalRoot, "defaults")
     const globalOverridesDir = join(globalRoot, "overrides")

--- a/lib/state/persistence.ts
+++ b/lib/state/persistence.ts
@@ -8,20 +8,9 @@ import * as fs from "fs/promises"
 import { existsSync } from "fs"
 import { homedir } from "os"
 import { join } from "path"
-import { cpSync, existsSync as existsSyncSync } from "fs"
 import type { CompressionBlock, PrunedMessageEntry, SessionState, SessionStats } from "./types"
 import type { Logger } from "../logger"
 import { serializePruneMessagesState } from "./utils"
-
-function getLegacyStorageDir(): string {
-    return join(
-        process.env.XDG_DATA_HOME || join(homedir(), ".local", "share"),
-        "opencode",
-        "storage",
-        "plugin",
-        "dcp",
-    )
-}
 
 /** Prune state as stored on disk */
 export interface PersistedPruneMessagesState {
@@ -81,24 +70,9 @@ function getStorageDir(): string {
     )
 }
 
-/** One-time migration: copy plugin/dcp/ → plugin/acp/ if ACP dir doesn't exist yet */
-function migrateFromLegacyIfNeeded(logger: Logger): void {
-    const storageDir = getStorageDir()
-    const legacyDir = getLegacyStorageDir()
-    if (existsSyncSync(storageDir)) return
-    if (!existsSyncSync(legacyDir)) return
-    try {
-        cpSync(legacyDir, storageDir, { recursive: true })
-        logger.info(`[ACP] Migrated storage from ${legacyDir} → ${storageDir}`)
-    } catch (e: any) {
-        logger.warn(`[ACP] Storage migration failed: ${e.message}`)
-    }
-}
-
 async function ensureStorageDir(logger: Logger): Promise<void> {
     const storageDir = getStorageDir()
     if (!existsSync(storageDir)) {
-        migrateFromLegacyIfNeeded(logger)
         await fs.mkdir(storageDir, { recursive: true })
     }
 }
@@ -117,7 +91,6 @@ async function writePersistedSessionState(
     const filePath = getSessionFilePath(sessionId)
     const storageDir = getStorageDir()
     if (!existsSync(storageDir)) {
-        migrateFromLegacyIfNeeded(logger)
         await fs.mkdir(storageDir, { recursive: true })
     }
 

--- a/lib/state/tool-cache.ts
+++ b/lib/state/tool-cache.ts
@@ -36,18 +36,7 @@ export function syncToolCache(
                     continue
                 }
 
-                const turnProtectionEnabled = config.turnProtection.enabled
-                const turnProtectionTurns = config.turnProtection.turns
-                const isProtectedByTurn =
-                    turnProtectionEnabled &&
-                    turnProtectionTurns > 0 &&
-                    state.currentTurn - turnCounter < turnProtectionTurns
-
                 if (state.toolParameters.has(part.callID)) {
-                    continue
-                }
-
-                if (isProtectedByTurn) {
                     continue
                 }
 

--- a/tests/batch-compress.test.ts
+++ b/tests/batch-compress.test.ts
@@ -31,10 +31,6 @@ function buildConfig(): PluginConfig {
             enabled: true,
             protectedTools: [],
         },
-        turnProtection: {
-            enabled: false,
-            turns: 4,
-        },
         experimental: {
             allowSubAgents: true,
             customPrompts: false,

--- a/tests/compress-range.test.ts
+++ b/tests/compress-range.test.ts
@@ -28,10 +28,6 @@ function buildConfig(): PluginConfig {
             enabled: true,
             protectedTools: [],
         },
-        turnProtection: {
-            enabled: false,
-            turns: 4,
-        },
         experimental: {
             allowSubAgents: true,
             customPrompts: false,

--- a/tests/config-validation.test.ts
+++ b/tests/config-validation.test.ts
@@ -10,7 +10,6 @@ test("getInvalidConfigKeys returns empty array for valid keys", () => {
 test("getInvalidConfigKeys returns empty array for valid nested keys", () => {
     const result = getInvalidConfigKeys({
         enabled: true,
-        turnProtection: { enabled: false, turns: 4 },
         compress: { nudgeForce: "soft" },
     })
     assert.deepEqual(result, [])
@@ -25,9 +24,9 @@ test("getInvalidConfigKeys accepts compress.toolOutputNudgeThreshold (#18)", () 
 
 test("getInvalidConfigKeys returns dot-path keys for unknown nested keys", () => {
     const result = getInvalidConfigKeys({
-        turnProtection: { enabled: false, unknownSubKey: true },
+        compress: { nudgeForce: "soft", unknownSubKey: true },
     })
-    assert.ok(result.includes("turnProtection.unknownSubKey"))
+    assert.ok(result.includes("compress.unknownSubKey"))
 })
 
 test("getInvalidConfigKeys returns top-level unknown keys", () => {
@@ -95,23 +94,6 @@ test("validateConfigTypes catches non-string entries in protectedFilePatterns", 
     const result = validateConfigTypes({ protectedFilePatterns: ["ok", 42] })
     assert.equal(result.length, 1)
     assert.equal(result[0].actual, "non-string entries")
-})
-
-test("validateConfigTypes catches wrong type in nested turnProtection", () => {
-    const result = validateConfigTypes({
-        turnProtection: { enabled: "yes", turns: 4 },
-    })
-    assert.equal(result.length, 1)
-    assert.equal(result[0].key, "turnProtection.enabled")
-})
-
-test("validateConfigTypes catches negative turns in turnProtection", () => {
-    const result = validateConfigTypes({
-        turnProtection: { enabled: true, turns: 0 },
-    })
-    assert.equal(result.length, 1)
-    assert.equal(result[0].key, "turnProtection.turns")
-    assert.ok(result[0].expected.includes("positive"))
 })
 
 test("validateConfigTypes catches invalid compress.permission enum", () => {

--- a/tests/e2e-blocks-nudges.test.ts
+++ b/tests/e2e-blocks-nudges.test.ts
@@ -34,7 +34,6 @@ function buildConfig(overrides: Partial<PluginConfig> = {}): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "chat",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         compress: {

--- a/tests/e2e-message-transform.test.ts
+++ b/tests/e2e-message-transform.test.ts
@@ -37,7 +37,6 @@ function buildConfig(overrides: Partial<PluginConfig> = {}): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "chat",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         compress: {

--- a/tests/e2e-tier-compression.test.ts
+++ b/tests/e2e-tier-compression.test.ts
@@ -38,7 +38,6 @@ function buildConfig(overrides: Partial<PluginConfig> = {}): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "chat",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         compress: {

--- a/tests/e2e-tier-simulation.test.ts
+++ b/tests/e2e-tier-simulation.test.ts
@@ -38,7 +38,6 @@ function buildConfig(overrides: Partial<PluginConfig> = {}): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "chat",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         compress: {

--- a/tests/gc-merge.test.ts
+++ b/tests/gc-merge.test.ts
@@ -98,7 +98,6 @@ function buildConfig(gcOverrides: Partial<GCConfig> = {}): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "chat",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         compress: {

--- a/tests/hooks-permission.test.ts
+++ b/tests/hooks-permission.test.ts
@@ -26,10 +26,6 @@ function buildConfig(permission: "allow" | "ask" | "deny" = "allow"): PluginConf
             enabled: true,
             protectedTools: [],
         },
-        turnProtection: {
-            enabled: false,
-            turns: 4,
-        },
         experimental: {
             allowSubAgents: false,
             customPrompts: false,

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -20,7 +20,6 @@ function buildConfig(mode: "message" | "range" = "range"): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "chat",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         compress: {

--- a/tests/keep-markers.test.ts
+++ b/tests/keep-markers.test.ts
@@ -13,7 +13,6 @@ function buildConfig(): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "chat",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         compress: {

--- a/tests/message-priority.test.ts
+++ b/tests/message-priority.test.ts
@@ -21,10 +21,6 @@ function buildConfig(mode: "message" | "range" = "message"): PluginConfig {
             enabled: true,
             protectedTools: [],
         },
-        turnProtection: {
-            enabled: false,
-            turns: 4,
-        },
         experimental: {
             allowSubAgents: false,
             customPrompts: false,

--- a/tests/nudge-text.test.ts
+++ b/tests/nudge-text.test.ts
@@ -26,7 +26,6 @@ function buildConfig(): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "chat",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         compress: {

--- a/tests/preserve-recent.test.ts
+++ b/tests/preserve-recent.test.ts
@@ -44,7 +44,6 @@ function buildConfig(compressOverrides: Partial<PluginConfig["compress"]> = {}):
         pruneNotification: "off",
         pruneNotificationType: "chat",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         compress: buildCompress(compressOverrides),

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -22,7 +22,7 @@ function createPromptStoreFixture(overrideContent?: string, overrideFileName = "
     delete process.env.OPENCODE_CONFIG_DIR
 
     if (overrideContent !== undefined) {
-        const overrideDir = join(configHome, "opencode", "dcp-prompts", "overrides")
+        const overrideDir = join(configHome, "opencode", "acp-prompts", "overrides")
         mkdirSync(overrideDir, { recursive: true })
         writeFileSync(join(overrideDir, overrideFileName), overrideContent, "utf-8")
     }

--- a/tests/property-invariants.test.ts
+++ b/tests/property-invariants.test.ts
@@ -42,7 +42,6 @@ function buildConfig(overrides?: Partial<PluginConfig["compress"]>): PluginConfi
         pruneNotification: "off",
         pruneNotificationType: "chat",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         compress: {

--- a/tests/proportional-baseline.test.ts
+++ b/tests/proportional-baseline.test.ts
@@ -15,7 +15,6 @@ function buildConfig(): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "chat",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         compress: {

--- a/tests/protected-tool-exclusion.test.ts
+++ b/tests/protected-tool-exclusion.test.ts
@@ -33,10 +33,6 @@ function buildConfig(overrides: Partial<PluginConfig> = {}): PluginConfig {
             enabled: true,
             protectedTools: [],
         },
-        turnProtection: {
-            enabled: false,
-            turns: 4,
-        },
         experimental: {
             allowSubAgents: true,
             customPrompts: false,

--- a/tests/prune.test.ts
+++ b/tests/prune.test.ts
@@ -15,7 +15,6 @@ function buildConfig(mode: "message" | "range" = "range"): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "chat",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         compress: {

--- a/tests/quality-gate-enforcement.test.ts
+++ b/tests/quality-gate-enforcement.test.ts
@@ -32,7 +32,6 @@ function buildConfig(qualityGateEnabled: boolean): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "chat",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: true, customPrompts: false },
         protectedFilePatterns: [],
         compress: {

--- a/tests/quality-gate-pipeline-integration.test.ts
+++ b/tests/quality-gate-pipeline-integration.test.ts
@@ -47,7 +47,6 @@ function buildConfig(qualityGateEnabled: boolean): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "chat",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         compress: {

--- a/tests/query-mock.test.ts
+++ b/tests/query-mock.test.ts
@@ -114,7 +114,6 @@ function makeConfig(overrides: Partial<PluginConfig> = {}): PluginConfig {
         pruneNotification: "detailed",
         pruneNotificationType: "chat",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         compress: {

--- a/tests/rebuild.test.ts
+++ b/tests/rebuild.test.ts
@@ -19,7 +19,6 @@ function buildConfig(overrides: Partial<PluginConfig> = {}): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "chat",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         compress: {

--- a/tests/remove-prune-regression.test.ts
+++ b/tests/remove-prune-regression.test.ts
@@ -25,7 +25,6 @@ function buildConfig(): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "toast",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         compress: {

--- a/tests/soft-block.test.ts
+++ b/tests/soft-block.test.ts
@@ -19,7 +19,6 @@ function buildConfig(): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "chat",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         autoUpdate: true,

--- a/tests/token-usage.test.ts
+++ b/tests/token-usage.test.ts
@@ -17,10 +17,6 @@ function buildConfig(maxContextLimit: number, minContextLimit = 1): PluginConfig
             enabled: true,
             protectedTools: [],
         },
-        turnProtection: {
-            enabled: false,
-            turns: 4,
-        },
         experimental: {
             allowSubAgents: false,
             customPrompts: false,

--- a/tests/truncate-tools.test.ts
+++ b/tests/truncate-tools.test.ts
@@ -22,7 +22,6 @@ function makeConfig(gc?: Partial<PluginConfig["gc"]>): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "chat",
         commands: { enabled: true, protectedTools: [] },
-        turnProtection: { enabled: false, turns: 4 },
         experimental: { allowSubAgents: false, customPrompts: false },
         protectedFilePatterns: [],
         compress: {


### PR DESCRIPTION
## Summary

Part of Issue #30 codebase slimming effort. Removes two dead/disabled features:

### turnProtection removal
- **Why**: Disabled by default (`enabled: false`), fully redundant with `preserveRecentMessages` which already protects recent messages from compression
- **What**: Removed `TurnProtection` interface, config field, default config, deepClone, merge layer, validation logic, tool-cache guard, schema section, all test factories, and docs

### DCP migration removal
- **Why**: Migration code (`dcp.jsonc → acp.jsonc`, `plugin/dcp/ → plugin/acp/`) has been running for 8+ months. Migration window is closed.
- **What**: Removed `LEGACY_GLOBAL_CONFIG_PATH` constants, `dcp.jsonc`/`dcp.json` fallback paths in `getConfigPaths()`, `createDefaultConfig()` migration block, `getConfig()` migration block, `migrateFromLegacyIfNeeded()` in persistence

## Impact
- **42 files changed, 272 lines removed** (61 insertions, 272 deletions)
- Config surface simplified (one fewer config section)
- Legacy migration codepaths eliminated
- All remaining DCP-derived code in `lib/config.ts` and `lib/state/persistence.ts` is reduced

## Verification
- `tsc --noEmit`: PASS (0 errors)
- `node --import tsx --test tests/*.test.ts`: **915/915 PASS**
- `npm run build`: PASS
- Zero remaining `turnProtection` references in `lib/` or `tests/`
- Zero remaining DCP migration references in `lib/`