### PR TITLE
release: v1.14.8-dev.3 — tool pair integrity fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,15 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.8-dev.3 — Dev Prerelease (1 PR since v1.14.8-dev.2)
+
+Dev prerelease covering PR #248. Published to `dev` npm tag for early testing.
+
+**PRs included**:
+- **#248** — Fix: auto-extend compression ranges to prevent splitting tool_use/tool_result pairs. When the model selects a compression boundary that falls between a tool call and its result, the orphaned tool_result references a non-existent tool_use_id → API rejection. New `adjustBoundariesForToolPairs` in `compress/search.ts` scans forward/backward (up to 20 messages) to include the matching pair. Excludes `compress` tool (force-protected) and only extends message boundaries (never block boundaries) to avoid tier misclassification. 11 tests.
+
+**Install**: `opencode plugin opencode-acp@dev --global`
+
 ### v1.14.8-dev.2 — Dev Prerelease (2 PRs since v1.14.8-dev.1)
 
 Dev prerelease covering PRs #244–#245. Published to `dev` npm tag for early testing.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,6 +446,15 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 ## 更新日志
 
+### v1.14.8-dev.3 — Dev 预发布（v1.14.8-dev.2 以来 1 个 PR）
+
+Dev 预发布，涵盖 PR #248。发布到 `dev` npm tag 供早期测试。
+
+**包含的 PR**：
+- **#248** — 修复：自动扩展压缩范围以防止拆分 tool_use/tool_result 配对。当模型选择的压缩边界落在 tool 调用与其结果之间时，孤立的 tool_result 引用不存在的 tool_use_id → API 拒绝。新增 `adjustBoundariesForToolPairs`（`compress/search.ts`）向前/向后扫描（最多 20 条消息）以包含匹配的配对。排除 `compress` 工具（强制保护）并仅扩展消息边界（从不扩展 block 边界）以避免层级错误分类。11 个测试。
+
+**安装**：`opencode plugin opencode-acp@dev --global`
+
 ### v1.14.8-dev.2 — Dev 预发布（v1.14.8-dev.1 以来 2 个 PR）
 
 Dev 预发布，涵盖 PR #244–#245。发布到 `dev` npm tag 供早期测试。

--- a/devlog/2026-07-30_release-v1.14.8-dev.3/REQ.md
+++ b/devlog/2026-07-30_release-v1.14.8-dev.3/REQ.md
@@ -1,0 +1,21 @@
+# REQ: Dev Prerelease v1.14.8-dev.3
+
+## Requirement
+
+Publish a dev prerelease (`dev` npm tag) to include PR #248 (tool pair integrity fix) since v1.14.8-dev.2.
+
+## Scope
+
+- Bump version to `1.14.8-dev.3`
+- Add changelog entries to `README.md` and `README.zh-CN.md`
+- Create devlog entry
+- CI auto-publishes with `--tag dev` (version contains `-`)
+
+## PRs Included
+
+- **#248** — Fix: auto-extend compression ranges to prevent splitting tool_use/tool_result pairs (Issue #247)
+
+## Out of Scope
+
+- No source code changes (release-only)
+- Stable release (v1.14.8) deferred until dev testing confirms

--- a/devlog/2026-07-30_release-v1.14.8-dev.3/WORKLOG.md
+++ b/devlog/2026-07-30_release-v1.14.8-dev.3/WORKLOG.md
@@ -1,0 +1,19 @@
+# WORKLOG: Dev Prerelease v1.14.8-dev.3
+
+## 2026-07-30
+
+### Release Prep
+
+- Created worktree `/tmp/opencode-acp-release-v1.14.8-dev.3` from `github/master` (`00cc3f7`)
+- Bumped `package.json` version: `1.14.8-dev.2` → `1.14.8-dev.3`
+- Added changelog entry to `README.md` (1 PR: #248)
+- Added changelog entry to `README.zh-CN.md` (1 PR: #248)
+- Created devlog `REQ.md` + `WORKLOG.md`
+
+### Verification
+
+- CI will run: pr-validation, test (22/24), build, e2e
+
+### Status
+
+- PR created, awaiting user merge

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.8-dev.2",
+    "version": "1.14.8-dev.3",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Dev prerelease `v1.14.8-dev.3` — published to `dev` npm tag.

### PRs included (since v1.14.8-dev.2)

- **#248** — Fix: auto-extend compression ranges to prevent splitting tool_use/tool_result pairs (Issue #247). New `adjustBoundariesForToolPairs` in `compress/search.ts`. 11 tests.

### Install

```bash
opencode plugin opencode-acp@dev --global
```

CI will auto-publish with `--tag dev` (version contains `-`).