### PR TITLE
feat: re-add /acp stats as acp_status wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ docs/
 SCHEMA_NOTES.md
 
 repomix-output.xml
+results.txt
+symbols.txt

--- a/devlog/2026-07-29_acp-stats-wrapper/REQ.md
+++ b/devlog/2026-07-29_acp-stats-wrapper/REQ.md
@@ -1,0 +1,28 @@
+# REQ: /acp stats command as acp_status wrapper
+
+## Problem
+
+PR #233 removed `/acp stats` along with other redundant slash commands. Users lost direct access to compression status from the command bar.
+
+## Solution
+
+Re-add `/acp stats` (and `/acp status` alias) as a thin wrapper around `buildStatusReport` — the same logic used by the model-facing `acp_status` tool. This gives users the acp_status overview via slash command without duplicating any rendering logic.
+
+## Changes
+
+1. **`lib/compress/status.ts`**: Extract `buildStatusReport()` from `createAcpStatusTool.execute`. The tool's execute now delegates to it. Introduced `StatusRenderContext` interface (`{ state, config? }`) replacing `ToolContext` in internal render functions.
+
+2. **`lib/commands/stats.ts`** (new): `handleStatsCommand` calls `buildStatusReport` with no args (overview) and sends result via `sendIgnoredMessage`.
+
+3. **`lib/commands/index.ts`**: Export `handleStatsCommand`.
+
+4. **`lib/hooks.ts`**: Dispatch `stats`/`status` sub-args to `handleStatsCommand`.
+
+5. **`tests/stats-command.test.ts`** (new): 3 tests covering overview, token breakdown, compressed scope.
+
+## User experience
+
+```
+/acp stats
+```
+Shows the same overview as `acp_status` tool: visible context breakdown, compressed blocks, compressible ranges.

--- a/devlog/2026-07-29_acp-stats-wrapper/WORKLOG.md
+++ b/devlog/2026-07-29_acp-stats-wrapper/WORKLOG.md
@@ -1,0 +1,19 @@
+# WORKLOG
+
+## Implementation
+
+1. Created branch `2026-07-29_acp-stats-wrapper` from master (`e83a1a2`)
+2. Refactored `lib/compress/status.ts`:
+   - Added `StatusRenderContext` interface
+   - Changed `collectVisibleMessages`, `renderOverview`, `renderUncompressedRanges` from `ToolContext` to `StatusRenderContext`
+   - Extracted `buildStatusReport(renderCtx, rawMessages, options?)` — pure function returning status string
+   - Updated `createAcpStatusTool.execute` to delegate to `buildStatusReport`
+3. Created `lib/commands/stats.ts` — `handleStatsCommand` thin wrapper
+4. Wired into `lib/commands/index.ts` and `lib/hooks.ts` command dispatch
+5. Added `tests/stats-command.test.ts` — 3 tests
+
+## Verification
+
+- typecheck: 0 errors
+- tests: 886 pass (883 existing + 3 new), 0 failures
+- build: 377 KB

--- a/lib/commands/index.ts
+++ b/lib/commands/index.ts
@@ -1,1 +1,3 @@
 export { handleContextCommand } from "./context"
+export { handleStatsCommand } from "./stats"
+export type { StatsCommandContext } from "./stats"

--- a/lib/commands/stats.ts
+++ b/lib/commands/stats.ts
@@ -1,0 +1,42 @@
+import type { Logger } from "../logger"
+import type { PluginConfig } from "../config"
+import type { SessionState, WithParts } from "../state"
+import { sendIgnoredMessage } from "../ui/notification"
+import { buildStatusReport } from "../compress/status"
+
+export interface StatsCommandContext {
+    client: any
+    state: SessionState
+    config: PluginConfig
+    logger: Logger
+    sessionId: string
+    messages: WithParts[]
+    userInfo?: {
+        providerId?: string
+        modelId?: string
+        agent?: string
+        variant?: string
+    }
+}
+
+export async function handleStatsCommand(ctx: StatsCommandContext): Promise<void> {
+    const report = buildStatusReport(
+        { state: ctx.state, config: ctx.config },
+        ctx.messages,
+    )
+
+    const text = `[ACP Status]\n${report}`
+
+    await sendIgnoredMessage(
+        ctx.client,
+        ctx.sessionId,
+        text,
+        {
+            providerId: ctx.userInfo?.providerId,
+            modelId: ctx.userInfo?.modelId,
+            agent: ctx.userInfo?.agent,
+            variant: ctx.userInfo?.variant,
+        },
+        ctx.logger,
+    )
+}

--- a/lib/compress/status.ts
+++ b/lib/compress/status.ts
@@ -2,6 +2,9 @@ import { tool } from "@opencode-ai/plugin"
 import { type ToolContext, type ToolFactoryContext, resolveToolContext } from "./types"
 import { formatAge } from "../ui/utils"
 import type { CompressionBlock, WithParts } from "../state/types"
+import type { SessionState } from "../state/types"
+import type { PluginConfig } from "../config"
+import type { Logger } from "../logger"
 import {
     estimateContextComposition,
     buildCompressibleRanges,
@@ -112,9 +115,14 @@ interface VisibleMessageInfo {
     index: number
 }
 
+export interface StatusRenderContext {
+    state: SessionState
+    config?: PluginConfig
+}
+
 function collectVisibleMessages(
     rawMessages: WithParts[],
-    ctx: ToolContext,
+    ctx: StatusRenderContext,
 ): { messages: VisibleMessageInfo[]; summaryTokens: number } {
     const pruneMap = ctx.state.prune.messages.byMessageId
     const byRawId = ctx.state.messageIds.byRawId
@@ -171,7 +179,7 @@ function renderOverview(
     blocks: CompressionBlock[],
     fetchFailed: boolean,
     rawMessages: WithParts[],
-    ctx: ToolContext,
+    ctx: StatusRenderContext,
 ): string[] {
     const lines: string[] = []
 
@@ -284,7 +292,7 @@ function renderOverview(
     return lines
 }
 
-function renderUncompressedRanges(rawMessages: WithParts[], ctx: ToolContext): string[] {
+function renderUncompressedRanges(rawMessages: WithParts[], ctx: StatusRenderContext): string[] {
     const pruneMap = ctx.state.prune.messages.byMessageId
     const visibleMessages = rawMessages.filter((msg) => {
         const msgId = (msg.info as any)?.id || ""
@@ -477,6 +485,57 @@ function buildVisibleWithSummaries(rawMessages: WithParts[], ctx: ToolContext): 
     return visible
 }
 
+export interface StatusReportOptions {
+    scope?: "compressed" | "uncompressed"
+    view?: "ranges" | "messages"
+    tool?: string
+    sort?: "size" | "time" | "tool" | "age"
+    limit?: number
+}
+
+export function buildStatusReport(
+    renderCtx: StatusRenderContext,
+    rawMessages: WithParts[],
+    options?: StatusReportOptions,
+): string {
+    const scope = options?.scope
+    const view = options?.view ?? "ranges"
+    const toolFilter = options?.tool
+    const sort = options?.sort ?? "size"
+    const limit = options?.limit ?? 30
+
+    const msgState = renderCtx.state.prune.messages
+    const activeIds = Array.from(msgState.activeBlockIds).sort((a, b) => a - b)
+    const allBlocks = activeIds
+        .map((id) => msgState.blocksById.get(id))
+        .filter((b): b is NonNullable<typeof b> => b !== undefined && b.active)
+
+    const lines: string[] = []
+
+    if (scope === "compressed") {
+        lines.push(...renderCompressedDrilldown(allBlocks, sort, limit, msgState.blocksById))
+        return lines.join("\n")
+    }
+
+    const result = collectVisibleMessages(rawMessages, renderCtx)
+    const visibleMsgs = result.messages
+    const summaryTokens = result.summaryTokens
+
+    if (scope === "uncompressed") {
+        if (view === "messages") {
+            lines.push(...renderUncompressedDrilldown(visibleMsgs, toolFilter, sort, limit))
+        } else {
+            lines.push(...renderUncompressedRanges(rawMessages, renderCtx))
+        }
+    } else {
+        lines.push(
+            ...renderOverview(visibleMsgs, summaryTokens, allBlocks, false, rawMessages, renderCtx),
+        )
+    }
+
+    return lines.join("\n")
+}
+
 export function createAcpStatusTool(factoryCtx: ToolFactoryContext): ReturnType<typeof tool> {
     factoryCtx.prompts.reload()
 
@@ -520,61 +579,27 @@ export function createAcpStatusTool(factoryCtx: ToolFactoryContext): ReturnType<
             const limit =
                 Number.isFinite(args.limit) && args.limit! > 0 ? Math.min(args.limit!, 200) : 30
 
-            const msgState = ctx.state.prune.messages
-            const activeIds = Array.from(msgState.activeBlockIds).sort((a, b) => a - b)
-            const allBlocks = activeIds
-                .map((id) => msgState.blocksById.get(id))
-                .filter((b): b is NonNullable<typeof b> => b !== undefined && b.active)
-
-            const lines: string[] = []
-
             if (scope === "compressed") {
-                lines.push(
-                    ...renderCompressedDrilldown(
-                        allBlocks,
-                        sort,
-                        limit,
-                        msgState.blocksById,
-                    ),
+                return buildStatusReport(
+                    { state: ctx.state, config: ctx.config },
+                    [],
+                    { scope: "compressed", sort, limit },
                 )
-                return lines.join("\n")
             }
 
-            let visibleMsgs: VisibleMessageInfo[] = []
-            let summaryTokens = 0
-            let fetchFailed = false
             let rawMessages: WithParts[] = []
-
             try {
                 rawMessages = await fetchSessionMessages(ctx.client, toolCtx.sessionID)
-                const result = collectVisibleMessages(rawMessages, ctx)
-                visibleMsgs = result.messages
-                summaryTokens = result.summaryTokens
             } catch {
-                fetchFailed = true
+                if (scope === "uncompressed") return "(unable to fetch messages)"
+                rawMessages = []
             }
 
-            if (scope === "uncompressed") {
-                if (fetchFailed) return "(unable to fetch messages)"
-                if (view === "messages") {
-                    lines.push(...renderUncompressedDrilldown(visibleMsgs, toolFilter, sort, limit))
-                } else {
-                    lines.push(...renderUncompressedRanges(rawMessages, ctx))
-                }
-            } else {
-                lines.push(
-                    ...renderOverview(
-                        visibleMsgs,
-                        summaryTokens,
-                        allBlocks,
-                        fetchFailed,
-                        rawMessages,
-                        ctx,
-                    ),
-                )
-            }
-
-            return lines.join("\n")
+            return buildStatusReport(
+                { state: ctx.state, config: ctx.config },
+                rawMessages,
+                { scope, view, tool: toolFilter, sort, limit },
+            )
         },
     })
 }

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -27,6 +27,7 @@ import { getLastUserMessage } from "./messages/query"
 import { truncateLargeToolOutputs } from "./messages/truncate-tools"
 import {
     handleContextCommand,
+    handleStatsCommand,
 } from "./commands"
 import { type HostPermissionSnapshot } from "./host-permissions"
 import { compressPermission, syncCompressPermissionState } from "./compress-permission"
@@ -276,6 +277,12 @@ export function createCommandExecuteHandler(
                 logger,
                 sessionId: input.sessionID,
                 messages,
+            }
+
+            const sub = input.arguments?.trim().toLowerCase()
+            if (sub === "stats" || sub === "status") {
+                await handleStatsCommand(commandCtx)
+                throw new Error("__DCP_CONTEXT_HANDLED__")
             }
 
             await handleContextCommand(commandCtx)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-acp",
-    "version": "1.14.6",
+    "version": "1.14.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-acp",
-            "version": "1.14.6",
+            "version": "1.14.7",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@anthropic-ai/tokenizer": "^0.0.4",

--- a/tests/stats-command.test.ts
+++ b/tests/stats-command.test.ts
@@ -1,0 +1,168 @@
+import { describe, test } from "node:test"
+import assert from "node:assert/strict"
+import { buildStatusReport } from "../lib/compress/status"
+import type { SessionState, WithParts } from "../lib/state/types"
+import type { PluginConfig } from "../lib/config"
+
+function buildConfig(): PluginConfig {
+    return {
+        enabled: true,
+        autoUpdate: false,
+        debug: false,
+        pruneNotification: "off",
+        pruneNotificationType: "chat",
+        commands: { enabled: true, protectedTools: [] },
+        turnProtection: { enabled: false, turns: 4 },
+        experimental: { allowSubAgents: false, customPrompts: false },
+        protectedFilePatterns: [],
+        compress: {
+            mode: "range",
+            permission: "allow",
+            showCompression: false,
+            summaryBuffer: true,
+            maxContextLimit: 150000,
+            minContextLimit: 50000,
+            nudgeFrequency: 5,
+            minNudgeContextPercent: 15,
+            iterationNudgeThreshold: 15,
+            nudgeForce: "soft",
+            protectedTools: [],
+            protectTags: false,
+            protectUserMessages: false,
+            maxSummaryLengthHard: 10000,
+            minCompressRange: 5000,
+            minNudgeGrowthRatio: 0.45,
+            minNudgeGrowthFloor: 5000,
+            emergencyThresholdPercent: "98%",
+            maxVisibleSegments: 50,
+            keepEmbedMaxChars: 2000,
+            lastSegmentSoftBlock: true,
+            preserveRecentMessages: 5,
+            preserveRecentTokens: 5000,
+            preserveLastUserMessage: true,
+        },
+        gc: {
+            algorithm: "truncate",
+            promotionThreshold: 5,
+            maxBlockAge: Number.MAX_SAFE_INTEGER,
+            maxOldGenSummaryLength: 3000,
+            majorGcThresholdPercent: "100%",
+            batchCleanup: {
+                lowThreshold: "55%",
+                highThreshold: "75%",
+                forceThreshold: "90%",
+            },
+        },
+        qualityGate: {
+            enabled: false,
+            algorithm: "rouge-recall-v1",
+            algorithms: {
+                "rouge-recall-v1": {
+                    layer1MinChars: 200,
+                    layer1MinRetentionPct: 5.0,
+                    layer2MaxRougeF1: 0.05,
+                    layer2MaxTop20Recall: 0.20,
+                },
+            },
+        },
+    }
+}
+
+function buildState(): SessionState {
+    return {
+        sessionId: "test-stats",
+        modelContextLimit: 200000,
+        currentTurn: 1,
+        prune: {
+            messages: {
+                byMessageId: new Map(),
+                activeBlockIds: new Set(),
+                blocksById: new Map(),
+                nextBlockId: 1,
+                nextRunId: 1,
+            },
+        },
+        nudges: {
+            byAnchor: new Map(),
+            compressBaselineSet: false,
+            lastNudgeShownTokens: undefined,
+            lastPerMessageNudgeTokens: undefined,
+            baselineLocked: false,
+            shouldInjectThisTurn: false,
+            lastProcessedCompressMessageId: undefined,
+        },
+        stats: {
+            totalTokens: 0,
+            totalTools: 0,
+            totalMessages: 0,
+            sessionCount: 0,
+        },
+        messageIds: {
+            byRawId: new Map(),
+            byRef: new Map(),
+            nextRefId: 1,
+        },
+        compressionTiming: {},
+        toolParameters: new Map(),
+        compressPermission: undefined,
+    } as any
+}
+
+function userMsg(id: string, text: string): WithParts {
+    return {
+        info: { id, role: "user" } as any,
+        parts: [{ type: "text", text } as any],
+    }
+}
+
+function assistantMsg(id: string, text: string): WithParts {
+    return {
+        info: { id, role: "assistant" } as any,
+        parts: [{ type: "text", text } as any],
+    }
+}
+
+describe("buildStatusReport (acp_stats wrapper)", () => {
+    test("overview with no blocks shows empty state", () => {
+        const config = buildConfig()
+        const state = buildState()
+        const messages: WithParts[] = [
+            userMsg("m1", "hello"),
+            assistantMsg("m2", "hi there"),
+        ]
+
+        const report = buildStatusReport({ state, config }, messages)
+
+        assert.ok(report.includes("VISIBLE CONTEXT"))
+        assert.ok(report.includes("No compressed blocks"))
+    })
+
+    test("overview with messages shows token breakdown", () => {
+        const config = buildConfig()
+        const state = buildState()
+        const messages: WithParts[] = [
+            userMsg("m1", "hello world this is a test message"),
+            assistantMsg("m2", "hi there this is a response that has some content"),
+        ]
+
+        const report = buildStatusReport({ state, config }, messages)
+
+        assert.ok(report.includes("VISIBLE CONTEXT"))
+        assert.ok(report.includes("total"))
+        assert.ok(report.includes("text"))
+    })
+
+    test("scope compressed with no blocks shows empty", () => {
+        const config = buildConfig()
+        const state = buildState()
+
+        const report = buildStatusReport(
+            { state, config },
+            [],
+            { scope: "compressed" },
+        )
+
+        assert.ok(report.includes("COMPRESSED"))
+        assert.ok(report.includes("0 blocks"))
+    })
+})


### PR DESCRIPTION
## Summary

- Re-adds `/acp stats` (and `/acp status` alias) removed by PR #233
- Both commands now delegate to `buildStatusReport` — the same logic as the model-facing `acp_status` tool
- Extracted `buildStatusReport()` from `createAcpStatusTool.execute` as a pure function, no rendering logic duplication

## Changes

- `lib/compress/status.ts`: Extract `buildStatusReport()` + `StatusRenderContext` interface
- `lib/commands/stats.ts` (new): Thin wrapper calling `buildStatusReport`, sends via `sendIgnoredMessage`
- `lib/hooks.ts`: Dispatch `stats`/`status` sub-args
- `tests/stats-command.test.ts`: 3 tests (overview, token breakdown, compressed scope)

## Verification

- 886 tests pass (883 existing + 3 new), 0 failures
- typecheck: 0 errors
- build: 377KB