### PR TITLE
feat: add system token breakdown to acp_status and nudge

### DIFF
--- a/devlog/2026-07-30_acp-status-system-tokens/REQ.md
+++ b/devlog/2026-07-30_acp-status-system-tokens/REQ.md
@@ -7,6 +7,10 @@ token proportions — never system prompt tokens. The system prompt (AGENTS.md, 
 definitions, etc.) can be 5-15K tokens, a significant context portion. Without it,
 the model lacks a true big-picture view of total context usage.
 
+Additionally, the context fill percentage ("Context: 47% full.") was leaked to the
+model, which made it lazy about compression — the model would see "47% full" and
+think context is healthy, delaying compression unnecessarily.
+
 ## Fix
 
 1. `estimateContextComposition` now returns `systemTokens`, calculated from the
@@ -17,10 +21,23 @@ the model lacks a true big-picture view of total context usage.
 3. Nudge breakdown line prepends `system (N%)` when system tokens > 0.
 4. `compressibleTokens` calculation subtracts `systemTokens` (system prompt is
    not compressible).
+5. Removed context fill percentage leak — `buildContextUsageGuidance` no longer
+   emits "Context: X% full." text. Category proportions (tool 40%, text 22%) are
+   kept because they help the model prioritize compression without revealing total
+   fill level.
+6. Deleted dead code: `buildContextUsageGuidance` (was returning ""), its sole
+   caller `injectContextUsage`, and the tautological test.
+7. Extracted shared `estimateSystemPromptTokens()` into `token-utils.ts` using
+   the real Anthropic tokenizer (was `length/4` — 2-4x inaccurate for CJK).
+   Consolidated 4 duplicate implementations into 1.
 
 ## Files
 
-- `lib/messages/inject/utils.ts` — added `systemTokens` to `ContextComposition` + calculation
-- `lib/compress/status.ts` — added `estimateSystemTokens`, show in overview
-- `lib/messages/inject/inject.ts` — show system in nudge breakdown, subtract from compressible
+- `lib/token-utils.ts` — added shared `estimateSystemPromptTokens()` with typed accessor
+- `lib/messages/inject/utils.ts` — use shared helper, deleted dead `buildContextUsageGuidance`
+- `lib/compress/status.ts` — use shared helper (was local `estimateSystemTokens`)
+- `lib/messages/inject/inject.ts` — show system in nudge breakdown, subtract from compressible,
+  deleted dead `injectContextUsage` + import
+- `tests/inject-utils-pure.test.ts` — added 4 positive tests for system token estimation
+- `tests/nudge-text.test.ts` — removed tautological test + unused constants
 - `tests/stats-command.test.ts` — updated header assertion

--- a/devlog/2026-07-30_acp-status-system-tokens/REQ.md
+++ b/devlog/2026-07-30_acp-status-system-tokens/REQ.md
@@ -1,0 +1,26 @@
+# REQ: Add system token breakdown to acp_status and nudge
+
+## Problem
+
+`acp_status` overview and the nudge breakdown line only showed tool/text/code/summary
+token proportions — never system prompt tokens. The system prompt (AGENTS.md, tool
+definitions, etc.) can be 5-15K tokens, a significant context portion. Without it,
+the model lacks a true big-picture view of total context usage.
+
+## Fix
+
+1. `estimateContextComposition` now returns `systemTokens`, calculated from the
+   first assistant message's API-reported `input + cache.read + cache.write` minus
+   first user message tokens. Included in `total`.
+2. `acp_status` overview header changed from "VISIBLE CONTEXT (uncompressed)" to
+   "CONTEXT BREAKDOWN", and breakdown line now starts with `system (N%)`.
+3. Nudge breakdown line prepends `system (N%)` when system tokens > 0.
+4. `compressibleTokens` calculation subtracts `systemTokens` (system prompt is
+   not compressible).
+
+## Files
+
+- `lib/messages/inject/utils.ts` — added `systemTokens` to `ContextComposition` + calculation
+- `lib/compress/status.ts` — added `estimateSystemTokens`, show in overview
+- `lib/messages/inject/inject.ts` — show system in nudge breakdown, subtract from compressible
+- `tests/stats-command.test.ts` — updated header assertion

--- a/devlog/2026-07-30_acp-status-system-tokens/WORKLOG.md
+++ b/devlog/2026-07-30_acp-status-system-tokens/WORKLOG.md
@@ -1,0 +1,17 @@
+# WORKLOG: acp-status-system-tokens
+
+## Changes
+
+1. `estimateContextComposition` (utils.ts): Added `systemTokens` field to `ContextComposition`. Estimated from first assistant message's `tokens.input + cache.read + cache.write` minus first user message text tokens (length/4). Added to `total`.
+
+2. `status.ts`: Added private `estimateSystemTokens()` function. `collectVisibleMessages` returns `systemTokens`. `renderOverview` shows system in breakdown with `CONTEXT BREAKDOWN` header. Total now = system + tool + text + summaries.
+
+3. `inject.ts`: Nudge breakdown prepends `system (N%)` when `composition.systemTokens > 0`. `compressibleTokens` now subtracts `systemTokens` (not compressible).
+
+4. Tests: Updated `stats-command.test.ts` to expect `CONTEXT BREAKDOWN` instead of `VISIBLE CONTEXT`.
+
+## Test Results
+
+- 923 tests pass (0 failures)
+- Typecheck clean
+- Build success (382.42 KB)

--- a/lib/compress/status.ts
+++ b/lib/compress/status.ts
@@ -237,7 +237,7 @@ function renderOverview(
 
         lines.push("CONTEXT BREAKDOWN")
         lines.push(
-            `  ${formatTokens(total)} total | ${formatTokens(systemTokens)} system (${sysPct}%) | ${formatTokens(totalTool)} tool (${toolPct}%) | ${formatTokens(totalText)} text (${textPct}%) | ${formatTokens(summaryTokens)} summaries (${summaryPct}%)`,
+            `  ${formatTokens(systemTokens)} system (${sysPct}%) | ${formatTokens(totalTool)} tool (${toolPct}%) | ${formatTokens(totalText)} text (${textPct}%) | ${formatTokens(summaryTokens)} summaries (${summaryPct}%)`,
         )
 
         const topTypes = Array.from(toolTypeMap.entries())

--- a/lib/compress/status.ts
+++ b/lib/compress/status.ts
@@ -123,7 +123,7 @@ export interface StatusRenderContext {
 function collectVisibleMessages(
     rawMessages: WithParts[],
     ctx: StatusRenderContext,
-): { messages: VisibleMessageInfo[]; summaryTokens: number } {
+): { messages: VisibleMessageInfo[]; summaryTokens: number; systemTokens: number } {
     const pruneMap = ctx.state.prune.messages.byMessageId
     const byRawId = ctx.state.messageIds.byRawId
     const result: VisibleMessageInfo[] = []
@@ -170,12 +170,41 @@ function collectVisibleMessages(
         }
     })
 
-    return { messages: result, summaryTokens }
+    return { messages: result, summaryTokens, systemTokens: estimateSystemTokens(rawMessages) }
+}
+
+function estimateSystemTokens(rawMessages: WithParts[]): number {
+    let firstInput: number | undefined
+    for (const msg of rawMessages) {
+        if (msg.info.role !== "assistant") continue
+        const t = (msg.info as any)?.tokens
+        if (!t) continue
+        const input = (t.input || 0) + (t.cache?.read || 0) + (t.cache?.write || 0)
+        if (input > 0) {
+            firstInput = input
+            break
+        }
+    }
+    if (firstInput === undefined) return 0
+
+    let firstUserText = ""
+    for (const msg of rawMessages) {
+        if (msg.info.role !== "user") continue
+        const parts = Array.isArray(msg.parts) ? msg.parts : []
+        for (const part of parts) {
+            if (part.type === "text" && typeof (part as any).text === "string") {
+                firstUserText += (part as any).text
+            }
+        }
+        if (firstUserText) break
+    }
+    return Math.max(0, firstInput - Math.round(firstUserText.length / 4))
 }
 
 function renderOverview(
     visibleMessages: VisibleMessageInfo[],
     summaryTokens: number,
+    systemTokens: number,
     blocks: CompressionBlock[],
     fetchFailed: boolean,
     rawMessages: WithParts[],
@@ -199,15 +228,16 @@ function renderOverview(
         const totalText = visibleMessages
             .filter((m) => m.tool === "text")
             .reduce((s, m) => s + m.tokens, 0)
-        const total = totalTool + totalText + summaryTokens
+        const total = systemTokens + totalTool + totalText + summaryTokens
 
+        const sysPct = pct(systemTokens, total)
         const toolPct = pct(totalTool, total)
         const textPct = pct(totalText, total)
         const summaryPct = pct(summaryTokens, total)
 
-        lines.push("VISIBLE CONTEXT (uncompressed)")
+        lines.push("CONTEXT BREAKDOWN")
         lines.push(
-            `  ${formatTokens(total)} total | ${formatTokens(totalTool)} tool (${toolPct}%) | ${formatTokens(totalText)} text (${textPct}%) | ${formatTokens(summaryTokens)} summaries (${summaryPct}%)`,
+            `  ${formatTokens(total)} total | ${formatTokens(systemTokens)} system (${sysPct}%) | ${formatTokens(totalTool)} tool (${toolPct}%) | ${formatTokens(totalText)} text (${textPct}%) | ${formatTokens(summaryTokens)} summaries (${summaryPct}%)`,
         )
 
         const topTypes = Array.from(toolTypeMap.entries())
@@ -520,6 +550,7 @@ export function buildStatusReport(
     const result = collectVisibleMessages(rawMessages, renderCtx)
     const visibleMsgs = result.messages
     const summaryTokens = result.summaryTokens
+    const systemTokens = result.systemTokens
 
     if (scope === "uncompressed") {
         if (view === "messages") {
@@ -529,7 +560,15 @@ export function buildStatusReport(
         }
     } else {
         lines.push(
-            ...renderOverview(visibleMsgs, summaryTokens, allBlocks, false, rawMessages, renderCtx),
+            ...renderOverview(
+                visibleMsgs,
+                summaryTokens,
+                systemTokens,
+                allBlocks,
+                false,
+                rawMessages,
+                renderCtx,
+            ),
         )
     }
 

--- a/lib/compress/status.ts
+++ b/lib/compress/status.ts
@@ -12,6 +12,7 @@ import {
     formatCompressibleRanges,
 } from "../messages/inject/utils"
 import { fetchSessionMessages } from "./search"
+import { estimateSystemPromptTokens } from "../token-utils"
 
 const ACP_STATUS_TOOL_DESCRIPTION = `Show context status — overview includes compressible ranges by default.
 
@@ -170,35 +171,7 @@ function collectVisibleMessages(
         }
     })
 
-    return { messages: result, summaryTokens, systemTokens: estimateSystemTokens(rawMessages) }
-}
-
-function estimateSystemTokens(rawMessages: WithParts[]): number {
-    let firstInput: number | undefined
-    for (const msg of rawMessages) {
-        if (msg.info.role !== "assistant") continue
-        const t = (msg.info as any)?.tokens
-        if (!t) continue
-        const input = (t.input || 0) + (t.cache?.read || 0) + (t.cache?.write || 0)
-        if (input > 0) {
-            firstInput = input
-            break
-        }
-    }
-    if (firstInput === undefined) return 0
-
-    let firstUserText = ""
-    for (const msg of rawMessages) {
-        if (msg.info.role !== "user") continue
-        const parts = Array.isArray(msg.parts) ? msg.parts : []
-        for (const part of parts) {
-            if (part.type === "text" && typeof (part as any).text === "string") {
-                firstUserText += (part as any).text
-            }
-        }
-        if (firstUserText) break
-    }
-    return Math.max(0, firstInput - Math.round(firstUserText.length / 4))
+    return { messages: result, summaryTokens, systemTokens: estimateSystemPromptTokens(rawMessages) }
 }
 
 function renderOverview(

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -26,7 +26,6 @@ import {
     addAnchor,
     applyAnchoredNudges,
     buildCompressibleRanges,
-    buildContextUsageGuidance,
     computeProtectedRefs,
     computeShouldNudge,
     countMessagesAfterIndex,
@@ -502,8 +501,6 @@ export const injectCompressNudges = (
     let tipsText: string | null = null
 
     if (shouldInject) {
-        injectContextUsage(suffixMessage, config, currentTokens, modelContextLimit)
-
         if (suffixMessage && composition.total > 0) {
             const fmt = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n))
             const pct = (n: number) =>
@@ -615,26 +612,6 @@ function resolveEmergencyThreshold(
     if (isNaN(parsedPercent)) return undefined
     const clampedPercent = Math.max(0, Math.min(100, Math.round(parsedPercent)))
     return Math.round((clampedPercent / 100) * modelContextLimit)
-}
-
-function injectContextUsage(
-    target: WithParts | null,
-    config: PluginConfig,
-    currentTokens?: number,
-    modelContextLimit?: number,
-): void {
-    if (!target) return
-    const rawUsage = buildContextUsageGuidance(config, currentTokens, modelContextLimit)
-    if (!rawUsage) return
-    const usageTag = rawUsage
-
-    for (const part of target.parts) {
-        if (part.type === "text") {
-            appendToTextPart(part, usageTag)
-            return
-        }
-    }
-    target.parts.push(createSyntheticTextPart(target, usageTag))
 }
 
 export interface VisibleSegment {

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -520,10 +520,16 @@ export const injectCompressNudges = (
             const efficiencyNote = effectiveTipsVariant !== "maxLimit"
                 ? `\nThis is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.\n\n${COMPRESS_PHILOSOPHY}`
                 : ""
-            let breakdown = `${efficiencyNote}\nBreakdown: ${fmt(composition.toolTokens)} tool (${pct(composition.toolTokens)}%) | ${fmt(composition.summaryTokens)} summaries (${pct(composition.summaryTokens)}%) | ${fmt(composition.codeTokens)} code (${pct(composition.codeTokens)}%) | ${fmt(plainTextTokens)} text (${pct(plainTextTokens)}%)${growthStr}`
+            const sysPart = composition.systemTokens > 0
+                ? `${fmt(composition.systemTokens)} system (${pct(composition.systemTokens)}%) | `
+                : ""
+            let breakdown = `${efficiencyNote}\nBreakdown: ${sysPart}${fmt(composition.toolTokens)} tool (${pct(composition.toolTokens)}%) | ${fmt(composition.summaryTokens)} summaries (${pct(composition.summaryTokens)}%) | ${fmt(composition.codeTokens)} code (${pct(composition.codeTokens)}%) | ${fmt(plainTextTokens)} text (${pct(plainTextTokens)}%)${growthStr}`
 
             const compressibleTokens =
-                composition.total - composition.protectedTokens - composition.summaryTokens
+                composition.total -
+                composition.systemTokens -
+                composition.protectedTokens -
+                composition.summaryTokens
             if (composition.protectedTokens > 0) {
                 breakdown += `\n⚠️ ${fmt(composition.protectedTokens)} tokens are protected (environment-managed tools) — not compressible. Effective compressible: ~${fmt(compressibleTokens)}.`
             }

--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -380,26 +380,12 @@ function resolveThresholdPercent(
     return isNaN(parsed) ? undefined : parsed
 }
 
-/**
- * Build tiered context usage guidance based on actual config thresholds.
- * Shared by inject.ts (suffix message) and utils.ts (anchored nudges).
- *
- * Note: we deliberately do NOT reveal the absolute token count — only the
- * percentage of the model's context limit. This prevents the model from
- * gaming exact thresholds and keeps the guidance qualitative.
- */
 export function buildContextUsageGuidance(
-    config: PluginConfig,
-    currentTokens?: number,
-    modelContextLimit?: number,
+    _config: PluginConfig,
+    _currentTokens?: number,
+    _modelContextLimit?: number,
 ): string {
-    if (currentTokens === undefined || modelContextLimit === undefined || modelContextLimit === 0) {
-        return ""
-    }
-
-    const pct = Math.round((currentTokens / modelContextLimit) * 100)
-
-    return `\n\nContext: ${pct}% full.`
+    return ""
 }
 
 export function applyAnchoredNudges(

--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -14,6 +14,7 @@ import {
     type MessagePriority,
     listPriorityRefsBeforeIndex,
 } from "../priority"
+import { estimateSystemPromptTokens } from "../../token-utils"
 import {
     appendToTextPart,
     appendToLastTextPart,
@@ -380,14 +381,6 @@ function resolveThresholdPercent(
     return isNaN(parsed) ? undefined : parsed
 }
 
-export function buildContextUsageGuidance(
-    _config: PluginConfig,
-    _currentTokens?: number,
-    _modelContextLimit?: number,
-): string {
-    return ""
-}
-
 export function applyAnchoredNudges(
     state: SessionState,
     config: PluginConfig,
@@ -569,27 +562,7 @@ export function estimateContextComposition(
         .map(([tool, tokens]) => ({ tool, tokens }))
         .sort((a, b) => b.tokens - a.tokens)
 
-    let systemTokens = 0
-    for (const msg of messages) {
-        if (msg.info.role !== "assistant") continue
-        const t = (msg.info as any)?.tokens
-        if (!t) continue
-        const input = (t.input || 0) + (t.cache?.read || 0) + (t.cache?.write || 0)
-        if (input > 0) {
-            let firstUserText = ""
-            for (const m of messages) {
-                if (m.info.role !== "user") continue
-                for (const part of m.parts || []) {
-                    if (part.type === "text" && typeof (part as any).text === "string") {
-                        firstUserText += (part as any).text
-                    }
-                }
-                if (firstUserText) break
-            }
-            systemTokens = Math.max(0, input - Math.round(firstUserText.length / 4))
-            break
-        }
-    }
+    const systemTokens = estimateSystemPromptTokens(messages)
 
     return {
         toolTokens,

--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -451,6 +451,7 @@ export interface ContextComposition {
     summaryTokens: number
     messageTokens: number
     textTokens: number
+    systemTokens: number
     protectedTokens: number
     total: number
     largestRanges: { ref: string; tokens: number }[]
@@ -578,14 +579,37 @@ export function estimateContextComposition(
         .map(([tool, tokens]) => ({ tool, tokens }))
         .sort((a, b) => b.tokens - a.tokens)
 
+    let systemTokens = 0
+    for (const msg of messages) {
+        if (msg.info.role !== "assistant") continue
+        const t = (msg.info as any)?.tokens
+        if (!t) continue
+        const input = (t.input || 0) + (t.cache?.read || 0) + (t.cache?.write || 0)
+        if (input > 0) {
+            let firstUserText = ""
+            for (const m of messages) {
+                if (m.info.role !== "user") continue
+                for (const part of m.parts || []) {
+                    if (part.type === "text" && typeof (part as any).text === "string") {
+                        firstUserText += (part as any).text
+                    }
+                }
+                if (firstUserText) break
+            }
+            systemTokens = Math.max(0, input - Math.round(firstUserText.length / 4))
+            break
+        }
+    }
+
     return {
         toolTokens,
         codeTokens,
         summaryTokens,
         messageTokens,
         textTokens: Math.max(0, messageTokens - codeTokens),
+        systemTokens,
         protectedTokens,
-        total: toolTokens + summaryTokens + messageTokens,
+        total: systemTokens + toolTokens + summaryTokens + messageTokens,
         largestRanges: perMessage.slice(0, 15),
         largestToolRanges: perTool.slice(0, 15),
         largestCodeRanges: perCode.slice(0, 5),

--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -383,6 +383,10 @@ function resolveThresholdPercent(
 /**
  * Build tiered context usage guidance based on actual config thresholds.
  * Shared by inject.ts (suffix message) and utils.ts (anchored nudges).
+ *
+ * Note: we deliberately do NOT reveal the absolute token count — only the
+ * percentage of the model's context limit. This prevents the model from
+ * gaming exact thresholds and keeps the guidance qualitative.
  */
 export function buildContextUsageGuidance(
     config: PluginConfig,
@@ -393,9 +397,9 @@ export function buildContextUsageGuidance(
         return ""
     }
 
-    const formatK = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n))
+    const pct = Math.round((currentTokens / modelContextLimit) * 100)
 
-    return `\n\nContext: ${formatK(currentTokens)} tokens.`
+    return `\n\nContext: ${pct}% full.`
 }
 
 export function applyAnchoredNudges(

--- a/lib/prompts/system.ts
+++ b/lib/prompts/system.ts
@@ -71,7 +71,7 @@ PERIODIC CONTEXT STATUS
 
 Periodically, as context grows, the system appends a short status line in a synthetic suffix message. It looks like:
 
-[ACP] Context: 47.3K tokens. Visible: m00001–m00929, m00944–m00950 (810 msgs). 3 active blocks. \`acp_status\` for details.
+[ACP] Context: 47% full. Visible: m00001–m00929, m00944–m00950 (810 msgs). 3 active blocks. \`acp_status\` for details.
 
 This line is INFORMATION, not an instruction. Seeing it does not mean you should compress. Compress only when one of the WHEN TO COMPRESS conditions actually holds. Between these lines, context is not under additional pressure — you do not need to seek things to compress.
 
@@ -81,8 +81,9 @@ CONTEXT BREAKDOWN
 
 When context usage passes a threshold, the system appends a breakdown showing where your context tokens are spent:
 
-Breakdown: 12.3K tool (40%) | 3.1K summaries (10%) | 8.5K code (28%) | 6.5K text (22%)
+Breakdown: 5.2K system (21%) | 12.3K tool (40%) | 3.1K summaries (10%) | 8.5K code (28%) | 6.5K text (22%)
 
+- "system" = system prompt tokens (AGENTS.md, tool definitions — not compressible)
 - "tool" = tool call outputs (largest category — compress first when consumed)
 - "summaries" = existing compression block summaries (already compressed; do not re-compress standalone)
 - "code" = messages containing code blocks

--- a/lib/prompts/system.ts
+++ b/lib/prompts/system.ts
@@ -67,15 +67,7 @@ Summaries accumulate as the session grows. When tier-1 summaries pile up, the sy
 
 To compress blocks: use block IDs as boundaries: \`compress({ content: [{ startId: "b3", endId: "b15", summary: "..." }] })\`. This deactivates the consumed blocks and creates a new higher-tier block. The system prompt at the trigger tells you which rules to follow.
 
-PERIODIC CONTEXT STATUS
-
-Periodically, as context grows, the system appends a short status line in a synthetic suffix message. It looks like:
-
-[ACP] Context: 47% full. Visible: m00001–m00929, m00944–m00950 (810 msgs). 3 active blocks. \`acp_status\` for details.
-
-This line is INFORMATION, not an instruction. Seeing it does not mean you should compress. Compress only when one of the WHEN TO COMPRESS conditions actually holds. Between these lines, context is not under additional pressure — you do not need to seek things to compress.
-
-If you are unsure which \`mNNNNN\` refs are still compressible, or which blocks have already consumed which ranges, call \`acp_status\` first. It returns the visible context breakdown (tool/code/text/summary tokens with largest items) and the compressed block list (block IDs, sizes, message counts each covers).
+If you are unsure which \`mNNNNN\` refs are still compressible, or which blocks have already consumed which ranges, call \`acp_status\` first. It returns the visible context breakdown and the compressed block list.
 
 CONTEXT BREAKDOWN
 

--- a/lib/token-utils.ts
+++ b/lib/token-utils.ts
@@ -53,6 +53,48 @@ export function getCurrentTokenUsage(state: SessionState, messages: WithParts[])
     return estimated
 }
 
+/**
+ * Estimate system prompt tokens by subtracting the first user message's tokens
+ * from the first assistant message's total input prompt tokens.
+ *
+ * The first assistant turn's prompt = system_prompt + first_user_message (+
+ * any injected suffixes). By subtracting the first user message's token count
+ * (via countTokens for CJK/code accuracy), we isolate the system prompt estimate.
+ *
+ * Uses the real Anthropic tokenizer (countTokens) — NOT length/4 — for
+ * consistency with /acp context and cacheSystemPromptTokens.
+ *
+ * Returns 0 if no assistant message with token data is found.
+ */
+export function estimateSystemPromptTokens(messages: WithParts[]): number {
+    let firstInput: number | undefined
+    for (const msg of messages) {
+        if (msg.info.role !== "assistant") continue
+        const assistantInfo = msg.info as AssistantMessage
+        const t = assistantInfo.tokens
+        if (!t) continue
+        const input = (t.input || 0) + (t.cache?.read || 0) + (t.cache?.write || 0)
+        if (input > 0) {
+            firstInput = input
+            break
+        }
+    }
+    if (firstInput === undefined) return 0
+
+    let firstUserText = ""
+    for (const msg of messages) {
+        if (msg.info.role !== "user") continue
+        const parts = Array.isArray(msg.parts) ? msg.parts : []
+        for (const part of parts) {
+            if (part.type === "text" && typeof part.text === "string") {
+                firstUserText += part.text
+            }
+        }
+        if (firstUserText) break
+    }
+    return Math.max(0, firstInput - countTokens(firstUserText))
+}
+
 export function getCurrentParams(
     state: SessionState,
     messages: WithParts[],

--- a/tests/e2e-blocks-nudges.test.ts
+++ b/tests/e2e-blocks-nudges.test.ts
@@ -190,11 +190,10 @@ function setupPipeline(
 
 // ─── Test: Nudge injection when context is near limits ──────────────────────
 
-test("nudge injection: context usage tag injected when modelContextLimit is set", async () => {
+test("nudge injection: nudge breakdown injected when modelContextLimit is set", async () => {
     const { state, handler } = setupPipeline(SID_A, {}, {
         modelContextLimit: 200000,
     })
-    // Simulate post-baseline state so growth-gating can fire (not first turn).
     state.nudges.lastPerMessageNudgeTokens = 0
 
     const output = {
@@ -213,7 +212,8 @@ test("nudge injection: context usage tag injected when modelContextLimit is set"
     assert.ok(suffixMessage, "suffix message should be created")
     const textParts = suffixMessage!.parts.filter((p: any) => p.type === "text")
     const combinedText = textParts.map((p: any) => p.text).join("")
-    assert.ok(combinedText.includes("Context:"), "should inject context tag")
+    assert.ok(combinedText.includes("Breakdown:"), "should inject breakdown")
+    assert.ok(!combinedText.match(/\d+%\s*full/i), "should NOT inject context fill percentage")
 })
 
 // ─── Test: No nudge when permission is denied ───────────────────────────────
@@ -242,7 +242,7 @@ test("nudge injection: no context usage tag when permission is denied", async ()
     assert.ok(lastUser)
     const textParts = lastUser!.parts.filter((p: any) => p.type === "text" && !p.synthetic)
     const originalText = textParts.map((p: any) => p.text).join("")
-    assert.ok(!originalText.includes("Context:"), "should NOT inject context with deny")
+    assert.ok(!originalText.includes("Breakdown:"), "should NOT inject nudge with deny")
 })
 
 // ─── Test: Age-based deactivation removed (memory-loss fix) ────────────────

--- a/tests/inject-utils-pure.test.ts
+++ b/tests/inject-utils-pure.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 import { computeShouldNudge, resolveAdaptiveNudgeGrowth, estimateContextComposition } from "../lib/messages/inject/utils"
+import { estimateSystemPromptTokens } from "../lib/token-utils"
+import { countTokens } from "../lib/token-utils"
 import type { WithParts } from "../lib/state"
 
 const baseParams = {
@@ -224,6 +226,51 @@ function mkSummary(id: string, text: string): WithParts {
     return { info: { id: `msg_dcp_summary_${id}` } as any, parts: [{ type: "text", text: `[Compressed conversation section]\n${text}` }] as any }
 }
 
+function mkAssistantWithTokens(input: number, cacheRead = 0, cacheWrite = 0): WithParts {
+    return {
+        info: { id: "a1", role: "assistant", tokens: { input, output: 100, cache: { read: cacheRead, write: cacheWrite } } } as any,
+        parts: [{ type: "text", text: "ok", id: "a1-p", sessionID: "s", messageID: "a1" }] as any,
+    }
+}
+
+test("estimateSystemPromptTokens: assistant input minus first user text", () => {
+    const userText = "Hello, please help me with a task."
+    const input = 10_000
+    const messages = [
+        { info: { id: "u1", role: "user" } as any, parts: [{ type: "text", text: userText }] as any },
+        mkAssistantWithTokens(input),
+    ]
+    const sys = estimateSystemPromptTokens(messages)
+    assert.ok(sys > 0, "system tokens should be positive")
+    assert.equal(sys, input - countTokens(userText))
+})
+
+test("estimateSystemPromptTokens: returns 0 when no assistant token data", () => {
+    const messages = [mkText("u1", "hello")]
+    assert.equal(estimateSystemPromptTokens(messages), 0)
+})
+
+test("estimateSystemPromptTokens: handles cache.read and cache.write", () => {
+    const messages = [
+        { info: { id: "u1", role: "user" } as any, parts: [{ type: "text", text: "hi" }] as any },
+        mkAssistantWithTokens(5000, 3000, 2000),
+    ]
+    const sys = estimateSystemPromptTokens(messages)
+    assert.ok(sys > 0)
+    assert.equal(sys, 10_000 - countTokens("hi"))
+})
+
+test("estimateContextComposition: systemTokens from assistant data included in total", () => {
+    const msgs = [
+        { info: { id: "u1", role: "user" } as any, parts: [{ type: "text", text: "hello" }] as any },
+        mkAssistantWithTokens(8000),
+        mkText("m1", "x".repeat(400)),
+    ]
+    const c = estimateContextComposition(msgs)
+    assert.ok(c.systemTokens > 0, "system tokens should be computed from assistant data")
+    assert.equal(c.total, c.systemTokens + c.toolTokens + c.summaryTokens + c.messageTokens)
+})
+
 test("estimateContextComposition: empty messages returns zeros", () => {
     const c = estimateContextComposition([])
     assert.equal(c.toolTokens, 0)
@@ -272,7 +319,7 @@ test("estimateContextComposition: code blocks counted in codeTokens (subset of m
     assert.equal(c.total, c.messageTokens)
 })
 
-test("estimateContextComposition: total = tool + summary + message (mutually exclusive)", () => {
+test("estimateContextComposition: total = system + tool + summary + message (no assistant data → system=0)", () => {
     const msgs = [
         mkText("m1", "hello world"),
         mkTool("m2", '{"a":1}'),

--- a/tests/nudge-text.test.ts
+++ b/tests/nudge-text.test.ts
@@ -1,56 +1,9 @@
 import assert from "node:assert/strict"
 import test from "node:test"
-import type { PluginConfig } from "../lib/config"
 import { TURN_NUDGE } from "../lib/prompts/turn-nudge"
 import { CONTEXT_LIMIT_NUDGE } from "../lib/prompts/context-limit-nudge"
 import { buildCompressedBlockGuidance } from "../lib/prompts/extensions/nudge"
-import { buildContextUsageGuidance } from "../lib/messages/inject/utils"
 import { createSessionState } from "../lib/state"
-
-const MODEL_CONTEXT_LIMIT = 100_000
-const LOW_USAGE = 20_000
-const MODERATE_USAGE = 40_000
-const HIGH_USAGE = 50_000
-
-/**
- * PluginConfig fixture whose thresholds (30% / 45%) place the three usage points
- * LOW_USAGE / MODERATE_USAGE / HIGH_USAGE into distinct tiers so each tier's
- * wording can be asserted independently. Mirrors the shape used in
- * tests/inject.test.ts; only compress.minContextLimit / maxContextLimit are read.
- */
-function buildConfig(): PluginConfig {
-    return {
-        enabled: true,
-        autoUpdate: true,
-        debug: false,
-        pruneNotification: "off",
-        pruneNotificationType: "chat",
-        commands: { enabled: true, protectedTools: [] },
-        experimental: { allowSubAgents: false, customPrompts: false },
-        protectedFilePatterns: [],
-        compress: {
-            permission: "allow",
-            showCompression: false,
-            summaryBuffer: true,
-            maxContextLimit: "45%",
-            minContextLimit: "30%",
-            nudgeFrequency: 5,
-            iterationNudgeThreshold: 15,
-            nudgeForce: "soft",
-            protectedTools: [],
-            protectTags: false,
-            protectUserMessages: false,
-        },
-        gc: {
-            algorithm: "truncate",
-            promotionThreshold: 5,
-            maxBlockAge: 15,
-            maxOldGenSummaryLength: 3000,
-            majorGcThresholdPercent: "100%",
-            batchCleanup: { lowThreshold: "55%", highThreshold: "75%", forceThreshold: "90%" },
-        },
-    }
-}
 
 test("TURN_NUDGE uses conditional compression language with decompress safety net", () => {
     assert.match(TURN_NUDGE, /finished reading/i)
@@ -94,16 +47,6 @@ test("buildCompressedBlockGuidance shows last compression age", () => {
     const guidance = buildCompressedBlockGuidance(state)
 
     assert.match(guidance, /5m ago/)
-})
-
-test("buildContextUsageGuidance returns empty (no context fill leaked to model)", () => {
-    const low = buildContextUsageGuidance(buildConfig(), LOW_USAGE, MODEL_CONTEXT_LIMIT)
-    const mid = buildContextUsageGuidance(buildConfig(), MODERATE_USAGE, MODEL_CONTEXT_LIMIT)
-    const high = buildContextUsageGuidance(buildConfig(), HIGH_USAGE, MODEL_CONTEXT_LIMIT)
-
-    assert.equal(low, "")
-    assert.equal(mid, "")
-    assert.equal(high, "")
 })
 
 test("buildCompressedBlockGuidance aggregates summary tokens across blocks", () => {

--- a/tests/nudge-text.test.ts
+++ b/tests/nudge-text.test.ts
@@ -96,19 +96,14 @@ test("buildCompressedBlockGuidance shows last compression age", () => {
     assert.match(guidance, /5m ago/)
 })
 
-test("buildContextUsageGuidance returns context number without compression guidance", () => {
+test("buildContextUsageGuidance returns empty (no context fill leaked to model)", () => {
     const low = buildContextUsageGuidance(buildConfig(), LOW_USAGE, MODEL_CONTEXT_LIMIT)
     const mid = buildContextUsageGuidance(buildConfig(), MODERATE_USAGE, MODEL_CONTEXT_LIMIT)
     const high = buildContextUsageGuidance(buildConfig(), HIGH_USAGE, MODEL_CONTEXT_LIMIT)
 
-    assert.match(low, /Context:/)
-    assert.match(mid, /Context:/)
-    assert.match(high, /Context:/)
-
-    assert.doesNotMatch(low, /be frugal/i)
-    assert.doesNotMatch(low, /MUST|aggressive|critical/i)
-    assert.doesNotMatch(mid, /growing|MUST|aggressive/i)
-    assert.doesNotMatch(high, /aggressive|MUST/i)
+    assert.equal(low, "")
+    assert.equal(mid, "")
+    assert.equal(high, "")
 })
 
 test("buildCompressedBlockGuidance aggregates summary tokens across blocks", () => {

--- a/tests/stats-command.test.ts
+++ b/tests/stats-command.test.ts
@@ -133,7 +133,7 @@ describe("buildStatusReport (acp_stats wrapper)", () => {
 
         const report = buildStatusReport({ state, config }, messages)
 
-        assert.ok(report.includes("VISIBLE CONTEXT"))
+        assert.ok(report.includes("CONTEXT BREAKDOWN"))
         assert.ok(report.includes("No compressed blocks"))
     })
 
@@ -147,7 +147,7 @@ describe("buildStatusReport (acp_stats wrapper)", () => {
 
         const report = buildStatusReport({ state, config }, messages)
 
-        assert.ok(report.includes("VISIBLE CONTEXT"))
+        assert.ok(report.includes("CONTEXT BREAKDOWN"))
         assert.ok(report.includes("total"))
         assert.ok(report.includes("text"))
     })

--- a/tests/stats-command.test.ts
+++ b/tests/stats-command.test.ts
@@ -148,7 +148,7 @@ describe("buildStatusReport (acp_stats wrapper)", () => {
         const report = buildStatusReport({ state, config }, messages)
 
         assert.ok(report.includes("CONTEXT BREAKDOWN"))
-        assert.ok(report.includes("total"))
+        assert.ok(report.includes("tool"))
         assert.ok(report.includes("text"))
     })
 


### PR DESCRIPTION
## Summary

Three changes:
1. **Add system token estimation** to `acp_status` overview and nudge breakdown
2. **Hide context fill percentage** from the model (was making it lazy about compression)
3. **Delete dead code** + consolidate 4 duplicate implementations into 1 shared helper

## Design Rationale

The model should see **category proportions** (tool 40%, text 22%) to help prioritize compression, but must NOT see the **total context fill level** (47% of limit). If the model sees "47% full", it thinks context is healthy and delays compression.

### System Token Estimation

```
First assistant turn prompt = system_prompt + first_user_message
system_tokens = first_assistant.input + cache.read + cache.write − countTokens(first_user_text)
```

Uses the real `@anthropic-ai/tokenizer` (not `length/4`) for CJK/code accuracy, shared via `estimateSystemPromptTokens()` in `token-utils.ts`.

### Before / After

**`acp_status` overview:**
```
Before: CONTEXT BREAKDOWN
        25.0K total | 8.5K tool (69%) | ...

After:  CONTEXT BREAKDOWN
        5.2K system (21%) | 8.5K tool (34%) | 3.1K text (12%) | 0.7K summaries (3%)
```

**Nudge breakdown (injected into model context):**
```
Before: Context: 47% full.
        Breakdown: 8.5K tool (40%) | ...

After:  Breakdown: 5.2K system (21%) | 8.5K tool (40%) | 3.1K text (14%) | ...
```

## Review Fixes (dual-agent review)

Both Oracle and Explore identified issues in the initial implementation. All fixed:
- **[HIGH]** Removed `(msg.info as any)?.tokens` — replaced with typed accessor `msg.info.tokens?.input`
- **[HIGH]** Consolidated 4 duplicate implementations into 1 shared `estimateSystemPromptTokens()` in `token-utils.ts`
- **[HIGH]** Switched from `length/4` to real `countTokens()` — fixes 2-4x CJK inaccuracy
- **[MEDIUM]** Deleted dead code: `buildContextUsageGuidance`, `injectContextUsage`, tautological test
- **[MEDIUM]** Added 4 positive tests for system token estimation

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 926 tests, 0 failures
- [x] `npm run build` — 382KB