### PR TITLE
release: v1.14.8-dev.1 — dev prerelease (7 PRs since v1.14.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,21 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.8-dev.1 — Dev Prerelease (7 PRs since v1.14.7)
+
+Dev prerelease covering PRs #238–#242. Published to `dev` npm tag for early testing.
+
+**PRs included**:
+- **#238** — E2E hardening: observation recording, T2 cadence regression scenario, consumed-call hiding scenario, auxiliary call filtering. 12 E2E scenarios (was 8).
+- **#232** — Refactor: remove dead `turnProtection` config + DCP migration code.
+- **#234** — Re-add `/acp stats` as `acp_status` wrapper.
+- **#239** — Pluggable message filter for third-party injection cleanup.
+- **#240** — Fix: splice orphan messages (only structural parts remain after consumed compress removal).
+- **#241** — System token breakdown in `acp_status` + nudge; hide context fill percentage from model; consolidate 4 duplicate estimations into 1 shared `estimateSystemPromptTokens()`.
+- **#242** — `keepLastOnly` dedup mechanism + 4 OMO builtin filters.
+
+**Install**: `opencode plugin opencode-acp@dev --global`
+
 ### v1.14.7 — Deduplicate HOW_TO_COMPRESS_RULES (PR #228)
 
 **Problem**: `HOW_TO_COMPRESS_RULES` (~1.2K tokens) was injected 3-4 times per nudge turn — once in the system prompt, 1-2 times in nudge templates (turn/iteration/context-limit), and again in the breakdown block. In non-maxLimit scenarios the suffix message alone contained the rules 2-3 times. This wasted 2.4-3.6K tokens per nudge turn. The duplication became visible in v1.14.6 which persists debug nudge text to chat UI.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,6 +446,21 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 ## 更新日志
 
+### v1.14.8-dev.1 — Dev 预发布（v1.14.7 以来 7 个 PR）
+
+Dev 预发布，涵盖 PR #238–#242。发布到 `dev` npm tag 供早期测试。
+
+**包含的 PR**：
+- **#238** — E2E 强化：观察记录、T2 节奏回归场景、consumed-call 隐藏场景、辅助调用过滤。E2E 场景 8→12 个。
+- **#232** — 重构：移除死代码 `turnProtection` 配置 + DCP 迁移代码。
+- **#234** — 重新添加 `/acp stats` 作为 `acp_status` 的封装。
+- **#239** — 可插拔消息过滤器，用于第三方注入清理。
+- **#240** — 修复：splice 孤儿消息（consumed compress 移除后仅剩结构化部分）。
+- **#241** — `acp_status` + nudge 中的系统 token 分类；隐藏上下文填充百分比；4 处重复估算整合为 1 个共享 `estimateSystemPromptTokens()`。
+- **#242** — `keepLastOnly` 去重机制 + 4 个 OMO 内置过滤器。
+
+**安装**：`opencode plugin opencode-acp@dev --global`
+
 ### v1.14.7 — 去重 HOW_TO_COMPRESS_RULES（PR #228）
 
 **问题**：`HOW_TO_COMPRESS_RULES`（~1.2K tokens）每次 nudge 注入重复 3-4 次——系统提示词 1 次、nudge 模板 1-2 次、breakdown 块 1 次。非 maxLimit 场景下 suffix 消息单独就包含 2-3 份规则。每次 nudge 浪费 2.4-3.6K tokens。v1.14.6 让 debug 模式持久化 nudge 文本到聊天界面后，重复变得可见。

--- a/devlog/2026-07-30_release-v1.14.8-dev/REQ.md
+++ b/devlog/2026-07-30_release-v1.14.8-dev/REQ.md
@@ -1,0 +1,33 @@
+# REQ: Dev Prerelease v1.14.8-dev.1
+
+## Objective
+
+Publish a dev prerelease covering the 7 PRs merged since v1.14.7 (master at f842e3f).
+
+## Scope
+
+Version: `1.14.8-dev.1` (contains `-` → CI publishes with `--tag dev`, GitHub Release marked as prerelease).
+
+**PRs included** (#238–#242):
+- #238 — E2E hardening (observation recording, T2 cadence regression, consumed-call hiding, auxiliary call filtering)
+- #232 — Refactor: remove dead turnProtection + DCP migration code
+- #234 — Re-add /acp stats as acp_status wrapper
+- #239 — Pluggable message filter for third-party injection cleanup
+- #240 — Fix: splice orphan messages with only structural parts after consumed compress removal
+- #241 — System token breakdown in acp_status + nudge; hide context fill; consolidate duplicate estimations
+- #242 — keepLastOnly dedup mechanism + 4 OMO builtin filters
+
+## Deliverables
+
+- [x] `package.json` version bumped to `1.14.8-dev.1`
+- [x] `README.md` changelog entry
+- [x] `README.zh-CN.md` changelog entry
+- [x] `devlog/2026-07-30_release-v1.14.8-dev/REQ.md` + `WORKLOG.md`
+- [ ] CI checks pass
+- [ ] PR created
+
+## Installation
+
+```bash
+opencode plugin opencode-acp@dev --global
+```

--- a/devlog/2026-07-30_release-v1.14.8-dev/WORKLOG.md
+++ b/devlog/2026-07-30_release-v1.14.8-dev/WORKLOG.md
@@ -1,0 +1,17 @@
+# WORKLOG: Dev Prerelease v1.14.8-dev.1
+
+## 2026-07-30
+
+### Release prep
+- Created worktree `/tmp/opencode-acp-release-v1.14.8-dev` on branch `2026-07-30_release-v1.14.8-dev` from master (`f842e3f`)
+- Bumped version: `1.14.7` → `1.14.8-dev.1`
+- Added changelog entries to `README.md` and `README.zh-CN.md`
+- Created devlog
+
+### Verification
+- npm view: latest=1.14.7, dev=1.13.9-dev.1 (stale — this release updates dev to current master)
+
+### Pending
+- Run CI checks locally
+- Commit, push, create PR
+- Human merges PR → CI auto-publishes to `dev` npm tag

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.7",
+    "version": "1.14.8-dev.1",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Dev prerelease covering 7 PRs merged since v1.14.7. Published to `dev` npm tag — no impact on `latest`/`stable` users.

## PRs Included

| PR | Description |
|----|-------------|
| #238 | E2E hardening: observation recording, T2 cadence regression, consumed-call hiding, auxiliary call filtering (8→12 scenarios) |
| #232 | Refactor: remove dead `turnProtection` config + DCP migration code |
| #234 | Re-add `/acp stats` as `acp_status` wrapper |
| #239 | Pluggable message filter for third-party injection cleanup |
| #240 | Fix: splice orphan messages with only structural parts after consumed compress removal |
| #241 | System token breakdown in `acp_status` + nudge; hide context fill %; consolidate 4 duplicate estimations into 1 shared `estimateSystemPromptTokens()` |
| #242 | `keepLastOnly` dedup mechanism + 4 OMO builtin filters |

## Dev Prerelease Details

- **Version**: `1.14.8-dev.1` (contains `-` → CI publishes with `--tag dev`, GitHub Release marked as prerelease)
- **npm tag**: `dev` (not `latest`)
- **Install**: `opencode plugin opencode-acp@dev --global`

## Checklist

- [x] Version bumped to `1.14.8-dev.1`
- [x] Changelog entries in `README.md` + `README.zh-CN.md`
- [x] Devlog created
- [x] CI checks pass (`./scripts/ci/check-pr.sh`)
- [x] No source code changes (release-only PR)

## After Merge

CI will automatically:
1. Detect release branch merge (`YYYY-MM-DD_release-v*`)
2. Create `v1.14.8-dev.1` tag
3. Build + test
4. Publish to npm with `--tag dev`
5. Create prerelease GitHub Release