### PR TITLE
fix: splice orphan messages with only structural parts after consumed compress removal

### DIFF
--- a/devlog/2026-07-29_orphan-message-fix/REQ.md
+++ b/devlog/2026-07-29_orphan-message-fix/REQ.md
@@ -1,0 +1,26 @@
+# REQ: Splice orphan messages after consumed compress part removal
+
+## Problem
+
+When `hideConsumedCompressCalls` removes the compress tool-call part from an
+assistant message whose block was consumed by a higher-tier compression, the
+message may survive with only structural parts (step-start, step-finish,
+reasoning). These orphan messages waste context tokens (~500-2000 each) with
+zero useful content.
+
+Root cause: `hideConsumedCompressCalls` checked `remaining.length > 0` to decide
+whether to keep the message. Structural parts count as "remaining" even though
+they carry no meaningful content. `dropEmptyMessages` also does not catch them
+because it only considers text-only-empty/ignored messages as empty.
+
+## Fix
+
+After removing the compress tool part, check whether the remaining parts contain
+any meaningful content (text, tool, file, anything not in the structural set).
+If only structural parts remain, splice the message entirely.
+
+## Files
+
+- `lib/compress/hide-consumed.ts` — added `STRUCTURAL_PART_TYPES` set and
+  `hasMeaningfulContent` check
+- `tests/hide-consumed.test.ts` — 4 new tests

--- a/devlog/2026-07-29_orphan-message-fix/WORKLOG.md
+++ b/devlog/2026-07-29_orphan-message-fix/WORKLOG.md
@@ -1,0 +1,15 @@
+# WORKLOG: orphan-message-fix
+
+## Changes
+
+1. Added `STRUCTURAL_PART_TYPES = new Set(["step-start", "step-finish", "reasoning"])` constant
+2. Changed the post-filter decision in `hideConsumedCompressCalls`:
+   - Before: `if (remaining.length > 0)` → keep message
+   - After: `if (remaining.some(p => !STRUCTURAL_PART_TYPES.has(p.type)))` → keep message
+3. Added 4 tests covering: reasoning+step-finish orphan, reasoning-only orphan, text survives, non-compress tool survives
+
+## Test Results
+
+- 899 tests pass (0 failures)
+- Typecheck clean
+- 8 hide-consumed tests pass (4 existing + 4 new)

--- a/lib/compress/hide-consumed.ts
+++ b/lib/compress/hide-consumed.ts
@@ -1,11 +1,5 @@
 import type { SessionState, WithParts } from "../state"
-
-/**
- * Part types that are structural wrappers, not meaningful content. When a
- * compress tool-call part is removed and only these remain, the message is an
- * orphan shell and should be spliced entirely.
- */
-const STRUCTURAL_PART_TYPES = new Set(["step-start", "step-finish", "reasoning"])
+import { hasMeaningfulContent } from "./parts"
 
 /**
  * Hide compress tool-call parts whose blocks have been consumed by another
@@ -61,10 +55,7 @@ export function hideConsumedCompressCalls(state: SessionState, messages: WithPar
         })
 
         if (changed) {
-            const hasMeaningfulContent = remaining.some(
-                (p) => !STRUCTURAL_PART_TYPES.has(p.type),
-            )
-            if (hasMeaningfulContent) {
+            if (hasMeaningfulContent(remaining)) {
                 messages[i] = { ...msg, parts: remaining }
             } else {
                 messages.splice(i, 1)

--- a/lib/compress/hide-consumed.ts
+++ b/lib/compress/hide-consumed.ts
@@ -1,6 +1,13 @@
 import type { SessionState, WithParts } from "../state"
 
 /**
+ * Part types that are structural wrappers, not meaningful content. When a
+ * compress tool-call part is removed and only these remain, the message is an
+ * orphan shell and should be spliced entirely.
+ */
+const STRUCTURAL_PART_TYPES = new Set(["step-start", "step-finish", "reasoning"])
+
+/**
  * Hide compress tool-call parts whose blocks have been consumed by another
  * compression (tier escalation or range overlap).
  *
@@ -8,6 +15,10 @@ import type { SessionState, WithParts } from "../state"
  * of hiding whole messages covered by active blocks, it hides individual
  * compress tool-call PARTS whose blocks are no longer active. The message shell
  * survives (it may carry other parts); only the consumed compress call disappears.
+ *
+ * If after removal the message contains only structural parts (step-start,
+ * step-finish, reasoning), it is spliced entirely — those carry no useful
+ * content once the compress call they wrapped is gone.
  *
  * Block data (full summary, original messages) is preserved in session state and
  * remains recoverable via `decompress`.
@@ -50,7 +61,10 @@ export function hideConsumedCompressCalls(state: SessionState, messages: WithPar
         })
 
         if (changed) {
-            if (remaining.length > 0) {
+            const hasMeaningfulContent = remaining.some(
+                (p) => !STRUCTURAL_PART_TYPES.has(p.type),
+            )
+            if (hasMeaningfulContent) {
                 messages[i] = { ...msg, parts: remaining }
             } else {
                 messages.splice(i, 1)

--- a/lib/compress/hide-failed.ts
+++ b/lib/compress/hide-failed.ts
@@ -1,4 +1,5 @@
 import type { WithParts } from "../state"
+import { hasMeaningfulContent } from "./parts"
 
 // Must run AFTER injectCompressNudges: the nudge system needs to see failed
 // compress calls for baseline reset (messageHasCompressAttempt). Removing them
@@ -50,7 +51,7 @@ export function hideFailedCompressCalls(messages: WithParts[]): number {
         })
 
         if (changed) {
-            if (remaining.length > 0) {
+            if (hasMeaningfulContent(remaining)) {
                 messages[i] = { ...msg, parts: remaining }
             } else {
                 messages.splice(i, 1)

--- a/lib/compress/parts.ts
+++ b/lib/compress/parts.ts
@@ -1,0 +1,5 @@
+const STRUCTURAL_PART_TYPES = new Set(["step-start", "step-finish", "reasoning"])
+
+export function hasMeaningfulContent(parts: { type: string }[]): boolean {
+    return parts.some((p) => !STRUCTURAL_PART_TYPES.has(p.type))
+}

--- a/tests/hide-consumed.test.ts
+++ b/tests/hide-consumed.test.ts
@@ -212,4 +212,164 @@ describe("hideConsumedCompressCalls", () => {
             0,
         )
     })
+
+    it("splices message when only reasoning + step-finish remain after compress removal", () => {
+        const b1 = makeBlock({
+            blockId: 1,
+            active: false,
+            deactivatedByBlockId: 4,
+            compressMessageId: "msg-t1-compress",
+            tier: 1,
+        })
+        const b4 = makeBlock({
+            blockId: 4,
+            active: true,
+            compressMessageId: "msg-t2-compress",
+            tier: 2,
+        })
+
+        const state = makeState([b1, b4])
+        const messages: WithParts[] = [
+            { info: { id: "msg-user-1", role: "user" } as any, parts: [{ type: "text", text: "Hi" }] },
+            {
+                info: { id: "msg-t1-compress", role: "assistant" } as any,
+                parts: [
+                    { type: "reasoning", text: "I need to compress the early messages..." },
+                    { type: "tool", tool: "compress", state: { status: "completed" } },
+                    { type: "step-finish", reason: "stop" },
+                ],
+            },
+            { info: { id: "msg-user-2", role: "user" } as any, parts: [{ type: "text", text: "Next" }] },
+        ]
+
+        const hidden = hideConsumedCompressCalls(state, messages)
+
+        assert.equal(hidden, 1)
+        assert.equal(
+            messages.find((m) => m.info.id === "msg-t1-compress"),
+            undefined,
+            "structural-only orphan should be spliced entirely",
+        )
+    })
+
+    it("splices message when only reasoning remains after compress removal", () => {
+        const b1 = makeBlock({
+            blockId: 1,
+            active: false,
+            deactivatedByBlockId: 4,
+            compressMessageId: "msg-t1-compress",
+            tier: 1,
+        })
+        const b4 = makeBlock({
+            blockId: 4,
+            active: true,
+            compressMessageId: "msg-t2-compress",
+            tier: 2,
+        })
+
+        const state = makeState([b1, b4])
+        const messages: WithParts[] = [
+            { info: { id: "msg-user-1", role: "user" } as any, parts: [{ type: "text", text: "Hi" }] },
+            {
+                info: { id: "msg-t1-compress", role: "assistant" } as any,
+                parts: [
+                    { type: "reasoning", text: "Analyzing context usage..." },
+                    { type: "tool", tool: "compress", state: { status: "completed" } },
+                ],
+            },
+            { info: { id: "msg-user-2", role: "user" } as any, parts: [{ type: "text", text: "Next" }] },
+        ]
+
+        const hidden = hideConsumedCompressCalls(state, messages)
+
+        assert.equal(hidden, 1)
+        assert.equal(
+            messages.find((m) => m.info.id === "msg-t1-compress"),
+            undefined,
+            "reasoning-only orphan should be spliced entirely",
+        )
+    })
+
+    it("preserves message when text accompanies reasoning after compress removal", () => {
+        const b1 = makeBlock({
+            blockId: 1,
+            active: false,
+            deactivatedByBlockId: 4,
+            compressMessageId: "msg-t1-compress",
+            tier: 1,
+        })
+        const b4 = makeBlock({
+            blockId: 4,
+            active: true,
+            compressMessageId: "msg-t2-compress",
+            tier: 2,
+        })
+
+        const state = makeState([b1, b4])
+        const messages: WithParts[] = [
+            { info: { id: "msg-user-1", role: "user" } as any, parts: [{ type: "text", text: "Hi" }] },
+            {
+                info: { id: "msg-t1-compress", role: "assistant" } as any,
+                parts: [
+                    { type: "reasoning", text: "I need to compress..." },
+                    { type: "text", text: "Compressing early messages" },
+                    { type: "tool", tool: "compress", state: { status: "completed" } },
+                    { type: "step-finish", reason: "stop" },
+                ],
+            },
+            { info: { id: "msg-user-2", role: "user" } as any, parts: [{ type: "text", text: "Next" }] },
+        ]
+
+        const hidden = hideConsumedCompressCalls(state, messages)
+
+        assert.equal(hidden, 1)
+        const t1Msg = messages.find((m) => m.info.id === "msg-t1-compress")!
+        assert.ok(t1Msg, "message with text should survive")
+        assert.equal(t1Msg.parts.length, 3, "reasoning + text + step-finish remain")
+        assert.equal(
+            t1Msg.parts.filter((p: any) => p.type === "tool" && p.tool === "compress").length,
+            0,
+        )
+    })
+
+    it("preserves message when non-compress tool accompanies structural parts", () => {
+        const b1 = makeBlock({
+            blockId: 1,
+            active: false,
+            deactivatedByBlockId: 4,
+            compressMessageId: "msg-t1-compress",
+            tier: 1,
+        })
+        const b4 = makeBlock({
+            blockId: 4,
+            active: true,
+            compressMessageId: "msg-t2-compress",
+            tier: 2,
+        })
+
+        const state = makeState([b1, b4])
+        const messages: WithParts[] = [
+            { info: { id: "msg-user-1", role: "user" } as any, parts: [{ type: "text", text: "Hi" }] },
+            {
+                info: { id: "msg-t1-compress", role: "assistant" } as any,
+                parts: [
+                    { type: "reasoning", text: "I need to compress..." },
+                    { type: "tool", tool: "compress", state: { status: "completed" } },
+                    { type: "tool", tool: "bash", state: { status: "completed" } },
+                    { type: "step-finish", reason: "stop" },
+                ],
+            },
+            { info: { id: "msg-user-2", role: "user" } as any, parts: [{ type: "text", text: "Next" }] },
+        ]
+
+        const hidden = hideConsumedCompressCalls(state, messages)
+
+        assert.equal(hidden, 1)
+        const t1Msg = messages.find((m) => m.info.id === "msg-t1-compress")!
+        assert.ok(t1Msg, "message with bash tool should survive")
+        assert.equal(
+            t1Msg.parts.filter((p: any) => p.type === "tool" && p.tool === "compress").length,
+            0,
+        )
+    })
 })

--- a/tests/hide-consumed.test.ts
+++ b/tests/hide-consumed.test.ts
@@ -372,4 +372,43 @@ describe("hideConsumedCompressCalls", () => {
             0,
         )
     })
+
+    it("splices message when only step-start + step-finish remain after compress removal", () => {
+        const b1 = makeBlock({
+            blockId: 1,
+            active: false,
+            deactivatedByBlockId: 4,
+            compressMessageId: "msg-t1-compress",
+            tier: 1,
+        })
+        const b4 = makeBlock({
+            blockId: 4,
+            active: true,
+            compressMessageId: "msg-t2-compress",
+            tier: 2,
+        })
+
+        const state = makeState([b1, b4])
+        const messages: WithParts[] = [
+            { info: { id: "msg-user-1", role: "user" } as any, parts: [{ type: "text", text: "Hi" }] },
+            {
+                info: { id: "msg-t1-compress", role: "assistant" } as any,
+                parts: [
+                    { type: "step-start" },
+                    { type: "tool", tool: "compress", state: { status: "completed" } },
+                    { type: "step-finish", reason: "stop" },
+                ],
+            },
+            { info: { id: "msg-user-2", role: "user" } as any, parts: [{ type: "text", text: "Next" }] },
+        ]
+
+        const hidden = hideConsumedCompressCalls(state, messages)
+
+        assert.equal(hidden, 1)
+        assert.equal(
+            messages.find((m) => m.info.id === "msg-t1-compress"),
+            undefined,
+            "step-start + step-finish orphan should be spliced",
+        )
+    })
 })

--- a/tests/hide-failed.test.ts
+++ b/tests/hide-failed.test.ts
@@ -142,3 +142,28 @@ test("hideFailedCompressCalls: handles messages with no parts", () => {
     const hidden = hideFailedCompressCalls(messages)
     assert.equal(hidden, 0)
 })
+
+test("hideFailedCompressCalls: splices orphan when only structural parts remain after failure removal", () => {
+    const messages = [
+        makeMessage("msg-1", "user", [makeTextPart("hello")]),
+        makeMessage("msg-2", "assistant", [
+            { type: "reasoning", text: "thinking..." },
+            makeCompressPart("error", "call-1"),
+            { type: "step-finish", reason: "stop" },
+        ]),
+        makeMessage("msg-3", "user", [makeTextPart("retry")]),
+        makeMessage("msg-4", "assistant", [
+            makeCompressPart("error", "call-2"),
+        ]),
+    ]
+
+    const hidden = hideFailedCompressCalls(messages)
+
+    assert.equal(hidden, 1, "older failed compress removed, most recent kept")
+    assert.equal(
+        messages.find((m) => m.info.id === "msg-2"),
+        undefined,
+        "structural-only orphan msg-2 should be spliced",
+    )
+    assert.ok(messages.find((m) => m.info.id === "msg-4"), "msg-4 (most recent failure) survives")
+})


### PR DESCRIPTION
## Summary

When `hideConsumedCompressCalls` removes the compress tool-call part from a message whose block was consumed by a higher-tier compression, the message may survive with only structural parts (`step-start`, `step-finish`, `reasoning`). These orphan messages waste ~500-2000 tokens each with zero useful content.

**Root cause**: `hideConsumedCompressCalls` checked `remaining.length > 0` to decide whether to keep the message. Structural parts count as "remaining" even though they carry no meaningful content. `dropEmptyMessages` also does not catch them because it only considers text-only-empty/ignored messages as empty.

**Fix**: After removing the compress tool part, check whether remaining parts contain any meaningful content (anything not in `{step-start, step-finish, reasoning}`). If only structural parts remain, splice the message entirely.

## Test Coverage

4 new tests added:
- `splices message when only reasoning + step-finish remain after compress removal`
- `splices message when only reasoning remains after compress removal`
- `preserves message when text accompanies reasoning after compress removal`
- `preserves message when non-compress tool accompanies structural parts`

All 899 tests pass. Typecheck clean.

Files: `lib/compress/hide-consumed.ts`. Tests: `tests/hide-consumed.test.ts`.