### PR TITLE
promote: stable v1.14.8 — stable tag update

### DIFF
--- a/devlog/2026-07-31_promote-stable-v1.14.8/REQ.md
+++ b/devlog/2026-07-31_promote-stable-v1.14.8/REQ.md
@@ -1,0 +1,10 @@
+# REQ: Promote v1.14.8 to npm `stable` tag
+
+## Problem
+npm `stable` tag is still at `1.14.7` while `latest` is at `1.14.8`. Users installing via `opencode-acp@stable` get the old version.
+
+## Solution
+Create a promote-stable PR. On merge, CI runs `npm dist-tag add opencode-acp@1.14.8 stable`.
+
+## Rationale
+v1.14.8 has been on `latest` since 2026-07-30 and validated in production. Promoting to `stable` makes it available to conservative users.

--- a/devlog/2026-07-31_promote-stable-v1.14.8/WORKLOG.md
+++ b/devlog/2026-07-31_promote-stable-v1.14.8/WORKLOG.md
@@ -1,0 +1,10 @@
+# WORKLOG: Promote v1.14.8 to npm `stable` tag
+
+## Steps
+1. Created branch `2026-07-31_promote-stable-v1.14.8` from master (`e637f57`)
+2. Created devlog REQ.md
+3. Commit message: `promote: stable v1.14.8 — stable tag update`
+4. On merge, CI detects promote-stable pattern → runs `npm dist-tag add opencode-acp@1.14.8 stable`
+
+## No code changes
+This is a tag promotion only. No source code, tests, or version numbers modified.


### PR DESCRIPTION
## Purpose

Promote `opencode-acp@1.14.8` to the npm `stable` tag.

## Current npm dist-tags
```
latest: 1.14.8  ← already published
stable: 1.14.7  ← stale, needs update
dev:    1.14.8-dev.3
```

## What CI does on merge

Detects `promote: stable v1.14.8` commit pattern → runs:
```bash
npm dist-tag add opencode-acp@1.14.8 stable
```

No code changes. No version bump. Tag promotion only.

## v1.14.8 changelog (since v1.14.7)
- 10 PRs: system token visibility, HOW_TO_COMPRESS_RULES re-added to nudge, tool pair integrity, pluggable message filters, orphan splice, E2E hardening, filterRecommendedRanges fix (#252 excluded — separate PR)