### PR TITLE
release: v1.14.8-dev.2 — dev prerelease (2 PRs since dev.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,16 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.8-dev.2 — Dev Prerelease (2 PRs since v1.14.8-dev.1)
+
+Dev prerelease covering PRs #244–#245. Published to `dev` npm tag for early testing.
+
+**PRs included**:
+- **#245** — Fix: re-add HOW_TO_COMPRESS_RULES to nudge injection for high-attention summary guidance. v1.14.7 over-removed the rules from all 4 nudge locations (breakdown + 3 templates), leaving them only in system prompt. In long sessions, system prompt rules degrade due to "lost in the middle" effect — model needs rules at high attention (end of context) when nudge fires.
+- **#244** — Fix: acp_status hides consumed compress calls from PROTECTED list.
+
+**Install**: `opencode plugin opencode-acp@dev --global`
+
 ### v1.14.8-dev.1 — Dev Prerelease (7 PRs since v1.14.7)
 
 Dev prerelease covering PRs #238–#242. Published to `dev` npm tag for early testing.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,6 +446,16 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 ## 更新日志
 
+### v1.14.8-dev.2 — Dev 预发布（v1.14.8-dev.1 以来 2 个 PR）
+
+Dev 预发布，涵盖 PR #244–#245。发布到 `dev` npm tag 供早期测试。
+
+**包含的 PR**：
+- **#245** — 修复：重新将 HOW_TO_COMPRESS_RULES 加入 nudge 注入。v1.14.7 过度删除了所有 4 处 nudge 位置的规则（breakdown + 3 个模板），只保留在 system prompt。在长 session 中，system prompt 的规则因"lost in the middle"效应衰减——模型在 nudge 触发时需要规则在高注意力区（上下文末尾）。
+- **#244** — 修复：acp_status 隐藏 PROTECTED 列表中已消耗的 compress 调用。
+
+**安装**：`opencode plugin opencode-acp@dev --global`
+
 ### v1.14.8-dev.1 — Dev 预发布（v1.14.7 以来 7 个 PR）
 
 Dev 预发布，涵盖 PR #238–#242。发布到 `dev` npm tag 供早期测试。

--- a/devlog/2026-07-30_release-v1.14.8-dev.2/REQ.md
+++ b/devlog/2026-07-30_release-v1.14.8-dev.2/REQ.md
@@ -1,0 +1,28 @@
+# REQ: Dev Prerelease v1.14.8-dev.2
+
+## Objective
+
+Publish a dev prerelease covering the 2 PRs merged since v1.14.8-dev.1 (master at de1d99f).
+
+## Scope
+
+Version: `1.14.8-dev.2` (contains `-` → CI publishes with `--tag dev`, GitHub Release marked as prerelease).
+
+**PRs included** (#244–#245):
+- #244 — Fix: acp_status hides consumed compress calls from PROTECTED list
+- #245 — Fix: re-add HOW_TO_COMPRESS_RULES to nudge injection for high-attention summary guidance
+
+## Deliverables
+
+- [x] `package.json` version bumped to `1.14.8-dev.2`
+- [x] `README.md` changelog entry
+- [x] `README.zh-CN.md` changelog entry
+- [x] `devlog/2026-07-30_release-v1.14.8-dev.2/REQ.md` + `WORKLOG.md`
+- [ ] CI checks pass
+- [ ] PR created
+
+## Installation
+
+```bash
+opencode plugin opencode-acp@dev --global
+```

--- a/devlog/2026-07-30_release-v1.14.8-dev.2/WORKLOG.md
+++ b/devlog/2026-07-30_release-v1.14.8-dev.2/WORKLOG.md
@@ -1,0 +1,12 @@
+# WORKLOG: Dev Prerelease v1.14.8-dev.2
+
+## 2026-07-30
+
+### Release prep
+- Created worktree `/tmp/opencode-acp-release-v1.14.8-dev.2` on branch `2026-07-30_release-v1.14.8-dev.2` from github/master (`de1d99f`)
+- Bumped version: `1.14.8-dev.1` → `1.14.8-dev.2`
+- Added changelog entries to `README.md` and `README.zh-CN.md`
+- Created devlog
+
+### Verification
+- npm view: latest=1.14.7, dev=1.14.8-dev.1 (this release updates dev to dev.2)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.8-dev.1",
+    "version": "1.14.8-dev.2",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Dev prerelease covering 2 PRs merged since v1.14.8-dev.1. Published to `dev` npm tag — no impact on `latest`/`stable` users.

## PRs Included

| PR | Description |
|----|-------------|
| #245 | Fix: re-add HOW_TO_COMPRESS_RULES to nudge injection (v1.14.7 over-removed from all 4 nudge locations) |
| #244 | Fix: acp_status hides consumed compress calls from PROTECTED list |

## Dev Prerelease Details

- **Version**: `1.14.8-dev.2` (contains `-` → CI publishes with `--tag dev`)
- **npm tag**: `dev` (not `latest`)
- **Install**: `opencode plugin opencode-acp@dev --global`

## After Merge

CI automatically publishes to npm `dev` tag + creates prerelease GitHub Release.