### PR TITLE
feat: pluggable message filter for third-party injection cleanup

### DIFF
--- a/devlog/2026-07-29_message-filter/REQ.md
+++ b/devlog/2026-07-29_message-filter/REQ.md
@@ -1,0 +1,62 @@
+# REQ: Message Filter — Pluggable Third-Party Injection Cleanup
+
+## Problem
+
+Third-party plugins (OMO = Oh My OpenCode) inject ephemeral metadata as user
+messages. Over a session, these accumulate to hundreds of thousands of tokens:
+
+| Type | Count | ~Tokens |
+|------|-------|---------|
+| `<system-reminder>` | 1,464 | 1.9M |
+| `[SYSTEM DIRECTIVE]` | 2,760 | 1.0M |
+| `[CONTEXT]` | 212 | 72K |
+
+These messages inflate context usage, trigger premature nudges, and waste
+compression on content that was never useful to the model.
+
+## Solution
+
+Pluggable `MessageFilter` interface. Filters run BEFORE `assignMessageRefs` in
+the message transform pipeline, stripping/trimming/dropping text parts before
+ACP assigns refs or counts context usage.
+
+### Interface
+
+```typescript
+interface MessageFilter {
+    name: string
+    version: string
+    description: string
+    filter(ctx: MessageFilterContext): FilterResult
+}
+```
+
+### Built-in: OMO system-reminder cleaner
+
+Default filter (`omo-system-reminder` v1.0.0) strips `<system-reminder>` blocks
+and `<!-- OMO_INTERNAL_INITIATOR -->` markers from user messages.
+
+### Config
+
+```jsonc
+{
+    "messageFilters": {
+        "enabled": true,
+        "filters": {
+            "omo-system-reminder": { "enabled": true }
+        }
+    }
+}
+```
+
+## Acceptance Criteria
+
+- [x] Filter interface defined + exported
+- [x] Registry with register/get/list/clear
+- [x] Pipeline integration in hooks.ts (after stripHallucinations, before assignMessageRefs)
+- [x] OMO system-reminder filter implemented + tested
+- [x] Config section added (defaults: enabled=true, omo-system-reminder enabled)
+- [x] Config validation keys added
+- [x] 20 unit tests pass
+- [x] Full suite: 915/915 pass
+- [x] typecheck + build clean

--- a/devlog/2026-07-29_message-filter/WORKLOG.md
+++ b/devlog/2026-07-29_message-filter/WORKLOG.md
@@ -1,0 +1,37 @@
+# WORKLOG: Message Filter
+
+## Phase 1: Module structure
+
+Created `lib/messages/filter/`:
+- `types.ts` — MessageFilter, MessageFilterContext, FilterResult, MessageFiltersConfig
+- `registry.ts` — singleton Map, register/get/list/clear
+- `apply.ts` — `applyMessageFilters(messages, config, logger, ctx)` iterates messages × parts × filters
+- `builtin/omo-system-reminder.ts` — strips `<system-reminder>` blocks + `<!-- OMO_INTERNAL_INITIATOR -->` markers
+- `builtin/index.ts` — `ensureBuiltinFiltersRegistered()` (check-and-register, idempotent)
+- `index.ts` — barrel export
+
+## Phase 2: Config integration
+
+- `lib/config.ts`: Added `MessageFiltersConfig` interface, default config (`enabled: true`, `omo-system-reminder: { enabled: true }`), `mergeMessageFilters()`, clone in deepClone, added to `mergeLayer()`
+- `lib/config-validation.ts`: Added `messageFilters`, `messageFilters.enabled`, `messageFilters.filters` to `VALID_CONFIG_KEYS`
+
+## Phase 3: Pipeline integration
+
+`lib/hooks.ts`:
+- Added imports: `applyMessageFilters` from `./messages/filter/apply`, `ensureBuiltinFiltersRegistered` from `./messages/filter/builtin`
+- Pipeline position: after `stripHallucinations`, before `cacheSystemPromptTokens` / `assignMessageRefs`
+- Passes session context: sessionId, isSubAgent, modelContextLimit
+
+## Phase 4: Tests
+
+`tests/message-filter.test.ts` — 20 tests:
+- Registry: register, get, list, re-register same version, version conflict
+- applyMessageFilters: disabled config, no filters, drop, modify, disabled filter, error catching, non-text/empty skip
+- OMO filter: normal keep, assistant keep, drop-only-block, modify-with-content, lone-reminder, lone-marker, multiple blocks, empty-after-strip
+- ensureBuiltinFiltersRegistered: registers OMO, idempotent
+
+## Verification
+
+- typecheck: 0 errors
+- tests: 915/915 pass (895 existing + 20 new)
+- build: 383.74 KB

--- a/lib/config-validation.ts
+++ b/lib/config-validation.ts
@@ -63,6 +63,9 @@ export const VALID_CONFIG_KEYS = new Set([
     "qualityGate.enabled",
     "qualityGate.algorithm",
     "qualityGate.algorithms",
+    "messageFilters",
+    "messageFilters.enabled",
+    "messageFilters.filters",
 ])
 
 function getConfigKeyPaths(obj: Record<string, any>, prefix = ""): string[] {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -81,6 +81,11 @@ export interface QualityGateConfig {
     algorithms: QualityGateAlgorithmConfigs
 }
 
+export interface MessageFiltersConfig {
+    enabled: boolean
+    filters: Record<string, { enabled: boolean }>
+}
+
 export interface PluginConfig {
     enabled: boolean
     autoUpdate: boolean
@@ -94,6 +99,7 @@ export interface PluginConfig {
     compress: CompressConfig
     gc: GCConfig
     qualityGate: QualityGateConfig
+    messageFilters: MessageFiltersConfig
 }
 
 type CompressOverride = Partial<CompressConfig>
@@ -239,6 +245,12 @@ const defaultConfig: PluginConfig = {
                 layer2MaxRougeF1: 0.05,
                 layer2MaxTop20Recall: 0.20,
             },
+        },
+    },
+    messageFilters: {
+        enabled: true,
+        filters: {
+            "omo-system-reminder": { enabled: true },
         },
     },
 }
@@ -461,6 +473,12 @@ function deepCloneConfig(config: PluginConfig): PluginConfig {
             algorithm: config.qualityGate.algorithm,
             algorithms: { ...config.qualityGate.algorithms },
         },
+        messageFilters: {
+            enabled: config.messageFilters.enabled,
+            filters: Object.fromEntries(
+                Object.entries(config.messageFilters.filters).map(([k, v]) => [k, { ...v }]),
+            ),
+        },
     }
 }
 
@@ -488,6 +506,26 @@ function mergeQualityGate(
     }
 }
 
+function mergeMessageFilters(
+    base: MessageFiltersConfig,
+    override?: Partial<MessageFiltersConfig>,
+): MessageFiltersConfig {
+    if (!override) return base
+    const mergedFilters = { ...base.filters }
+    if (override.filters) {
+        for (const [name, fc] of Object.entries(override.filters)) {
+            const existing = mergedFilters[name]
+            mergedFilters[name] = existing
+                ? { ...existing, ...fc }
+                : { enabled: fc?.enabled ?? true }
+        }
+    }
+    return {
+        enabled: override.enabled ?? base.enabled,
+        filters: mergedFilters,
+    }
+}
+
 function mergeLayer(config: PluginConfig, data: Record<string, any>): PluginConfig {
     return {
         enabled: data.enabled ?? config.enabled,
@@ -507,6 +545,7 @@ function mergeLayer(config: PluginConfig, data: Record<string, any>): PluginConf
         compress: mergeCompress(config.compress, data.compress as CompressOverride),
         gc: mergeGC(config.gc, data.gc as Partial<GCConfig>),
         qualityGate: mergeQualityGate(config.qualityGate, data.qualityGate as Partial<QualityGateConfig>),
+        messageFilters: mergeMessageFilters(config.messageFilters, data.messageFilters as Partial<MessageFiltersConfig>),
     }
 }
 

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -32,6 +32,8 @@ import { type HostPermissionSnapshot } from "./host-permissions"
 import { compressPermission, syncCompressPermissionState } from "./compress-permission"
 import { hideConsumedCompressCalls } from "./compress/hide-consumed"
 import { hideFailedCompressCalls } from "./compress/hide-failed"
+import { applyMessageFilters } from "./messages/filter/apply"
+import { ensureBuiltinFiltersRegistered } from "./messages/filter/builtin"
 import { createSessionState, saveSessionState, syncToolCache, updatePerTurnState, type SessionStateRegistry } from "./state"
 import { cacheSystemPromptTokens } from "./ui/utils"
 import { sendIgnoredMessage } from "./ui/notification"
@@ -165,6 +167,12 @@ export function createChatMessageTransformHandler(
         }
 
         stripHallucinations(output.messages)
+        ensureBuiltinFiltersRegistered()
+        applyMessageFilters(output.messages, config.messageFilters, logger, {
+            sessionId: state.sessionId ?? "",
+            isSubAgent: state.isSubAgent,
+            modelContextLimit: state.modelContextLimit,
+        })
         cacheSystemPromptTokens(state, output.messages)
         assignMessageRefs(state, output.messages)
         const activeBlockCountBefore = state.prune.messages.activeBlockIds.size // [FIX Bug 4]

--- a/lib/messages/filter/apply.ts
+++ b/lib/messages/filter/apply.ts
@@ -1,0 +1,109 @@
+import type { WithParts } from "../../state"
+import type { Logger } from "../../logger"
+import type { MessageFilter, MessageFilterContext, MessageFiltersConfig } from "./types"
+import { listMessageFilters } from "./registry"
+
+export interface ApplyResult {
+    partsFiltered: number
+    partsDropped: number
+    partsModified: number
+}
+
+export function applyMessageFilters(
+    messages: WithParts[],
+    config: MessageFiltersConfig | undefined,
+    logger: Logger,
+    ctx: { sessionId: string; isSubAgent: boolean; modelContextLimit?: number },
+): ApplyResult {
+    if (!config?.enabled) {
+        return { partsFiltered: 0, partsDropped: 0, partsModified: 0 }
+    }
+
+    const filters = listMessageFilters().filter((f) => {
+        const fc = config.filters?.[f.name]
+        return fc?.enabled !== false
+    })
+
+    if (filters.length === 0) {
+        return { partsFiltered: 0, partsDropped: 0, partsModified: 0 }
+    }
+
+    const result: ApplyResult = { partsFiltered: 0, partsDropped: 0, partsModified: 0 }
+    const total = messages.length
+
+    for (let i = 0; i < messages.length; i++) {
+        const msg = messages[i]
+        const role = (msg.info as { role?: string }).role ?? "unknown"
+        const parts = msg.parts ?? []
+
+        for (const part of parts) {
+            const text = (part as { text?: string }).text
+            if (typeof text !== "string" || text.length === 0) continue
+
+            const filterCtx: MessageFilterContext = {
+                text,
+                role,
+                sessionId: ctx.sessionId,
+                isSubAgent: ctx.isSubAgent,
+                messageIndex: i,
+                totalMessages: total,
+                toolName: (part as { tool?: string }).tool,
+                modelContextLimit: ctx.modelContextLimit,
+            }
+
+            for (const filter of filters) {
+                let decision
+                try {
+                    decision = filter.filter(filterCtx)
+                } catch (err) {
+                    logger.warn("Message filter threw error", {
+                        filter: filter.name,
+                        error: err instanceof Error ? err.message : String(err),
+                        messageIndex: i,
+                    })
+                    continue
+                }
+
+                if (decision.action === "keep") continue
+
+                result.partsFiltered++
+                if (decision.action === "drop") {
+                    ;(part as { text?: string }).text = ""
+                    result.partsDropped++
+                    if (decision.reason) {
+                        logger.debug("Message filter dropped text", {
+                            filter: filter.name,
+                            reason: decision.reason,
+                            messageIndex: i,
+                            originalLength: text.length,
+                        })
+                    }
+                } else if (decision.action === "modify" && decision.text !== undefined) {
+                    ;(part as { text?: string }).text = decision.text
+                    result.partsModified++
+                    if (decision.reason) {
+                        logger.debug("Message filter modified text", {
+                            filter: filter.name,
+                            reason: decision.reason,
+                            messageIndex: i,
+                            originalLength: text.length,
+                            newLength: decision.text.length,
+                        })
+                    }
+                    filterCtx.text = decision.text
+                }
+            }
+        }
+    }
+
+    if (result.partsFiltered > 0) {
+        logger.info("Message filters applied", {
+            filtersRun: filters.length,
+            partsFiltered: result.partsFiltered,
+            partsDropped: result.partsDropped,
+            partsModified: result.partsModified,
+        })
+    }
+
+    return result
+}

--- a/lib/messages/filter/builtin/index.ts
+++ b/lib/messages/filter/builtin/index.ts
@@ -1,0 +1,13 @@
+import type { MessageFilter } from "../types"
+import { registerMessageFilter, getMessageFilter } from "../registry"
+import { OMO_SYSTEM_REMINDER_FILTER } from "./omo-system-reminder"
+
+const BUILTIN_FILTERS: MessageFilter[] = [OMO_SYSTEM_REMINDER_FILTER]
+
+export function ensureBuiltinFiltersRegistered(): void {
+    for (const filter of BUILTIN_FILTERS) {
+        if (!getMessageFilter(filter.name)) {
+            registerMessageFilter(filter)
+        }
+    }
+}

--- a/lib/messages/filter/builtin/omo-system-reminder.ts
+++ b/lib/messages/filter/builtin/omo-system-reminder.ts
@@ -1,0 +1,82 @@
+import type { MessageFilter, MessageFilterContext, FilterResult } from "../types"
+
+/**
+ * OMO (Oh My OpenCode) system-reminder filter.
+ *
+ * Strips `<system-reminder>` blocks injected by the OMO plugin framework.
+ * These blocks contain background task notifications, todo continuation
+ * directives, and other ephemeral metadata that accumulates as user messages.
+ *
+ * Each block looks like:
+ * <system-reminder>
+ * [BACKGROUND TASK COMPLETED]
+ * ...
+ * </system-reminder>
+ * <!-- OMO_INTERNAL_INITIATOR -->
+ *
+ * By default, this filter strips ALL such blocks. Users can disable it
+ * per-session via config if they need to see OMO notifications.
+ */
+
+const SYSTEM_REMINDER_OPEN = "<system-reminder>"
+const SYSTEM_REMINDER_CLOSE = "</system-reminder>"
+const OMO_MARKER = "<!-- OMO_INTERNAL_INITIATOR -->"
+
+const OMO_SYSTEM_REMINDER_FILTER: MessageFilter = {
+    name: "omo-system-reminder",
+    version: "1.0.0",
+    description: "Strip OMO <system-reminder> blocks and OMO_INTERNAL_INITIATOR markers from user messages",
+
+    filter(ctx: MessageFilterContext): FilterResult {
+        if (ctx.role !== "user") return { action: "keep" }
+        if (!ctx.text.includes(SYSTEM_REMINDER_OPEN) && !ctx.text.includes(OMO_MARKER)) {
+            return { action: "keep" }
+        }
+
+        let modified = ctx.text
+        let removedBlocks = 0
+
+        const openRegex = new RegExp(
+            `${escapeRegex(SYSTEM_REMINDER_OPEN)}[\\s\\S]*?${escapeRegex(SYSTEM_REMINDER_CLOSE)}\\s*${escapeRegex(OMO_MARKER)}`,
+            "g",
+        )
+        modified = modified.replace(openRegex, (_match) => {
+            removedBlocks++
+            return ""
+        })
+
+        const loneReminderRegex = new RegExp(
+            `${escapeRegex(SYSTEM_REMINDER_OPEN)}[\\s\\S]*?${escapeRegex(SYSTEM_REMINDER_CLOSE)}`,
+            "g",
+        )
+        modified = modified.replace(loneReminderRegex, (_match) => {
+            removedBlocks++
+            return ""
+        })
+
+        const loneMarkerRegex = new RegExp(escapeRegex(OMO_MARKER), "g")
+        modified = modified.replace(loneMarkerRegex, "")
+
+        modified = modified.replace(/\n{3,}/g, "\n\n").trim()
+
+        if (modified.length === 0) {
+            return { action: "drop", reason: `Stripped ${removedBlocks} OMO system-reminder block(s)` }
+        }
+
+        if (modified !== ctx.text) {
+            return {
+                action: "modify",
+                text: modified,
+                reason: `Stripped ${removedBlocks} OMO system-reminder block(s)`,
+            }
+        }
+
+        return { action: "keep" }
+    },
+}
+
+function escapeRegex(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+export { OMO_SYSTEM_REMINDER_FILTER }

--- a/lib/messages/filter/builtin/omo-system-reminder.ts
+++ b/lib/messages/filter/builtin/omo-system-reminder.ts
@@ -22,6 +22,12 @@ const SYSTEM_REMINDER_OPEN = "<system-reminder>"
 const SYSTEM_REMINDER_CLOSE = "</system-reminder>"
 const OMO_MARKER = "<!-- OMO_INTERNAL_INITIATOR -->"
 
+// Pre-compiled module-level regexes (hoisted from per-call construction per review).
+// None of these literals contain regex metacharacters, so no escaping needed.
+const PAIRED_BLOCK_RE = /<system-reminder>[\s\S]*?<\/system-reminder>\s*<!-- OMO_INTERNAL_INITIATOR -->/g
+const LONE_REMINDER_RE = /<system-reminder>[\s\S]*?<\/system-reminder>/g
+const LONE_MARKER_RE = /<!-- OMO_INTERNAL_INITIATOR -->/g
+
 const OMO_SYSTEM_REMINDER_FILTER: MessageFilter = {
     name: "omo-system-reminder",
     version: "1.0.0",
@@ -36,26 +42,17 @@ const OMO_SYSTEM_REMINDER_FILTER: MessageFilter = {
         let modified = ctx.text
         let removedBlocks = 0
 
-        const openRegex = new RegExp(
-            `${escapeRegex(SYSTEM_REMINDER_OPEN)}[\\s\\S]*?${escapeRegex(SYSTEM_REMINDER_CLOSE)}\\s*${escapeRegex(OMO_MARKER)}`,
-            "g",
-        )
-        modified = modified.replace(openRegex, (_match) => {
+        modified = modified.replace(PAIRED_BLOCK_RE, () => {
             removedBlocks++
             return ""
         })
 
-        const loneReminderRegex = new RegExp(
-            `${escapeRegex(SYSTEM_REMINDER_OPEN)}[\\s\\S]*?${escapeRegex(SYSTEM_REMINDER_CLOSE)}`,
-            "g",
-        )
-        modified = modified.replace(loneReminderRegex, (_match) => {
+        modified = modified.replace(LONE_REMINDER_RE, () => {
             removedBlocks++
             return ""
         })
 
-        const loneMarkerRegex = new RegExp(escapeRegex(OMO_MARKER), "g")
-        modified = modified.replace(loneMarkerRegex, "")
+        modified = modified.replace(LONE_MARKER_RE, "")
 
         modified = modified.replace(/\n{3,}/g, "\n\n").trim()
 
@@ -73,10 +70,6 @@ const OMO_SYSTEM_REMINDER_FILTER: MessageFilter = {
 
         return { action: "keep" }
     },
-}
-
-function escapeRegex(s: string): string {
-    return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }
 
 export { OMO_SYSTEM_REMINDER_FILTER }

--- a/lib/messages/filter/index.ts
+++ b/lib/messages/filter/index.ts
@@ -1,0 +1,11 @@
+export type {
+    MessageFilter,
+    MessageFilterContext,
+    FilterResult,
+    MessageFilterConfig,
+    MessageFiltersConfig,
+} from "./types"
+export { registerMessageFilter, getMessageFilter, listMessageFilters, clearMessageFilters } from "./registry"
+export { applyMessageFilters } from "./apply"
+export type { ApplyResult } from "./apply"
+export { ensureBuiltinFiltersRegistered } from "./builtin"

--- a/lib/messages/filter/registry.ts
+++ b/lib/messages/filter/registry.ts
@@ -1,0 +1,26 @@
+import type { MessageFilter } from "./types"
+
+const registry = new Map<string, MessageFilter>()
+
+export function registerMessageFilter(filter: MessageFilter): void {
+    const existing = registry.get(filter.name)
+    if (existing && existing.version !== filter.version) {
+        throw new Error(
+            `Message filter "${filter.name}" already registered with version ${existing.version}, ` +
+                `cannot register version ${filter.version}. Use a different name or bump version.`,
+        )
+    }
+    registry.set(filter.name, filter)
+}
+
+export function getMessageFilter(name: string): MessageFilter | undefined {
+    return registry.get(name)
+}
+
+export function listMessageFilters(): MessageFilter[] {
+    return Array.from(registry.values())
+}
+
+export function clearMessageFilters(): void {
+    registry.clear()
+}

--- a/lib/messages/filter/types.ts
+++ b/lib/messages/filter/types.ts
@@ -1,0 +1,82 @@
+/**
+ * Message Filter — pluggable system for stripping/deduplicating third-party
+ * plugin injections (OMO system-reminders, background task notifications, etc.)
+ * from the visible context before ACP processes them.
+ *
+ * Filters run BEFORE assignMessageRefs, so filtered content never gets message
+ * refs and is never counted toward context usage or compression triggers.
+ */
+
+/**
+ * Context passed to each registered filter for a single text part.
+ */
+export interface MessageFilterContext {
+    /** The text content of this part. */
+    text: string
+    /** Role of the containing message ("user" | "assistant" | "system"). */
+    role: string
+    /** Session ID (may be empty for ephemeral state). */
+    sessionId: string
+    /** Whether this is a subagent session. */
+    isSubAgent: boolean
+    /** 0-based index of this message in the visible messages array. */
+    messageIndex: number
+    /** Total number of visible messages. */
+    totalMessages: number
+    /** Tool name if this part is a tool call (e.g. "bash", "read"). */
+    toolName?: string
+    /** Model context limit (for threshold-based filtering). */
+    modelContextLimit?: number
+}
+
+/**
+ * Result returned by a filter for a single text part.
+ */
+export interface FilterResult {
+    /** What to do with this text part. */
+    action: "keep" | "modify" | "drop"
+    /** Replacement text when action is "modify". Ignored for "keep" and "drop". */
+    text?: string
+    /** Human-readable reason for logging/auditing. */
+    reason?: string
+}
+
+/**
+ * A pluggable message filter. Filters are registered via {@link registerMessageFilter}
+ * and called by {@link applyMessageFilters} during the message transform pipeline.
+ *
+ * Filters MUST be pure and side-effect-free: they receive a snapshot of the
+ * text and return a decision. They MUST NOT mutate the input context.
+ *
+ * If a filter returns "drop", the text part is emptied (set to ""). If ALL
+ * text parts in a message become empty after filtering, the message itself
+ * is not removed (ACP's existing dropEmptyMessages handles that downstream).
+ */
+export interface MessageFilter {
+    /** Unique name (used in config to enable/disable). */
+    name: string
+    /** Semver version (for breaking-change detection). */
+    version: string
+    /** Human-readable description. */
+    description: string
+    /**
+     * Evaluate whether to keep, modify, or drop this text part.
+     * Called once per text part per message.
+     */
+    filter(ctx: MessageFilterContext): FilterResult
+}
+
+/**
+ * Per-filter configuration: whether the filter is enabled.
+ */
+export type MessageFilterConfig = Record<string, { enabled: boolean }>
+
+/**
+ * Top-level configuration for the message filter subsystem.
+ */
+export interface MessageFiltersConfig {
+    /** Master switch. When false, no filters run. */
+    enabled: boolean
+    /** Per-filter enable/disable. Keys are filter names. */
+    filters: MessageFilterConfig
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-acp",
-    "version": "1.14.6",
+    "version": "1.14.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-acp",
-            "version": "1.14.6",
+            "version": "1.14.7",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@anthropic-ai/tokenizer": "^0.0.4",

--- a/tests/message-filter.test.ts
+++ b/tests/message-filter.test.ts
@@ -7,6 +7,7 @@ import {
     clearMessageFilters,
 } from "../lib/messages/filter/registry"
 import type { MessageFilter, MessageFilterContext } from "../lib/messages/filter/types"
+import type { WithParts } from "../lib/state"
 import { applyMessageFilters } from "../lib/messages/filter/apply"
 import { OMO_SYSTEM_REMINDER_FILTER } from "../lib/messages/filter/builtin/omo-system-reminder"
 import { ensureBuiltinFiltersRegistered } from "../lib/messages/filter/builtin"
@@ -289,5 +290,48 @@ describe("ensureBuiltinFiltersRegistered", () => {
         ensureBuiltinFiltersRegistered()
         ensureBuiltinFiltersRegistered()
         assert.equal(listMessageFilters().length, 1)
+    })
+})
+
+describe("filter chaining", () => {
+    beforeEach(() => clearMessageFilters())
+
+    it("filter B sees modified text from filter A", () => {
+        const uppercase: MessageFilter = {
+            name: "uppercase",
+            version: "1.0.0",
+            description: "test",
+            filter(ctx) {
+                return { action: "modify", text: ctx.text.toUpperCase() }
+            },
+        }
+        const detectUpper: MessageFilter = {
+            name: "detect-upper",
+            version: "1.0.0",
+            description: "test",
+            filter(ctx) {
+                if (ctx.text === ctx.text.toUpperCase() && ctx.text.length > 0) {
+                    return { action: "drop", reason: "all uppercase detected" }
+                }
+                return { action: "keep" }
+            },
+        }
+        registerMessageFilter(uppercase)
+        registerMessageFilter(detectUpper)
+
+        const messages: WithParts[] = [
+            {
+                info: { id: "msg-1", role: "user", time: Date.now() } as any,
+                parts: [{ type: "text", text: "hello world" }],
+            },
+        ]
+        const config = { enabled: true, filters: { uppercase: { enabled: true }, "detect-upper": { enabled: true } } }
+        const stats = applyMessageFilters(messages, config, makeLogger(), {
+            sessionId: "ses-test",
+            isSubAgent: false,
+        })
+        assert.equal(stats.partsDropped, 1)
+        assert.equal(stats.partsFiltered, 2)
+        assert.equal(stats.partsModified, 1)
     })
 })

--- a/tests/message-filter.test.ts
+++ b/tests/message-filter.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, beforeEach, afterEach } from "node:test"
+import assert from "node:assert/strict"
+import {
+    registerMessageFilter,
+    getMessageFilter,
+    listMessageFilters,
+    clearMessageFilters,
+} from "../lib/messages/filter/registry"
+import type { MessageFilter, MessageFilterContext } from "../lib/messages/filter/types"
+import { applyMessageFilters } from "../lib/messages/filter/apply"
+import { OMO_SYSTEM_REMINDER_FILTER } from "../lib/messages/filter/builtin/omo-system-reminder"
+import { ensureBuiltinFiltersRegistered } from "../lib/messages/filter/builtin"
+
+type MockLogger = { debug: (...a: any[]) => void; info: (...a: any[]) => void; warn: (...a: any[]) => void }
+
+function makeLogger(): MockLogger {
+    return { debug: () => {}, info: () => {}, warn: () => {} }
+}
+
+function makeCtx(overrides: Partial<MessageFilterContext>): MessageFilterContext {
+    return {
+        text: "",
+        role: "user",
+        sessionId: "ses_test",
+        isSubAgent: false,
+        messageIndex: 0,
+        totalMessages: 1,
+        ...overrides,
+    }
+}
+
+describe("Message Filter Registry", () => {
+    beforeEach(() => clearMessageFilters())
+
+    it("registers and retrieves a filter", () => {
+        const filter: MessageFilter = {
+            name: "test-filter",
+            version: "1.0.0",
+            description: "test",
+            filter: () => ({ action: "keep" }),
+        }
+        registerMessageFilter(filter)
+        assert.equal(getMessageFilter("test-filter"), filter)
+        assert.equal(listMessageFilters().length, 1)
+    })
+
+    it("allows re-registering same name + same version", () => {
+        const filter: MessageFilter = {
+            name: "test-filter",
+            version: "1.0.0",
+            description: "test",
+            filter: () => ({ action: "keep" }),
+        }
+        registerMessageFilter(filter)
+        registerMessageFilter(filter)
+        assert.equal(listMessageFilters().length, 1)
+    })
+
+    it("throws on re-registering same name + different version", () => {
+        registerMessageFilter({
+            name: "test-filter",
+            version: "1.0.0",
+            description: "v1",
+            filter: () => ({ action: "keep" }),
+        })
+        assert.throws(
+            () =>
+                registerMessageFilter({
+                    name: "test-filter",
+                    version: "2.0.0",
+                    description: "v2",
+                    filter: () => ({ action: "keep" }),
+                }),
+            /version/i,
+        )
+    })
+})
+
+describe("applyMessageFilters", () => {
+    beforeEach(() => clearMessageFilters())
+
+    it("returns zero stats when config disabled", () => {
+        const logger = makeLogger()
+        const result = applyMessageFilters([], { enabled: false, filters: {} }, logger, {
+            sessionId: "s",
+            isSubAgent: false,
+        })
+        assert.deepEqual(result, { partsFiltered: 0, partsDropped: 0, partsModified: 0 })
+    })
+
+    it("returns zero stats when no filters registered", () => {
+        const logger = makeLogger()
+        const messages = [
+            { info: { role: "user" }, parts: [{ type: "text", text: "hello" }] },
+        ] as any
+        const result = applyMessageFilters(
+            messages,
+            { enabled: true, filters: {} },
+            logger,
+            { sessionId: "s", isSubAgent: false },
+        )
+        assert.deepEqual(result, { partsFiltered: 0, partsDropped: 0, partsModified: 0 })
+    })
+
+    it("drops text parts when filter returns drop", () => {
+        registerMessageFilter({
+            name: "dropper",
+            version: "1.0.0",
+            description: "drops all",
+            filter: () => ({ action: "drop" }),
+        })
+        const logger = makeLogger()
+        const messages = [
+            { info: { role: "user" }, parts: [{ type: "text", text: "hello" }] },
+        ] as any
+        const result = applyMessageFilters(
+            messages,
+            { enabled: true, filters: { dropper: { enabled: true } } },
+            logger,
+            { sessionId: "s", isSubAgent: false },
+        )
+        assert.equal(result.partsDropped, 1)
+        assert.equal(messages[0].parts[0].text, "")
+    })
+
+    it("modifies text parts when filter returns modify", () => {
+        registerMessageFilter({
+            name: "modifier",
+            version: "1.0.0",
+            description: "modifies",
+            filter: (ctx) => ({ action: "modify", text: "MODIFIED:" + ctx.text.slice(0, 5) }),
+        })
+        const logger = makeLogger()
+        const messages = [
+            { info: { role: "user" }, parts: [{ type: "text", text: "hello world" }] },
+        ] as any
+        const result = applyMessageFilters(
+            messages,
+            { enabled: true, filters: { modifier: { enabled: true } } },
+            logger,
+            { sessionId: "s", isSubAgent: false },
+        )
+        assert.equal(result.partsModified, 1)
+        assert.equal(messages[0].parts[0].text, "MODIFIED:hello")
+    })
+
+    it("skips disabled filters", () => {
+        registerMessageFilter({
+            name: "dropper",
+            version: "1.0.0",
+            description: "drops all",
+            filter: () => ({ action: "drop" }),
+        })
+        const logger = makeLogger()
+        const messages = [
+            { info: { role: "user" }, parts: [{ type: "text", text: "hello" }] },
+        ] as any
+        const result = applyMessageFilters(
+            messages,
+            { enabled: true, filters: { dropper: { enabled: false } } },
+            logger,
+            { sessionId: "s", isSubAgent: false },
+        )
+        assert.equal(result.partsFiltered, 0)
+        assert.equal(messages[0].parts[0].text, "hello")
+    })
+
+    it("catches filter errors without crashing", () => {
+        registerMessageFilter({
+            name: "crasher",
+            version: "1.0.0",
+            description: "always throws",
+            filter: () => {
+                throw new Error("boom")
+            },
+        })
+        const logger = makeLogger()
+        const messages = [
+            { info: { role: "user" }, parts: [{ type: "text", text: "hello" }] },
+        ] as any
+        const result = applyMessageFilters(
+            messages,
+            { enabled: true, filters: { crasher: { enabled: true } } },
+            logger,
+            { sessionId: "s", isSubAgent: false },
+        )
+        assert.equal(result.partsFiltered, 0)
+        assert.equal(messages[0].parts[0].text, "hello")
+    })
+
+    it("skips non-text and empty parts", () => {
+        registerMessageFilter({
+            name: "dropper",
+            version: "1.0.0",
+            description: "drops all",
+            filter: () => ({ action: "drop" }),
+        })
+        const logger = makeLogger()
+        const messages = [
+            {
+                info: { role: "user" },
+                parts: [
+                    { type: "tool", tool: "bash" },
+                    { type: "text", text: "" },
+                    { type: "text", text: "keep me" },
+                ],
+            },
+        ] as any
+        const result = applyMessageFilters(
+            messages,
+            { enabled: true, filters: { dropper: { enabled: true } } },
+            logger,
+            { sessionId: "s", isSubAgent: false },
+        )
+        assert.equal(result.partsDropped, 1)
+    })
+})
+
+describe("OMO system-reminder filter", () => {
+    const filter = OMO_SYSTEM_REMINDER_FILTER
+
+    it("keeps normal user messages", () => {
+        const result = filter.filter(makeCtx({ text: "hello world" }))
+        assert.equal(result.action, "keep")
+    })
+
+    it("keeps assistant messages with system-reminder tags", () => {
+        const text = "<system-reminder>foo</system-reminder><!-- OMO_INTERNAL_INITIATOR -->"
+        const result = filter.filter(makeCtx({ text, role: "assistant" }))
+        assert.equal(result.action, "keep")
+    })
+
+    it("drops user message that is ONLY a system-reminder block", () => {
+        const text = `<system-reminder>\n[BG COMPLETE]\n</system-reminder>\n<!-- OMO_INTERNAL_INITIATOR -->`
+        const result = filter.filter(makeCtx({ text, role: "user" }))
+        assert.equal(result.action, "drop")
+    })
+
+    it("modifies user message with system-reminder + real content", () => {
+        const text = `Please help me.\n\n<system-reminder>\n[BG COMPLETE]\n</system-reminder>\n<!-- OMO_INTERNAL_INITIATOR -->`
+        const result = filter.filter(makeCtx({ text, role: "user" }))
+        assert.equal(result.action, "modify")
+        assert.ok(result.text!.includes("Please help me"))
+        assert.ok(!result.text!.includes("<system-reminder>"))
+        assert.ok(!result.text!.includes("OMO_INTERNAL_INITIATOR"))
+    })
+
+    it("strips lone system-reminder without OMO marker", () => {
+        const text = `Real content.\n\n<system-reminder>\nfoo\n</system-reminder>`
+        const result = filter.filter(makeCtx({ text, role: "user" }))
+        assert.equal(result.action, "modify")
+        assert.ok(!result.text!.includes("<system-reminder>"))
+        assert.ok(result.text!.includes("Real content"))
+    })
+
+    it("strips lone OMO marker without system-reminder", () => {
+        const text = `Real content.\n<!-- OMO_INTERNAL_INITIATOR -->`
+        const result = filter.filter(makeCtx({ text, role: "user" }))
+        assert.equal(result.action, "modify")
+        assert.ok(!result.text!.includes("OMO_INTERNAL_INITIATOR"))
+    })
+
+    it("handles multiple system-reminder blocks in one message", () => {
+        const text = `Real content.\n<system-reminder>A</system-reminder>\n<!-- OMO_INTERNAL_INITIATOR -->\n<system-reminder>B</system-reminder>\n<!-- OMO_INTERNAL_INITIATOR -->`
+        const result = filter.filter(makeCtx({ text, role: "user" }))
+        assert.equal(result.action, "modify")
+        assert.ok(result.text!.includes("Real content"))
+        assert.ok(!result.text!.includes("system-reminder"))
+        assert.ok(!result.text!.includes("OMO_INTERNAL_INITIATOR"))
+    })
+
+    it("drops message that becomes empty after stripping", () => {
+        const text = `   \n\n<system-reminder>\nfoo\n</system-reminder>\n<!-- OMO_INTERNAL_INITIATOR -->\n\n   `
+        const result = filter.filter(makeCtx({ text, role: "user" }))
+        assert.equal(result.action, "drop")
+    })
+})
+
+describe("ensureBuiltinFiltersRegistered", () => {
+    beforeEach(() => clearMessageFilters())
+
+    it("registers the OMO filter", () => {
+        ensureBuiltinFiltersRegistered()
+        assert.ok(getMessageFilter("omo-system-reminder"))
+        assert.equal(getMessageFilter("omo-system-reminder")!.version, "1.0.0")
+    })
+
+    it("is idempotent", () => {
+        ensureBuiltinFiltersRegistered()
+        ensureBuiltinFiltersRegistered()
+        assert.equal(listMessageFilters().length, 1)
+    })
+})


### PR DESCRIPTION
## Summary

Third-party plugins (OMO = Oh My OpenCode) inject ephemeral metadata as user messages. Over a session, these accumulate to **5M+ tokens** across all sessions:
- `<system-reminder>`: 1,464 injections, **1.9M tokens**
- `[SYSTEM DIRECTIVE]`: 2,760 injections, **1.0M tokens**
- Old DCP/ACP compress notifs: 3,901 injections, **2.0M tokens**

This PR adds a pluggable `MessageFilter` interface that strips/modify/drops text parts **BEFORE** `assignMessageRefs`, so filtered content never gets message refs and is never counted toward context usage or compression triggers.

### Built-in: OMO system-reminder cleaner (`omo-system-reminder` v1.0.0)

Strips `<system-reminder>` blocks and `<!-- OMO_INTERNAL_INITIATOR -->` markers from user messages. Three-phase regex matching: full block+marker, lone block, lone marker.

### Config

```jsonc
{
    "messageFilters": {
        "enabled": true,
        "filters": {
            "omo-system-reminder": { "enabled": true }
        }
    }
}
```

### Files (13 changed, +767/−2)

**New**: `lib/messages/filter/{types,registry,apply,index}.ts`, `builtin/{omo-system-reminder,index}.ts`, `tests/message-filter.test.ts`
**Modified**: `lib/config.ts`, `lib/config-validation.ts`, `lib/hooks.ts`

### Test results

- **20 new tests** (registry, apply, OMO filter, idempotent registration)
- **915/915 total tests pass** (895 existing + 20 new)
- typecheck: 0 errors
- build: 383.74 KB

### Extension API

Third-party plugins can register their own filters:
```typescript
import { registerMessageFilter } from "opencode-acp"

registerMessageFilter({
    name: "my-custom-filter",
    version: "1.0.0",
    description: "Strip my plugin's injections",
    filter: (ctx) => {
        if (ctx.text.includes("[MY_PLUGIN]")) {
            return { action: "drop", reason: "stripped plugin injection" }
        }
        return { action: "keep" }
    },
})
```