### PR TITLE
release: v1.14.8-dev.4 — issue #251 fix + nudge loop fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,15 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.8-dev.4 — Dev Prerelease (1 PR since v1.14.8-dev.3)
+
+Dev prerelease covering PR #252. Published to `dev` npm tag for early testing.
+
+**PRs included**:
+- **#252** — Two fixes: (1) **Issue #251**: `filterRecommendedRanges` suppressed ALL recommendations when compressible content was below 5% of modelContextLimit (50K at 1M context). Rewrote to always show all ranges with `dangerous: true` on the last segment. Simplified `RangeFilterOptions`. (2) **Nudge loop fix**: `lastNudgeShownTokens` was reset to `undefined` on `nothingToCompress`, causing `growthReference` to fall back to stale session-start baseline → nudges firing every turn. Removed the reset. Also fixed growth display to use `lastNudgeShownTokens ?? lastPerMessageNudgeTokens` matching the actual decision logic. Oracle + Explore review: both APPROVE.
+
+**Install**: `opencode plugin opencode-acp@dev --global`
+
 ### v1.14.8 — Stable Release (10 PRs since v1.14.7)
 
 Stable release promoted from dev prereleases v1.14.8-dev.1 through v1.14.8-dev.3. Includes all fixes tested in the dev channel.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,6 +446,15 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 ## 更新日志
 
+### v1.14.8-dev.4 — Dev 预发布（v1.14.8-dev.3 以来 1 个 PR）
+
+Dev 预发布，涵盖 PR #252。发布到 `dev` npm tag 供早期测试。
+
+**包含的 PR**：
+- **#252** — 两个修复：(1) **Issue #251**：`filterRecommendedRanges` 在可压缩内容低于 modelContextLimit 的 5%（1M 上下文为 50K）时抑制所有推荐。重写为始终显示所有范围，最后一段标记 `dangerous: true`。简化 `RangeFilterOptions`。(2) **Nudge 循环修复**：`nothingToCompress` 时 `lastNudgeShownTokens` 被重置为 `undefined`，导致 `growthReference` 回退到 session 开始时的 stale baseline → 每轮都触发 nudge。移除该重置。同时修复增长显示使用 `lastNudgeShownTokens ?? lastPerMessageNudgeTokens`，与实际决策逻辑一致。Oracle + Explore Review：均通过。
+
+**安装**：`opencode plugin opencode-acp@dev --global`
+
 ### v1.14.8-dev.3 — Dev 预发布（v1.14.8-dev.2 以来 1 个 PR）
 
 Dev 预发布，涵盖 PR #248。发布到 `dev` npm tag 供早期测试。

--- a/devlog/2026-07-31_release-v1.14.8-dev.4/REQ.md
+++ b/devlog/2026-07-31_release-v1.14.8-dev.4/REQ.md
@@ -1,0 +1,11 @@
+# REQ: v1.14.8-dev.4 Dev Prerelease
+
+## Goal
+
+Publish dev prerelease v1.14.8-dev.4 containing PR #252 (Issue #251 fix + nudge loop fix).
+
+## Scope
+
+- PR #252: filterRecommendedRanges rewrite (remove context-relative suppression) + lastNudgeShownTokens loop fix + growth display alignment
+- Version bump to `1.14.8-dev.4` (CI publishes with `--tag dev`)
+- Changelog entries in README.md and README.zh-CN.md

--- a/devlog/2026-07-31_release-v1.14.8-dev.4/WORKLOG.md
+++ b/devlog/2026-07-31_release-v1.14.8-dev.4/WORKLOG.md
@@ -1,0 +1,9 @@
+# WORKLOG: v1.14.8-dev.4 Dev Prerelease
+
+## Steps
+
+1. Created worktree from master `d087522` (PR #252 merged)
+2. Bumped version to `1.14.8-dev.4` in package.json
+3. Added changelog entries to README.md and README.zh-CN.md
+4. Created devlog REQ.md + WORKLOG.md
+5. Committed, pushed, created PR

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.8",
+    "version": "1.14.8-dev.4",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Dev prerelease v1.14.8-dev.4. CI will publish to npm `dev` tag on merge.

**1 PR since v1.14.8-dev.3**:
- **#252** — Two fixes: (1) Issue #251: `filterRecommendedRanges` suppressed ALL recommendations when compressible content was below 5% of modelContextLimit (50K at 1M context). Rewrote to always show all ranges. (2) Nudge loop fix: `lastNudgeShownTokens` reset to `undefined` on `nothingToCompress` caused `growthReference` to fall back to stale baseline → nudges every turn.

**Install**: `opencode plugin opencode-acp@dev --global`