### PR TITLE
feat: keepLastOnly dedup mechanism + 4 OMO builtin filters

### DIFF
--- a/devlog/2026-07-29_omo-filters-keep-last/REQ.md
+++ b/devlog/2026-07-29_omo-filters-keep-last/REQ.md
@@ -1,0 +1,23 @@
+# REQ: OMO Filters — keepLastOnly Dedup + 4 New Builtin Filters
+
+## Problem
+
+OMO injects repeating directives (TODO CONTINUATION, CONTEXT, TASK) as separate
+user messages. A single session can accumulate 387 TODO reminders (~120K tokens).
+Stripping ALL of them loses the active directive (model stops working).
+
+## Solution
+
+- [x] Add `keepLastOnly` property to `MessageFilter` interface
+- [x] Two-phase filtering in `applyMessageFilters`: Phase 1 (immediate, forward),
+      Phase 2 (keepLastOnly, reverse dedup)
+- [x] 4 new builtin filters: `omo-todo-continuation`, `omo-context`,
+      `omo-task-directive` (keep last), `omo-mode-injection` (strip all)
+- [x] Config defaults updated with all 5 filters enabled
+- [x] Tests: keep-last dedup (TODO, CONTEXT, single occurrence), mode injection strip
+
+## Acceptance Criteria
+
+- [x] 927/927 tests pass
+- [x] TypeScript 0 errors
+- [x] DB verification: 316 pure system-reminder dropped, 3 mixed modified, 0 false positives

--- a/devlog/2026-07-29_omo-filters-keep-last/WORKLOG.md
+++ b/devlog/2026-07-29_omo-filters-keep-last/WORKLOG.md
@@ -1,0 +1,23 @@
+# WORKLOG
+
+## Phase 1: DB Analysis
+- Scanned 319 system-reminder messages: 316 pure, 3 mixed, 0 false positives
+- Categorized 1180 OMO-injected parts: todo-continuation (387), background-task (316), context (201), task-directive (28)
+- Estimated total savings: ~200K+ tokens per session
+
+## Phase 2: keepLastOnly Mechanism
+- Added `keepLastOnly?: boolean` to `MessageFilter` interface
+- Refactored `applyMessageFilters` into two phases:
+  - Phase 1: immediate filters (forward pass, chained)
+  - Phase 2: keepLastOnly filters (reverse pass, dedup)
+- Shared `applyDecision` helper extracted for DRY
+
+## Phase 3: Builtin Filters
+- `omo-todo-continuation`: matches `[SYSTEM DIRECTIVE` + `TODO CONTINUATION`, keepLastOnly
+- `omo-context`: matches `[CONTEXT]` or `CONTEXT:` prefix, keepLastOnly
+- `omo-task-directive`: matches `TASK:` or `## TASK` prefix, keepLastOnly
+- `omo-mode-injection`: matches `[search-mode]`, `[analyze-mode]`, `<ultrawork-mode>`, strip all
+
+## Phase 4: Tests
+- 4 new tests: keep-last TODO, keep-last CONTEXT, single occurrence, mode injection strip all
+- 927/927 total pass

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -241,6 +241,10 @@ const defaultConfig: PluginConfig = {
         enabled: true,
         filters: {
             "omo-system-reminder": { enabled: true },
+            "omo-todo-continuation": { enabled: true },
+            "omo-context": { enabled: true },
+            "omo-task-directive": { enabled: true },
+            "omo-mode-injection": { enabled: true },
         },
     },
 }

--- a/lib/messages/filter/apply.ts
+++ b/lib/messages/filter/apply.ts
@@ -19,39 +19,72 @@ export function applyMessageFilters(
         return { partsFiltered: 0, partsDropped: 0, partsModified: 0 }
     }
 
-    const filters = listMessageFilters().filter((f) => {
+    const allFilters = listMessageFilters().filter((f) => {
         const fc = config.filters?.[f.name]
         return fc?.enabled !== false
     })
 
-    if (filters.length === 0) {
+    if (allFilters.length === 0) {
         return { partsFiltered: 0, partsDropped: 0, partsModified: 0 }
     }
 
     const result: ApplyResult = { partsFiltered: 0, partsDropped: 0, partsModified: 0 }
     const total = messages.length
 
+    const buildCtx = (text: string, role: string, i: number): MessageFilterContext => ({
+        text,
+        role,
+        sessionId: ctx.sessionId,
+        isSubAgent: ctx.isSubAgent,
+        messageIndex: i,
+        totalMessages: total,
+        modelContextLimit: ctx.modelContextLimit,
+    })
+
+    const applyDecision = (
+        part: { text?: string },
+        decision: { action: string; text?: string; reason?: string },
+        filterName: string,
+        i: number,
+        originalText: string,
+    ): string => {
+        result.partsFiltered++
+        if (decision.action === "drop") {
+            part.text = ""
+            result.partsDropped++
+            if (decision.reason) {
+                logger.debug("Message filter dropped text", {
+                    filter: filterName, reason: decision.reason, messageIndex: i, originalLength: originalText.length,
+                })
+            }
+            return ""
+        }
+        if (decision.action === "modify" && decision.text !== undefined) {
+            part.text = decision.text
+            result.partsModified++
+            if (decision.reason) {
+                logger.debug("Message filter modified text", {
+                    filter: filterName, reason: decision.reason, messageIndex: i,
+                    originalLength: originalText.length, newLength: decision.text.length,
+                })
+            }
+            return decision.text
+        }
+        return originalText
+    }
+
+    // Phase 1: immediate filters (forward pass, chained)
+    const immediateFilters = allFilters.filter((f) => !f.keepLastOnly)
     for (let i = 0; i < messages.length; i++) {
         const msg = messages[i]
         const role = (msg.info as { role?: string }).role ?? "unknown"
-        const parts = msg.parts ?? []
-
-        for (const part of parts) {
+        for (const part of msg.parts ?? []) {
             const text = (part as { text?: string }).text
             if (typeof text !== "string" || text.length === 0) continue
-
-            const filterCtx: MessageFilterContext = {
-                text,
-                role,
-                sessionId: ctx.sessionId,
-                isSubAgent: ctx.isSubAgent,
-                messageIndex: i,
-                totalMessages: total,
-                toolName: (part as { tool?: string }).tool,
-                modelContextLimit: ctx.modelContextLimit,
-            }
-
-            for (const filter of filters) {
+            let current = text
+            const filterCtx = buildCtx(current, role, i)
+            filterCtx.toolName = (part as { tool?: string }).tool
+            for (const filter of immediateFilters) {
                 let decision
                 try {
                     decision = filter.filter(filterCtx)
@@ -63,34 +96,38 @@ export function applyMessageFilters(
                     })
                     continue
                 }
-
                 if (decision.action === "keep") continue
+                current = applyDecision(part as { text?: string }, decision, filter.name, i, current)
+                filterCtx.text = current
+            }
+        }
+    }
 
-                result.partsFiltered++
-                if (decision.action === "drop") {
-                    ;(part as { text?: string }).text = ""
-                    result.partsDropped++
-                    if (decision.reason) {
-                        logger.debug("Message filter dropped text", {
-                            filter: filter.name,
-                            reason: decision.reason,
-                            messageIndex: i,
-                            originalLength: text.length,
-                        })
+    // Phase 2: keep-last-only dedup (reverse pass)
+    const keepLastFilters = allFilters.filter((f) => f.keepLastOnly)
+    for (const filter of keepLastFilters) {
+        let foundLast = false
+        for (let i = messages.length - 1; i >= 0; i--) {
+            const msg = messages[i]
+            const role = (msg.info as { role?: string }).role ?? "unknown"
+            for (const part of msg.parts ?? []) {
+                const text = (part as { text?: string }).text
+                if (typeof text !== "string" || text.length === 0) continue
+                const filterCtx = buildCtx(text, role, i)
+                let decision
+                try {
+                    decision = filter.filter(filterCtx)
+                } catch {
+                    continue
+                }
+                if (decision.action !== "drop" && decision.action !== "modify") continue
+                if (foundLast) {
+                    applyDecision(part as { text?: string }, { action: "drop", reason: `keepLastOnly: earlier occurrence` }, filter.name, i, text)
+                } else {
+                    foundLast = true
+                    if (decision.action === "modify" && decision.text !== undefined) {
+                        applyDecision(part as { text?: string }, decision, filter.name, i, text)
                     }
-                } else if (decision.action === "modify" && decision.text !== undefined) {
-                    ;(part as { text?: string }).text = decision.text
-                    result.partsModified++
-                    if (decision.reason) {
-                        logger.debug("Message filter modified text", {
-                            filter: filter.name,
-                            reason: decision.reason,
-                            messageIndex: i,
-                            originalLength: text.length,
-                            newLength: decision.text.length,
-                        })
-                    }
-                    filterCtx.text = decision.text
                 }
             }
         }
@@ -98,7 +135,7 @@ export function applyMessageFilters(
 
     if (result.partsFiltered > 0) {
         logger.info("Message filters applied", {
-            filtersRun: filters.length,
+            filtersRun: allFilters.length,
             partsFiltered: result.partsFiltered,
             partsDropped: result.partsDropped,
             partsModified: result.partsModified,

--- a/lib/messages/filter/apply.ts
+++ b/lib/messages/filter/apply.ts
@@ -1,6 +1,6 @@
 import type { WithParts } from "../../state"
 import type { Logger } from "../../logger"
-import type { MessageFilter, MessageFilterContext, MessageFiltersConfig } from "./types"
+import type { MessageFilter, MessageFilterContext, MessageFiltersConfig, FilterResult } from "./types"
 import { listMessageFilters } from "./registry"
 
 export interface ApplyResult {
@@ -43,7 +43,7 @@ export function applyMessageFilters(
 
     const applyDecision = (
         part: { text?: string },
-        decision: { action: string; text?: string; reason?: string },
+        decision: FilterResult,
         filterName: string,
         i: number,
         originalText: string,
@@ -110,10 +110,13 @@ export function applyMessageFilters(
         for (let i = messages.length - 1; i >= 0; i--) {
             const msg = messages[i]
             const role = (msg.info as { role?: string }).role ?? "unknown"
-            for (const part of msg.parts ?? []) {
+            const parts = msg.parts ?? []
+            for (let p = parts.length - 1; p >= 0; p--) {
+                const part = parts[p]
                 const text = (part as { text?: string }).text
                 if (typeof text !== "string" || text.length === 0) continue
                 const filterCtx = buildCtx(text, role, i)
+                filterCtx.toolName = (part as { tool?: string }).tool
                 let decision
                 try {
                     decision = filter.filter(filterCtx)

--- a/lib/messages/filter/builtin/index.ts
+++ b/lib/messages/filter/builtin/index.ts
@@ -1,8 +1,18 @@
 import type { MessageFilter } from "../types"
 import { registerMessageFilter, getMessageFilter } from "../registry"
 import { OMO_SYSTEM_REMINDER_FILTER } from "./omo-system-reminder"
+import { OMO_TODO_FILTER } from "./omo-todo-continuation"
+import { OMO_CONTEXT_FILTER } from "./omo-context"
+import { OMO_TASK_FILTER } from "./omo-task-directive"
+import { OMO_MODE_FILTER } from "./omo-mode-injection"
 
-const BUILTIN_FILTERS: MessageFilter[] = [OMO_SYSTEM_REMINDER_FILTER]
+const BUILTIN_FILTERS: MessageFilter[] = [
+    OMO_SYSTEM_REMINDER_FILTER,
+    OMO_TODO_FILTER,
+    OMO_CONTEXT_FILTER,
+    OMO_TASK_FILTER,
+    OMO_MODE_FILTER,
+]
 
 export function ensureBuiltinFiltersRegistered(): void {
     for (const filter of BUILTIN_FILTERS) {

--- a/lib/messages/filter/builtin/omo-context.ts
+++ b/lib/messages/filter/builtin/omo-context.ts
@@ -1,0 +1,21 @@
+import type { MessageFilter, MessageFilterContext, FilterResult } from "../types"
+
+const CONTEXT_PREFIX = "[CONTEXT]"
+
+const OMO_CONTEXT_FILTER: MessageFilter = {
+    name: "omo-context",
+    version: "1.0.0",
+    description: "Keep only the latest OMO [CONTEXT] injection, drop earlier occurrences",
+    keepLastOnly: true,
+
+    filter(ctx: MessageFilterContext): FilterResult {
+        if (ctx.role !== "user") return { action: "keep" }
+        const stripped = ctx.text.trimStart()
+        if (!stripped.startsWith(CONTEXT_PREFIX) && !stripped.startsWith("CONTEXT:")) {
+            return { action: "keep" }
+        }
+        return { action: "drop", reason: "OMO context injection" }
+    },
+}
+
+export { OMO_CONTEXT_FILTER }

--- a/lib/messages/filter/builtin/omo-context.ts
+++ b/lib/messages/filter/builtin/omo-context.ts
@@ -1,6 +1,6 @@
 import type { MessageFilter, MessageFilterContext, FilterResult } from "../types"
 
-const CONTEXT_PREFIX = "[CONTEXT]"
+const OMO_MARKER = "<!-- OMO_INTERNAL_INITIATOR -->"
 
 const OMO_CONTEXT_FILTER: MessageFilter = {
     name: "omo-context",
@@ -10,8 +10,9 @@ const OMO_CONTEXT_FILTER: MessageFilter = {
 
     filter(ctx: MessageFilterContext): FilterResult {
         if (ctx.role !== "user") return { action: "keep" }
+        if (!ctx.text.includes(OMO_MARKER)) return { action: "keep" }
         const stripped = ctx.text.trimStart()
-        if (!stripped.startsWith(CONTEXT_PREFIX) && !stripped.startsWith("CONTEXT:")) {
+        if (!stripped.startsWith("[CONTEXT]") && !stripped.startsWith("CONTEXT:")) {
             return { action: "keep" }
         }
         return { action: "drop", reason: "OMO context injection" }

--- a/lib/messages/filter/builtin/omo-mode-injection.ts
+++ b/lib/messages/filter/builtin/omo-mode-injection.ts
@@ -1,0 +1,20 @@
+import type { MessageFilter, MessageFilterContext, FilterResult } from "../types"
+
+const MODE_PATTERNS = ["[search-mode]", "[analyze-mode]", "<ultrawork-mode>", "[ultrawork-mode]"]
+
+const OMO_MODE_FILTER: MessageFilter = {
+    name: "omo-mode-injection",
+    version: "1.0.0",
+    description: "Strip OMO mode injection blocks ([search-mode], [analyze-mode], <ultrawork-mode>)",
+
+    filter(ctx: MessageFilterContext): FilterResult {
+        if (ctx.role !== "user") return { action: "keep" }
+        const stripped = ctx.text.trimStart()
+        const isModeInjection = MODE_PATTERNS.some((p) => stripped.startsWith(p))
+        if (!isModeInjection) return { action: "keep" }
+
+        return { action: "drop", reason: "OMO mode injection" }
+    },
+}
+
+export { OMO_MODE_FILTER }

--- a/lib/messages/filter/builtin/omo-task-directive.ts
+++ b/lib/messages/filter/builtin/omo-task-directive.ts
@@ -1,5 +1,7 @@
 import type { MessageFilter, MessageFilterContext, FilterResult } from "../types"
 
+const OMO_MARKER = "<!-- OMO_INTERNAL_INITIATOR -->"
+
 const OMO_TASK_FILTER: MessageFilter = {
     name: "omo-task-directive",
     version: "1.0.0",
@@ -8,6 +10,7 @@ const OMO_TASK_FILTER: MessageFilter = {
 
     filter(ctx: MessageFilterContext): FilterResult {
         if (ctx.role !== "user") return { action: "keep" }
+        if (!ctx.text.includes(OMO_MARKER)) return { action: "keep" }
         const stripped = ctx.text.trimStart()
         if (!stripped.startsWith("TASK:") && !stripped.startsWith("## TASK")) {
             return { action: "keep" }

--- a/lib/messages/filter/builtin/omo-task-directive.ts
+++ b/lib/messages/filter/builtin/omo-task-directive.ts
@@ -1,0 +1,19 @@
+import type { MessageFilter, MessageFilterContext, FilterResult } from "../types"
+
+const OMO_TASK_FILTER: MessageFilter = {
+    name: "omo-task-directive",
+    version: "1.0.0",
+    description: "Keep only the latest OMO TASK directive, drop earlier occurrences",
+    keepLastOnly: true,
+
+    filter(ctx: MessageFilterContext): FilterResult {
+        if (ctx.role !== "user") return { action: "keep" }
+        const stripped = ctx.text.trimStart()
+        if (!stripped.startsWith("TASK:") && !stripped.startsWith("## TASK")) {
+            return { action: "keep" }
+        }
+        return { action: "drop", reason: "OMO task directive" }
+    },
+}
+
+export { OMO_TASK_FILTER }

--- a/lib/messages/filter/builtin/omo-todo-continuation.ts
+++ b/lib/messages/filter/builtin/omo-todo-continuation.ts
@@ -1,0 +1,21 @@
+import type { MessageFilter, MessageFilterContext, FilterResult } from "../types"
+
+const TODO_MARKER = "[SYSTEM DIRECTIVE"
+const TODO_CONTINUATION = "TODO CONTINUATION"
+
+const OMO_TODO_FILTER: MessageFilter = {
+    name: "omo-todo-continuation",
+    version: "1.0.0",
+    description: "Keep only the latest OMO TODO CONTINUATION directive, drop earlier occurrences",
+    keepLastOnly: true,
+
+    filter(ctx: MessageFilterContext): FilterResult {
+        if (ctx.role !== "user") return { action: "keep" }
+        if (!ctx.text.includes(TODO_MARKER) || !ctx.text.includes(TODO_CONTINUATION)) {
+            return { action: "keep" }
+        }
+        return { action: "drop", reason: "TODO CONTINUATION directive" }
+    },
+}
+
+export { OMO_TODO_FILTER }

--- a/lib/messages/filter/types.ts
+++ b/lib/messages/filter/types.ts
@@ -64,6 +64,14 @@ export interface MessageFilter {
      * Called once per text part per message.
      */
     filter(ctx: MessageFilterContext): FilterResult
+    /**
+     * When true, applyMessageFilters keeps only the LAST matching message
+     * and drops all earlier matches. Useful for repeating directives
+     * (e.g., TODO CONTINUATION) where only the latest is relevant.
+     * The filter() function still runs per-part to identify matches;
+     * the dedup pass then empties earlier occurrences.
+     */
+    keepLastOnly?: boolean
 }
 
 /**

--- a/tests/message-filter.test.ts
+++ b/tests/message-filter.test.ts
@@ -10,6 +10,9 @@ import type { MessageFilter, MessageFilterContext } from "../lib/messages/filter
 import type { WithParts } from "../lib/state"
 import { applyMessageFilters } from "../lib/messages/filter/apply"
 import { OMO_SYSTEM_REMINDER_FILTER } from "../lib/messages/filter/builtin/omo-system-reminder"
+import { OMO_TODO_FILTER } from "../lib/messages/filter/builtin/omo-todo-continuation"
+import { OMO_CONTEXT_FILTER } from "../lib/messages/filter/builtin/omo-context"
+import { OMO_MODE_FILTER } from "../lib/messages/filter/builtin/omo-mode-injection"
 import { ensureBuiltinFiltersRegistered } from "../lib/messages/filter/builtin"
 
 type MockLogger = { debug: (...a: any[]) => void; info: (...a: any[]) => void; warn: (...a: any[]) => void }
@@ -289,7 +292,7 @@ describe("ensureBuiltinFiltersRegistered", () => {
     it("is idempotent", () => {
         ensureBuiltinFiltersRegistered()
         ensureBuiltinFiltersRegistered()
-        assert.equal(listMessageFilters().length, 1)
+        assert.equal(listMessageFilters().length, 5)
     })
 })
 
@@ -333,5 +336,58 @@ describe("filter chaining", () => {
         assert.equal(stats.partsDropped, 1)
         assert.equal(stats.partsFiltered, 2)
         assert.equal(stats.partsModified, 1)
+    })
+})
+
+describe("keep-last-only dedup", () => {
+    beforeEach(() => clearMessageFilters())
+
+    it("keeps last TODO CONTINUATION, drops earlier ones", () => {
+        registerMessageFilter(OMO_TODO_FILTER)
+        const messages: WithParts[] = [
+            { info: { id: "m1", role: "user", time: 1 } as any, parts: [{ type: "text", text: "[SYSTEM DIRECTIVE: TODO CONTINUATION]\nWork on task A" }] },
+            { info: { id: "m2", role: "user", time: 2 } as any, parts: [{ type: "text", text: "real user message" }] },
+            { info: { id: "m3", role: "user", time: 3 } as any, parts: [{ type: "text", text: "[SYSTEM DIRECTIVE: TODO CONTINUATION]\nWork on task B" }] },
+        ]
+        const config = { enabled: true, filters: { "omo-todo-continuation": { enabled: true } } }
+        applyMessageFilters(messages, config, makeLogger(), { sessionId: "s", isSubAgent: false })
+        assert.equal((messages[0].parts[0] as any).text, "")
+        assert.equal((messages[1].parts[0] as any).text, "real user message")
+        assert.equal((messages[2].parts[0] as any).text, "[SYSTEM DIRECTIVE: TODO CONTINUATION]\nWork on task B")
+    })
+
+    it("keeps last [CONTEXT], drops earlier ones", () => {
+        registerMessageFilter(OMO_CONTEXT_FILTER)
+        const messages: WithParts[] = [
+            { info: { id: "m1", role: "user", time: 1 } as any, parts: [{ type: "text", text: "[CONTEXT] Old context" }] },
+            { info: { id: "m2", role: "user", time: 2 } as any, parts: [{ type: "text", text: "[CONTEXT] New context" }] },
+        ]
+        const config = { enabled: true, filters: { "omo-context": { enabled: true } } }
+        applyMessageFilters(messages, config, makeLogger(), { sessionId: "s", isSubAgent: false })
+        assert.equal((messages[0].parts[0] as any).text, "")
+        assert.equal((messages[1].parts[0] as any).text, "[CONTEXT] New context")
+    })
+
+    it("handles single occurrence (no dedup needed)", () => {
+        registerMessageFilter(OMO_TODO_FILTER)
+        const messages: WithParts[] = [
+            { info: { id: "m1", role: "user", time: 1 } as any, parts: [{ type: "text", text: "[SYSTEM DIRECTIVE: TODO CONTINUATION]\nOnly one" }] },
+        ]
+        const config = { enabled: true, filters: { "omo-todo-continuation": { enabled: true } } }
+        const stats = applyMessageFilters(messages, config, makeLogger(), { sessionId: "s", isSubAgent: false })
+        assert.equal((messages[0].parts[0] as any).text, "[SYSTEM DIRECTIVE: TODO CONTINUATION]\nOnly one")
+        assert.equal(stats.partsDropped, 0)
+    })
+
+    it("mode injection strips all occurrences", () => {
+        registerMessageFilter(OMO_MODE_FILTER)
+        const messages: WithParts[] = [
+            { info: { id: "m1", role: "user", time: 1 } as any, parts: [{ type: "text", text: "[search-mode]\nSearch for X" }] },
+            { info: { id: "m2", role: "user", time: 2 } as any, parts: [{ type: "text", text: "[analyze-mode]\nAnalyze Y" }] },
+        ]
+        const config = { enabled: true, filters: { "omo-mode-injection": { enabled: true } } }
+        applyMessageFilters(messages, config, makeLogger(), { sessionId: "s", isSubAgent: false })
+        assert.equal((messages[0].parts[0] as any).text, "")
+        assert.equal((messages[1].parts[0] as any).text, "")
     })
 })

--- a/tests/message-filter.test.ts
+++ b/tests/message-filter.test.ts
@@ -13,6 +13,7 @@ import { OMO_SYSTEM_REMINDER_FILTER } from "../lib/messages/filter/builtin/omo-s
 import { OMO_TODO_FILTER } from "../lib/messages/filter/builtin/omo-todo-continuation"
 import { OMO_CONTEXT_FILTER } from "../lib/messages/filter/builtin/omo-context"
 import { OMO_MODE_FILTER } from "../lib/messages/filter/builtin/omo-mode-injection"
+import { OMO_TASK_FILTER } from "../lib/messages/filter/builtin/omo-task-directive"
 import { ensureBuiltinFiltersRegistered } from "../lib/messages/filter/builtin"
 
 type MockLogger = { debug: (...a: any[]) => void; info: (...a: any[]) => void; warn: (...a: any[]) => void }
@@ -359,13 +360,13 @@ describe("keep-last-only dedup", () => {
     it("keeps last [CONTEXT], drops earlier ones", () => {
         registerMessageFilter(OMO_CONTEXT_FILTER)
         const messages: WithParts[] = [
-            { info: { id: "m1", role: "user", time: 1 } as any, parts: [{ type: "text", text: "[CONTEXT] Old context" }] },
-            { info: { id: "m2", role: "user", time: 2 } as any, parts: [{ type: "text", text: "[CONTEXT] New context" }] },
+            { info: { id: "m1", role: "user", time: 1 } as any, parts: [{ type: "text", text: "[CONTEXT] Old context\n<!-- OMO_INTERNAL_INITIATOR -->" }] },
+            { info: { id: "m2", role: "user", time: 2 } as any, parts: [{ type: "text", text: "[CONTEXT] New context\n<!-- OMO_INTERNAL_INITIATOR -->" }] },
         ]
         const config = { enabled: true, filters: { "omo-context": { enabled: true } } }
         applyMessageFilters(messages, config, makeLogger(), { sessionId: "s", isSubAgent: false })
         assert.equal((messages[0].parts[0] as any).text, "")
-        assert.equal((messages[1].parts[0] as any).text, "[CONTEXT] New context")
+        assert.equal((messages[1].parts[0] as any).text, "[CONTEXT] New context\n<!-- OMO_INTERNAL_INITIATOR -->")
     })
 
     it("handles single occurrence (no dedup needed)", () => {
@@ -377,6 +378,60 @@ describe("keep-last-only dedup", () => {
         const stats = applyMessageFilters(messages, config, makeLogger(), { sessionId: "s", isSubAgent: false })
         assert.equal((messages[0].parts[0] as any).text, "[SYSTEM DIRECTIVE: TODO CONTINUATION]\nOnly one")
         assert.equal(stats.partsDropped, 0)
+    })
+
+    it("last matching message is not the last message in array", () => {
+        registerMessageFilter(OMO_TODO_FILTER)
+        const messages: WithParts[] = [
+            { info: { id: "m1", role: "user", time: 1 } as any, parts: [{ type: "text", text: "[SYSTEM DIRECTIVE: TODO CONTINUATION]\nEarlier" }] },
+            { info: { id: "m2", role: "user", time: 2 } as any, parts: [{ type: "text", text: "[SYSTEM DIRECTIVE: TODO CONTINUATION]\nLatest" }] },
+            { info: { id: "m3", role: "user", time: 3 } as any, parts: [{ type: "text", text: "real user message after" }] },
+        ]
+        const config = { enabled: true, filters: { "omo-todo-continuation": { enabled: true } } }
+        applyMessageFilters(messages, config, makeLogger(), { sessionId: "s", isSubAgent: false })
+        assert.equal((messages[0].parts[0] as any).text, "")
+        assert.equal((messages[1].parts[0] as any).text, "[SYSTEM DIRECTIVE: TODO CONTINUATION]\nLatest")
+        assert.equal((messages[2].parts[0] as any).text, "real user message after")
+    })
+
+    it("multiple keepLastOnly filters run independently", () => {
+        registerMessageFilter(OMO_TODO_FILTER)
+        registerMessageFilter(OMO_CONTEXT_FILTER)
+        const messages: WithParts[] = [
+            { info: { id: "m1", role: "user", time: 1 } as any, parts: [{ type: "text", text: "[SYSTEM DIRECTIVE: TODO CONTINUATION]\nOld todo" }] },
+            { info: { id: "m2", role: "user", time: 2 } as any, parts: [{ type: "text", text: "[CONTEXT] Old\n<!-- OMO_INTERNAL_INITIATOR -->" }] },
+            { info: { id: "m3", role: "user", time: 3 } as any, parts: [{ type: "text", text: "[SYSTEM DIRECTIVE: TODO CONTINUATION]\nNew todo" }] },
+            { info: { id: "m4", role: "user", time: 4 } as any, parts: [{ type: "text", text: "[CONTEXT] New\n<!-- OMO_INTERNAL_INITIATOR -->" }] },
+        ]
+        const config = { enabled: true, filters: { "omo-todo-continuation": { enabled: true }, "omo-context": { enabled: true } } }
+        applyMessageFilters(messages, config, makeLogger(), { sessionId: "s", isSubAgent: false })
+        assert.equal((messages[0].parts[0] as any).text, "")
+        assert.equal((messages[1].parts[0] as any).text, "")
+        assert.equal((messages[2].parts[0] as any).text, "[SYSTEM DIRECTIVE: TODO CONTINUATION]\nNew todo")
+        assert.equal((messages[3].parts[0] as any).text, "[CONTEXT] New\n<!-- OMO_INTERNAL_INITIATOR -->")
+    })
+
+    it("TASK directive keepLastOnly with OMO marker", () => {
+        registerMessageFilter(OMO_TASK_FILTER)
+        const messages: WithParts[] = [
+            { info: { id: "m1", role: "user", time: 1 } as any, parts: [{ type: "text", text: "TASK: Write config.py\n<!-- OMO_INTERNAL_INITIATOR -->" }] },
+            { info: { id: "m2", role: "user", time: 2 } as any, parts: [{ type: "text", text: "TASK: Write tests\n<!-- OMO_INTERNAL_INITIATOR -->" }] },
+        ]
+        const config = { enabled: true, filters: { "omo-task-directive": { enabled: true } } }
+        applyMessageFilters(messages, config, makeLogger(), { sessionId: "s", isSubAgent: false })
+        assert.equal((messages[0].parts[0] as any).text, "")
+        assert.equal((messages[1].parts[0] as any).text, "TASK: Write tests\n<!-- OMO_INTERNAL_INITIATOR -->")
+    })
+
+    it("does not match TASK without OMO marker (avoids false positive)", () => {
+        registerMessageFilter(OMO_TASK_FILTER)
+        const messages: WithParts[] = [
+            { info: { id: "m1", role: "user", time: 1 } as any, parts: [{ type: "text", text: "TASK: Do something" }] },
+        ]
+        const config = { enabled: true, filters: { "omo-task-directive": { enabled: true } } }
+        const stats = applyMessageFilters(messages, config, makeLogger(), { sessionId: "s", isSubAgent: false })
+        assert.equal((messages[0].parts[0] as any).text, "TASK: Do something")
+        assert.equal(stats.partsFiltered, 0)
     })
 
     it("mode injection strips all occurrences", () => {


### PR DESCRIPTION
## Summary

- Add `keepLastOnly` property to `MessageFilter` interface for dedup-style filtering
- Two-phase `applyMessageFilters`: Phase 1 (immediate, forward), Phase 2 (keepLastOnly, reverse dedup)
- 4 new builtin OMO filters

## Filters

| Filter | Strategy | Pattern | ~Tokens saved |
|--------|----------|---------|---------------|
| `omo-todo-continuation` | keep last | `[SYSTEM DIRECTIVE: TODO CONTINUATION]` | ~120K |
| `omo-context` | keep last | `[CONTEXT]` / `CONTEXT:` | ~72K |
| `omo-task-directive` | keep last | `TASK:` / `## TASK` | ~8K |
| `omo-mode-injection` | strip all | `[search-mode]`, `[analyze-mode]`, `<ultrawork-mode>` | few K |

## DB Verification

Scanned 1180 OMO-injected parts across all sessions:
- 387 TODO CONTINUATION → only last survives
- 316 background-task notifications → already handled by `omo-system-reminder`
- 201 CONTEXT injections → only last survives
- 28 TASK directives → only last survives

**Zero false positives** on mixed content (3 messages with real user text preserved correctly).