### PR TITLE
release: v1.14.8 — stable release (10 PRs since v1.14.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,24 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.8 — Stable Release (10 PRs since v1.14.7)
+
+Stable release promoted from dev prereleases v1.14.8-dev.1 through v1.14.8-dev.3. Includes all fixes tested in the dev channel.
+
+**Highlights**:
+
+- **System token visibility** (#241): `acp_status` and nudge breakdown now show system prompt token proportion (5-15% of context). Consolidated 4 duplicate estimation algorithms into 1 shared `estimateSystemPromptTokens()` using the real Anthropic tokenizer.
+- **HOW_TO_COMPRESS_RULES re-added to nudge** (#245): v1.14.7 over-removed the compression rules from all nudge locations. In long sessions (8,000+ messages), the rules in the system prompt degrade due to "lost in the middle" effect — re-added to nudge for high-attention guidance when compression triggers.
+- **Tool pair integrity** (#248): Compression ranges that split tool_use/tool_result pairs caused API rejections. New `adjustBoundariesForToolPairs` auto-extends boundaries by callID matching.
+- **Pluggable message filters** (#239, #242): `keepLastOnly` dedup mechanism + 4 OMO builtin filters for cleaning up third-party (e.g. OMO) injected messages that accumulate duplicates.
+- **Orphan message splicing** (#240): When `hideConsumedCompressCalls` leaves only structural parts (step-finish, reasoning), the message is now spliced out instead of surviving as a 500-2000 token orphan.
+- **E2E hardening** (#238): Observation recording, T2 cadence regression scenario, consumed-call hiding scenario, auxiliary call filtering. 12 E2E scenarios (was 8).
+- **acp_status consumed compress hiding** (#244): Hides consumed compress calls from the PROTECTED list.
+
+**All PRs included**: #238 (E2E hardening), #232 (remove dead turnProtection/DCP migration), #234 (re-add /acp stats), #239 (pluggable message filter), #240 (orphan splice), #241 (system tokens), #242 (keepLastOnly + OMO filters), #244 (acp_status consumed compress), #245 (HOW_TO_COMPRESS_RULES re-add), #248 (tool pair integrity).
+
+**Install**: `opencode plugin opencode-acp@stable --global`
+
 ### v1.14.8-dev.3 — Dev Prerelease (1 PR since v1.14.8-dev.2)
 
 Dev prerelease covering PR #248. Published to `dev` npm tag for early testing.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -480,6 +480,24 @@ Dev 预发布，涵盖 PR #238–#242。发布到 `dev` npm tag 供早期测试�
 
 **安装**：`opencode plugin opencode-acp@dev --global`
 
+### v1.14.8 — 正式版（v1.14.7 以来 10 个 PR）
+
+正式版，从 dev 预发布 v1.14.8-dev.1 至 v1.14.8-dev.3 提升而来。包含所有在 dev 通道测试过的修复。
+
+**亮点**：
+
+- **系统 token 可见性**（#241）：`acp_status` 和 nudge breakdown 现在显示系统 prompt token 占比（上下文的 5-15%）。将 4 处重复的估算算法整合为 1 个共享 `estimateSystemPromptTokens()`，使用真正的 Anthropic 分词器。
+- **HOW_TO_COMPRESS_RULES 重新加入 nudge**（#245）：v1.14.7 过度删除了所有 nudge 位置的压缩规则。在长 session（8000+ 消息）中，system prompt 中的规则因"lost in the middle"效应衰减——重新加入 nudge 以在压缩触发时提供高注意力区指导。
+- **工具配对完整性**（#248）：压缩范围拆分 tool_use/tool_result 配对会导致 API 拒绝。新增 `adjustBoundariesForToolPairs` 按 callID 匹配自动扩展边界。
+- **可插拔消息过滤器**（#239, #242）：`keepLastOnly` 去重机制 + 4 个 OMO 内置过滤器，用于清理第三方注入消息的重复累积。
+- **孤儿消息清理**（#240）：`hideConsumedCompressCalls` 仅剩结构化部分时（step-finish、reasoning），消息现在被 splice 掉，不再作为 500-2000 token 孤儿存活。
+- **E2E 强化**（#238）：观察记录、T2 节奏回归场景、consumed-call 隐藏场景、辅助调用过滤。E2E 场景 8→12 个。
+- **acp_status 隐藏已消耗 compress**（#244）：从 PROTECTED 列表中隐藏已消耗的 compress 调用。
+
+**包含的所有 PR**：#238（E2E 强化）、#232（移除死代码 turnProtection/DCP 迁移）、#234（重新添加 /acp stats）、#239（可插拔消息过滤器）、#240（孤儿消息清理）、#241（系统 token）、#242（keepLastOnly + OMO 过滤器）、#244（acp_status 已消耗 compress）、#245（HOW_TO_COMPRESS_RULES 重新加入）、#248（工具配对完整性）。
+
+**安装**：`opencode plugin opencode-acp@stable --global`
+
 ### v1.14.7 — 去重 HOW_TO_COMPRESS_RULES（PR #228）
 
 **问题**：`HOW_TO_COMPRESS_RULES`（~1.2K tokens）每次 nudge 注入重复 3-4 次——系统提示词 1 次、nudge 模板 1-2 次、breakdown 块 1 次。非 maxLimit 场景下 suffix 消息单独就包含 2-3 份规则。每次 nudge 浪费 2.4-3.6K tokens。v1.14.6 让 debug 模式持久化 nudge 文本到聊天界面后，重复变得可见。

--- a/devlog/2026-07-30_release-v1.14.8/REQ.md
+++ b/devlog/2026-07-30_release-v1.14.8/REQ.md
@@ -1,0 +1,25 @@
+# REQ: Stable Release v1.14.8
+
+## Requirement
+
+Promote dev prereleases v1.14.8-dev.1 through v1.14.8-dev.3 to stable release v1.14.8.
+
+## Scope
+
+- Bump version to `1.14.8` (remove `-dev.3` suffix)
+- Add comprehensive changelog to `README.md` and `README.zh-CN.md`
+- Create devlog entry
+- CI auto-publishes with `--tag latest` (version has no `-`)
+
+## PRs Included (10 code PRs since v1.14.7)
+
+- #232 — Remove dead turnProtection config + DCP migration
+- #234 — Re-add /acp stats as acp_status wrapper
+- #238 — E2E hardening (12 scenarios, observation recording)
+- #239 — Pluggable message filter for third-party injection cleanup
+- #240 — Orphan message splicing (structural-only parts)
+- #241 — System token breakdown + hide context fill %
+- #242 — keepLastOnly dedup + OMO builtin filters
+- #244 — acp_status hides consumed compress from PROTECTED list
+- #245 — Re-add HOW_TO_COMPRESS_RULES to nudge
+- #248 — Tool pair integrity (auto-extend ranges)

--- a/devlog/2026-07-30_release-v1.14.8/WORKLOG.md
+++ b/devlog/2026-07-30_release-v1.14.8/WORKLOG.md
@@ -1,0 +1,19 @@
+# WORKLOG: Stable Release v1.14.8
+
+## 2026-07-30
+
+### Release Prep
+
+- Created worktree `/tmp/opencode-acp-release-v1.14.8` from `github/master` (`fd05241`)
+- Bumped `package.json` version: `1.14.8-dev.3` → `1.14.8`
+- Added comprehensive changelog to `README.md` (10 PRs)
+- Added changelog to `README.zh-CN.md`
+- Created devlog `REQ.md` + `WORKLOG.md`
+
+### Verification
+
+- CI will run: pr-validation, test (22/24), build, e2e
+
+### Status
+
+- PR created, awaiting user merge

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.8-dev.3",
+    "version": "1.14.8",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Stable release **v1.14.8** — promoted from dev prereleases v1.14.8-dev.1 through v1.14.8-dev.3.

### 10 PRs included

| PR | Description |
|----|-------------|
| #232 | Remove dead turnProtection config + DCP migration code |
| #234 | Re-add /acp stats as acp_status wrapper |
| #238 | E2E hardening (12 scenarios, observation recording, auxiliary filtering) |
| #239 | Pluggable message filter for third-party injection cleanup |
| #240 | Orphan message splicing (structural-only parts after consumed compress) |
| #241 | System token breakdown in acp_status + nudge; hide context fill %; consolidate 4 duplicate estimations |
| #242 | keepLastOnly dedup + 4 OMO builtin filters |
| #244 | acp_status hides consumed compress from PROTECTED list |
| #245 | Re-add HOW_TO_COMPRESS_RULES to nudge injection |
| #248 | Tool pair integrity (auto-extend ranges to prevent splitting tool_use/tool_result) |

### Install

```bash
opencode plugin opencode-acp@stable --global
```

CI will auto-publish with `--tag latest` (version has no `-`).