### PR TITLE
fix: remove lastUserIdx guard from hideConsumedCompressCalls

### DIFF
--- a/devlog/2026-07-29_hide-consumed-lastuser-guard/REQ.md
+++ b/devlog/2026-07-29_hide-consumed-lastuser-guard/REQ.md
@@ -1,0 +1,30 @@
+# REQ: Remove lastUserIdx guard from hideConsumedCompressCalls
+
+## Problem
+
+When T1 and T2 compression happen in the same agentic turn (no user message between them), `hideConsumedCompressCalls` fails to hide the consumed T1 compress call. The `lastUserIdx` guard breaks the loop at the last user message, skipping all messages after it — including the T1 compress call that was made after the user message but before the T2 compress call.
+
+Result: T1 summary stays visible + T2 summary is added → context grows instead of shrinking. The model reports "越压越大" (bigger with each compression).
+
+## Root Cause
+
+`lib/compress/hide-consumed.ts` line 43: `if (lastUserIdx >= 0 && i >= lastUserIdx) break`
+
+In OpenCode's agentic loop, multiple tool calls can happen between two user messages. The message layout for same-turn T1+T2:
+
+```
+messages[N]:    user message           ← lastUserIdx = N
+messages[N+1]:  assistant → T1 compress  ← i=N+1 >= N → BREAK, never processed
+messages[N+2]:  T1 tool result
+messages[N+3]:  assistant → T2 compress
+```
+
+## Fix
+
+Remove the `lastUserIdx` guard entirely. The function is already scoped to only target consumed blocks (inactive + deactivatedByBlockId !== undefined + has compressMessageId). Active blocks' compress calls are never in `consumedMessageIds`, so they're never touched regardless of position.
+
+## Impact
+
+- Files changed: `lib/compress/hide-consumed.ts` (removed lastUserIdx + unused import)
+- New tests: `tests/hide-consumed.test.ts` (4 tests)
+- Risk: Low — only affects consumed blocks, active blocks untouched

--- a/devlog/2026-07-29_hide-consumed-lastuser-guard/WORKLOG.md
+++ b/devlog/2026-07-29_hide-consumed-lastuser-guard/WORKLOG.md
@@ -1,0 +1,15 @@
+# WORKLOG: Remove lastUserIdx guard from hideConsumedCompressCalls
+
+## Timeline
+
+1. **Bug report**: User reported T2 compression makes context larger, not smaller. "原来的压缩消息还在" — old compression messages still visible.
+2. **Investigation**: Traced `hideConsumedCompressCalls` logic. Confirmed SDK types (ToolPart has input+output in same part, compressMessageId always set via toolCtx.messageID).
+3. **Root cause found**: `lastUserIdx` guard at line 43 breaks loop at last user message. In same-turn T1+T2, T1 compress call is after lastUserIdx → never processed.
+4. **Fix applied**: Removed lastUserIdx guard. Removed unused `isIgnoredUserMessage` import.
+5. **Tests written**: 4 tests covering previous-turn, same-turn, active-block, and mixed-parts scenarios.
+6. **Verification**: Test fails without fix (hidden=0, expected 1). All 887 tests pass with fix. Typecheck clean.
+
+## Files Changed
+
+- `lib/compress/hide-consumed.ts`: Removed lines 37-39 (lastUserIdx calculation) and line 43 (guard). Removed `isIgnoredUserMessage` import.
+- `tests/hide-consumed.test.ts`: New file, 4 tests.

--- a/lib/compress/hide-consumed.ts
+++ b/lib/compress/hide-consumed.ts
@@ -1,5 +1,4 @@
 import type { SessionState, WithParts } from "../state"
-import { isIgnoredUserMessage } from "../messages/query"
 
 /**
  * Hide compress tool-call parts whose blocks have been consumed by another
@@ -34,14 +33,8 @@ export function hideConsumedCompressCalls(state: SessionState, messages: WithPar
         return 0
     }
 
-    const lastUserIdx = messages.findLastIndex(
-        (m) => m.info.role === "user" && !isIgnoredUserMessage(m),
-    )
-
     let hidden = 0
     for (let i = 0; i < messages.length; i++) {
-        if (lastUserIdx >= 0 && i >= lastUserIdx) break
-
         const msg = messages[i]!
         if (!consumedMessageIds.has(msg.info.id)) continue
 

--- a/tests/hide-consumed.test.ts
+++ b/tests/hide-consumed.test.ts
@@ -1,0 +1,215 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import type { SessionState, WithParts } from "../lib/state"
+import { hideConsumedCompressCalls } from "../lib/compress/hide-consumed"
+
+function makeBlock(overrides: Record<string, unknown>): Record<string, unknown> {
+    return {
+        blockId: 0,
+        runId: 0,
+        active: true,
+        deactivatedByUser: false,
+        deactivatedByUserDeep: false,
+        deactivatedAt: undefined,
+        deactivatedByBlockId: undefined,
+        compressMessageId: undefined,
+        compressCallId: undefined,
+        anchorMessageId: "anchor-1",
+        summary: "test summary",
+        summaryTokens: 10,
+        survivedCount: 0,
+        generation: "young",
+        mode: "range",
+        tier: 1,
+        topic: "",
+        batchTopic: undefined,
+        startId: "m00001",
+        endId: "m00010",
+        includedBlockIds: [],
+        consumedBlockIds: [],
+        parentBlockIds: [],
+        directMessageIds: [],
+        directToolIds: [],
+        effectiveMessageIds: [],
+        effectiveToolIds: [],
+        createdAt: Date.now(),
+        durationMs: 0,
+        compressedTokens: 0,
+        ...overrides,
+    }
+}
+
+function makeState(blocks: Record<string, unknown>[]): SessionState {
+    const blocksById = new Map<number, unknown>()
+    const activeBlockIds = new Set<number>()
+    for (const b of blocks) {
+        blocksById.set(b.blockId as number, b)
+        if (b.active) activeBlockIds.add(b.blockId as number)
+    }
+    return {
+        sessionId: "test-session",
+        prune: {
+            messages: {
+                blocksById,
+                activeBlockIds,
+                byMessageId: new Map(),
+                activeByAnchorMessageId: new Map(),
+            },
+        },
+        nudges: {},
+        stats: { pruneTokenCounter: 0, totalPruneTokens: 0 },
+        messageIds: { byRef: new Map(), byId: new Map(), nextRefId: 1 },
+        compressionTiming: { startsByCallId: new Map(), pendingByCallId: new Map() },
+        toolParameters: [],
+    } as unknown as SessionState
+}
+
+describe("hideConsumedCompressCalls", () => {
+    it("hides T1 compress call when T2 consumes it (previous turn)", () => {
+        const b1 = makeBlock({
+            blockId: 1,
+            active: false,
+            deactivatedByBlockId: 4,
+            compressMessageId: "msg-t1-compress",
+            tier: 1,
+        })
+        const b4 = makeBlock({
+            blockId: 4,
+            active: true,
+            compressMessageId: "msg-t2-compress",
+            tier: 2,
+        })
+
+        const state = makeState([b1, b4])
+        const messages: WithParts[] = [
+            { info: { id: "msg-user-1", role: "user" } as any, parts: [{ type: "text", text: "Hi" }] },
+            {
+                info: { id: "msg-t1-compress", role: "assistant" } as any,
+                parts: [
+                    { type: "text", text: "Compressing" },
+                    { type: "tool", tool: "compress", state: { status: "completed" } },
+                ],
+            },
+            {
+                info: { id: "msg-t2-compress", role: "assistant" } as any,
+                parts: [{ type: "tool", tool: "compress", state: { status: "completed" } }],
+            },
+            { info: { id: "msg-user-2", role: "user" } as any, parts: [{ type: "text", text: "Next" }] },
+        ]
+
+        const hidden = hideConsumedCompressCalls(state, messages)
+
+        assert.equal(hidden, 1)
+        const t1Msg = messages.find((m) => m.info.id === "msg-t1-compress")!
+        assert.equal(
+            t1Msg.parts.filter((p: any) => p.type === "tool" && p.tool === "compress").length,
+            0,
+        )
+    })
+
+    it("hides T1 compress call even when it is AFTER lastUserIdx (same-turn T1+T2)", () => {
+        const b1 = makeBlock({
+            blockId: 1,
+            active: false,
+            deactivatedByBlockId: 4,
+            compressMessageId: "msg-t1-compress",
+            tier: 1,
+        })
+        const b4 = makeBlock({
+            blockId: 4,
+            active: true,
+            compressMessageId: "msg-t2-compress",
+            tier: 2,
+        })
+
+        const state = makeState([b1, b4])
+        const messages: WithParts[] = [
+            { info: { id: "msg-user-1", role: "user" } as any, parts: [{ type: "text", text: "Hi" }] },
+            {
+                info: { id: "msg-t1-compress", role: "assistant" } as any,
+                parts: [{ type: "tool", tool: "compress", state: { status: "completed" } }],
+            },
+            {
+                info: { id: "msg-t2-compress", role: "assistant" } as any,
+                parts: [{ type: "tool", tool: "compress", state: { status: "completed" } }],
+            },
+        ]
+
+        const hidden = hideConsumedCompressCalls(state, messages)
+
+        assert.equal(hidden, 1, "T1 compress call after lastUserIdx should be hidden")
+        assert.equal(
+            messages.find((m) => m.info.id === "msg-t1-compress"),
+            undefined,
+            "T1-only-compress message should be entirely removed",
+        )
+        assert.ok(
+            messages.find((m) => m.info.id === "msg-t2-compress"),
+            "T2 compress call (active block) should survive",
+        )
+    })
+
+    it("does NOT hide T1 compress call when T1 is still active", () => {
+        const b1 = makeBlock({
+            blockId: 1,
+            active: true,
+            compressMessageId: "msg-t1-compress",
+            tier: 1,
+        })
+
+        const state = makeState([b1])
+        const messages: WithParts[] = [
+            { info: { id: "msg-user-1", role: "user" } as any, parts: [{ type: "text", text: "Hi" }] },
+            {
+                info: { id: "msg-t1-compress", role: "assistant" } as any,
+                parts: [{ type: "tool", tool: "compress", state: { status: "completed" } }],
+            },
+            { info: { id: "msg-user-2", role: "user" } as any, parts: [{ type: "text", text: "Next" }] },
+        ]
+
+        const hidden = hideConsumedCompressCalls(state, messages)
+
+        assert.equal(hidden, 0)
+        assert.ok(messages.find((m) => m.info.id === "msg-t1-compress"))
+    })
+
+    it("preserves non-compress parts when hiding compress call", () => {
+        const b1 = makeBlock({
+            blockId: 1,
+            active: false,
+            deactivatedByBlockId: 4,
+            compressMessageId: "msg-t1-compress",
+            tier: 1,
+        })
+        const b4 = makeBlock({
+            blockId: 4,
+            active: true,
+            compressMessageId: "msg-t2-compress",
+            tier: 2,
+        })
+
+        const state = makeState([b1, b4])
+        const messages: WithParts[] = [
+            { info: { id: "msg-user-1", role: "user" } as any, parts: [{ type: "text", text: "Hi" }] },
+            {
+                info: { id: "msg-t1-compress", role: "assistant" } as any,
+                parts: [
+                    { type: "text", text: "Let me compress" },
+                    { type: "tool", tool: "compress", state: { status: "completed" } },
+                    { type: "tool", tool: "bash", state: { status: "completed" } },
+                ],
+            },
+            { info: { id: "msg-user-2", role: "user" } as any, parts: [{ type: "text", text: "Next" }] },
+        ]
+
+        const hidden = hideConsumedCompressCalls(state, messages)
+
+        assert.equal(hidden, 1)
+        const t1Msg = messages.find((m) => m.info.id === "msg-t1-compress")!
+        assert.equal(t1Msg.parts.length, 2, "text and bash parts should survive")
+        assert.equal(
+            t1Msg.parts.filter((p: any) => p.type === "tool" && p.tool === "compress").length,
+            0,
+        )
+    })
+})


### PR DESCRIPTION
## Problem

When T1 and T2 compression happen in the same agentic turn (no user message between them), `hideConsumedCompressCalls` fails to hide the consumed T1 compress call. The `lastUserIdx` guard breaks the loop at the last user message, skipping all messages after it.

Result: T1 summary stays visible + T2 summary is added → **context grows instead of shrinking**. The model reports "越压越大".

## Root Cause

`lib/compress/hide-consumed.ts` line 43:
```typescript
if (lastUserIdx >= 0 && i >= lastUserIdx) break
```

Message layout for same-turn T1+T2:
```
messages[N]:    user message           ← lastUserIdx = N
messages[N+1]:  assistant → T1 compress  ← i=N+1 >= N → BREAK, never processed
messages[N+2]:  T1 tool result
messages[N+3]:  assistant → T2 compress
```

## Fix

Removed the `lastUserIdx` guard. The function already only targets consumed blocks (inactive + `deactivatedByBlockId !== undefined`), so active blocks' compress calls are never touched regardless of position.

## Tests

4 new tests in `tests/hide-consumed.test.ts`:
- T1 hidden when consumed by T2 (previous turn)
- **T1 hidden even when AFTER lastUserIdx** (same-turn T1+T2 — the bug)
- T1 NOT hidden when still active
- Non-compress parts preserved when hiding compress call

Verified: test #2 fails without fix (hidden=0, expected 1), passes with fix.

All 887 tests pass. Typecheck clean.