### PR TITLE
fix: T2/T3 nudge loop — preserve cadence baseline after compress

### DIFF
--- a/devlog/2026-07-29_t2-nudge-loop-fix/REQ.md
+++ b/devlog/2026-07-29_t2-nudge-loop-fix/REQ.md
@@ -1,0 +1,23 @@
+# REQ: T2/T3 Nudge Loop Fix
+
+## Problem
+
+When any compress attempt is detected (success or failure), `injectCompressNudges` unconditionally resets `lastTier2NudgeTokens` and `lastTier3NudgeTokens` to `undefined`. On the next turn without compress, the T2/T3 cadence check treats `undefined` as "never fired" → cadence always passes → T2/T3 immediately re-triggers.
+
+This creates a loop:
+1. T2 fires → model attempts compress
+2. Compress-processing block resets `lastTier2NudgeTokens = undefined`
+3. Next turn: T2 cadence check passes (undefined = never fired)
+4. T2 fires again → goto 1
+
+The loop prevents T1 recommendations from ever appearing (T2 fires first when `!shouldInject`), which also causes the secondary symptom of skill/tool outputs not being exposed for compression even after the user removes them from `protectedTools`.
+
+## Fix
+
+Change lines 121-122 in `inject.ts`: set `lastTier2NudgeTokens` and `lastTier3NudgeTokens` to `currentTokens` instead of `undefined`. This preserves the cadence baseline so the `growthFloor` gate applies naturally — T2/T3 won't re-fire until context grows by at least `growthFloor` tokens since the last tier nudge.
+
+## Impact
+
+- Fixes T2/T3 repeated injection after any compress attempt
+- Allows T1 recommendations to appear after compress (previously blocked by T2 loop)
+- indirectly improves the "protectedTools=[] doesn't expose outputs" issue (T2 loop was hiding T1 recommendations)

--- a/devlog/2026-07-29_t2-nudge-loop-fix/WORKLOG.md
+++ b/devlog/2026-07-29_t2-nudge-loop-fix/WORKLOG.md
@@ -1,0 +1,22 @@
+# WORKLOG: T2/T3 Nudge Loop Fix
+
+## Changes
+
+### `lib/messages/inject/inject.ts`
+- Lines 121-122: Changed `lastTier2NudgeTokens = undefined` → `lastTier2NudgeTokens = currentTokens`
+- Same for `lastTier3NudgeTokens`
+- Added explanatory comment about why `undefined` was wrong (cadence loop)
+
+### `tests/inject.test.ts`
+- Added test: "T2 cadence: does NOT immediately re-fire after compress attempt (T2 loop bug)"
+  - Phase 1: Set up T1 blocks, verify T2 fires (tier1Tokens >= nudgeGrowthTokens)
+  - Phase 2: Add compress attempt, verify `lastTier2NudgeTokens` is NOT undefined
+  - Phase 3: Next turn with small growth (< growthFloor), verify T2 does NOT re-fire
+- Verified test FAILS without fix (reverted to `undefined`, confirmed failure)
+- Verified test PASSES with fix
+
+## Verification
+
+- 884 tests pass, 0 failures
+- TypeScript typecheck clean
+- Build: 376KB bundle

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -118,8 +118,14 @@ export const injectCompressNudges = (
             state.nudges.iterationNudgeAnchors.clear()
             state.nudges.lastNudgeShownTokens = undefined
             state.nudges.lastToolOutputNudgeTokens = undefined
-            state.nudges.lastTier2NudgeTokens = undefined
-            state.nudges.lastTier3NudgeTokens = undefined
+            // Preserve tier cadence baselines instead of resetting to undefined.
+            // Resetting to undefined causes T2/T3 to immediately re-trigger on
+            // the next turn (cadence check treats undefined as "never fired"),
+            // creating a loop: T2 fires → compress attempted → baseline reset
+            // → T2 fires again. Set to currentTokens so the growthFloor gate
+            // applies naturally.
+            state.nudges.lastTier2NudgeTokens = currentTokens
+            state.nudges.lastTier3NudgeTokens = currentTokens
 
             const currentTurnHasSuccessfulCompress = messages
                 .slice(currentTurnStart)

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -1506,3 +1506,109 @@ test("E2E autonomous: second compress also gets processed (Issue #176 multi-comp
     )
 })
 
+test("T2 cadence: does NOT immediately re-fire after compress attempt (T2 loop bug)", () => {
+    const state = createSessionState()
+    state.sessionId = "test-t2-cadence"
+    state.modelContextLimit = 1_000_000
+
+    const config = buildConfig()
+    config.compress.maxContextLimit = 500_000
+    config.compress.minContextLimit = 200_000
+    config.compress.nudgeGrowthTokens = 10_000
+    config.compress.minNudgeGrowthFloor = 5_000
+    config.compress.minNudgeGrowthRatio = 0.01
+    config.compress.preserveRecentMessages = 0
+    config.compress.preserveRecentTokens = 0
+    config.compress.preserveLastUserMessage = false
+
+    // Seed T1 blocks so tier1Tokens >= nudgeGrowthTokens
+    for (let i = 0; i < 5; i++) {
+        const blockId = i + 1
+        state.prune.messages.blocksById.set(blockId, {
+            blockId,
+            runId: i + 1,
+            active: true,
+            tier: 1,
+            generation: "young",
+            survivedCount: 1,
+            directMessageIds: [],
+            effectiveMessageIds: [],
+            consumedBlockIds: [],
+            parentBlockIds: [],
+            summary: "T1 summary ".repeat(200),
+            summaryTokens: 5_000,
+            topic: `T1 block ${i}`,
+            createdAt: Date.now(),
+        })
+        state.prune.messages.activeBlockIds.add(blockId)
+    }
+
+    state.messageIds.byRawId.set("u1", "m00001")
+
+    function mkAssistant(id: string, ref: string, inputTokens: number): WithParts {
+        state.messageIds.byRawId.set(id, ref)
+        return assistantMsgWithTokens(id, "work", { input: inputTokens, output: 50_000 }, [
+            toolPart(`${id}-tool`, "x".repeat(10_000)),
+        ])
+    }
+
+    // Phase 1: T1 won't fire (baseline very high → negative growth),
+    // but T2 should fire because tier1Tokens = 25K >= nudgeGrowthTokens
+    state.nudges.lastPerMessageNudgeTokens = 500_000
+
+    const phase1: WithParts[] = [
+        userMsg("u1", "do the task"),
+        mkAssistant("a1", "m00002", 300_000),
+    ]
+    injectCompressNudges(state, config, logger, phase1, {} as any)
+
+    assert.equal(
+        state.nudges.shouldInjectThisTurn,
+        true,
+        "phase 1: T2 should fire (tier1 blocks accumulated, T1 suppressed by high baseline)",
+    )
+    assert.notEqual(
+        state.nudges.lastTier2NudgeTokens,
+        undefined,
+        "phase 1: lastTier2NudgeTokens should be set after T2 fires",
+    )
+
+    // Phase 2: Compress attempt appears in the turn.
+    // The compress-processing block runs, resetting tier cadence baselines.
+    // BEFORE FIX: lastTier2NudgeTokens = undefined → T2 re-fires next turn
+    // AFTER FIX:  lastTier2NudgeTokens = currentTokens → growthFloor gate applies
+    const phase2 = [...phase1]
+    const compressId = "a_compress_1"
+    const compressRef = "m09001"
+    state.messageIds.byRawId.set(compressId, compressRef)
+    phase2.push(assistantMsg(compressId, "compressed", [
+        compressToolPart("compress-1", "compression result"),
+    ]))
+
+    injectCompressNudges(state, config, logger, phase2, {} as any, undefined, undefined, 310_000)
+
+    assert.notEqual(
+        state.nudges.lastTier2NudgeTokens,
+        undefined,
+        "phase 2: lastTier2NudgeTokens must NOT be undefined after compress (was the bug)",
+    )
+
+    // Phase 3: Next turn — no new compress, small growth (< growthFloor).
+    // T2 should NOT fire because growth < growthFloor.
+    // BEFORE FIX: lastTier2NudgeTokens was reset to undefined → cadence always met → T2 fires.
+    // AFTER FIX:  lastTier2NudgeTokens = currentTokens → growthFloor gate blocks re-fire.
+    const phase3 = [...phase2, mkAssistant("a3", "m00003", 301_000)]
+    injectCompressNudges(state, config, logger, phase3, {} as any)
+
+    assert.notEqual(
+        state.nudges.lastTier2NudgeTokens,
+        undefined,
+        "phase 3: lastTier2NudgeTokens should still be defined (not reset to undefined)",
+    )
+    assert.equal(
+        state.nudges.shouldInjectThisTurn,
+        false,
+        "phase 3: T2 should NOT re-fire with growth < growthFloor (the T2 loop bug)",
+    )
+})
+


### PR DESCRIPTION
## Summary

- **Bug**: T2/T3 nudge triggers repeatedly fired after any compress attempt (success or failure). The cadence baseline (`lastTier2NudgeTokens`/`lastTier3NudgeTokens`) was reset to `undefined`, which the cadence check treats as "never fired" → T2/T3 immediately re-triggered.
- **Impact**: The loop prevented T1 recommendations from ever appearing (T2 fires first when T1 doesn't), causing the model to get stuck in a T2 cycle. This also indirectly caused the "protectedTools=[] doesn't expose outputs" symptom — T1 recommendations were never shown because T2 kept firing.
- **Fix**: Set cadence baselines to `currentTokens` instead of `undefined`. The `growthFloor` gate then applies naturally — T2/T3 wait for sufficient growth before re-firing.

## Root Cause

`lib/messages/inject/inject.ts:121-122`:
```typescript
// BEFORE (bug):
state.nudges.lastTier2NudgeTokens = undefined
state.nudges.lastTier3NudgeTokens = undefined

// AFTER (fix):
state.nudges.lastTier2NudgeTokens = currentTokens
state.nudges.lastTier3NudgeTokens = currentTokens
```

The cadence check at line 406-407:
```typescript
const cadenceMet = tc.lastNudge === undefined ||  // ← always true when reset to undefined
    (currentTokens - tc.lastNudge >= growthFloor)
```

## Test

Added regression test: "T2 cadence: does NOT immediately re-fire after compress attempt"
- Verified test FAILS without fix (reverted to `undefined`)
- Verified test PASSES with fix

## Verification

- 884 tests pass, 0 failures
- TypeScript typecheck clean
- Build: 376KB