### PR TITLE
chore: bump context-compress-algorithms to 1.3.0

### DIFF
--- a/devlog/2026-08-01_bump-cc-alg-1.3.0/REQ.md
+++ b/devlog/2026-08-01_bump-cc-alg-1.3.0/REQ.md
@@ -1,0 +1,16 @@
+# REQ: Bump context-compress-algorithms to 1.3.0
+
+## Problem
+
+cc-alg 1.3.0 ships holistic TIER2/TIER3 compression prompts (summarize by theme,
+not per-block). The old per-block format caused length overflow when compressing
+70+ T1 blocks (issue #256). ACP needs to consume the updated prompts.
+
+## Solution
+
+Update `context-compress-algorithms` dependency from 1.2.1 to 1.3.0.
+
+## Scope
+
+- `package.json` — version bump
+- `package-lock.json` — lockfile update

--- a/devlog/2026-08-01_bump-cc-alg-1.3.0/WORKLOG.md
+++ b/devlog/2026-08-01_bump-cc-alg-1.3.0/WORKLOG.md
@@ -1,0 +1,12 @@
+# WORKLOG: Bump context-compress-algorithms to 1.3.0
+
+## Changes
+
+1. `package.json`: `context-compress-algorithms` 1.2.1 → 1.3.0
+2. `package-lock.json`: updated
+
+## Verification
+
+- `npm run build`: ✓ (383.94 KB)
+- `npm run typecheck`: ✓
+- `npm test`: 942 tests pass ✓

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-acp",
-    "version": "1.14.7",
+    "version": "1.14.8-dev.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-acp",
-            "version": "1.14.7",
+            "version": "1.14.8-dev.4",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@anthropic-ai/tokenizer": "^0.0.4",
@@ -17,7 +17,7 @@
             "devDependencies": {
                 "@opencode-ai/plugin": "^1.4.3",
                 "@types/node": "^25.5.0",
-                "context-compress-algorithms": "1.2.1",
+                "context-compress-algorithms": "1.3.0",
                 "fast-check": "^4.9.0",
                 "prettier": "^3.8.1",
                 "tsup": "^8.5.1",
@@ -1132,9 +1132,9 @@
             }
         },
         "node_modules/context-compress-algorithms": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/context-compress-algorithms/-/context-compress-algorithms-1.2.1.tgz",
-            "integrity": "sha512-xmPQau3CB3g4ohDp+JFvS9TfMWkMvkv1j7i1jcB8d/2m+UOjzjAAbNnTF64tigpY+sCNclfEN6uaLLT8N+EXSQ==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/context-compress-algorithms/-/context-compress-algorithms-1.3.0.tgz",
+            "integrity": "sha512-VrlDs4RLDEm4NxiUbN22bnCoMTokA74cI97oGwnEdpyE8Eu+6puIMJnSHTnWSdeCOltWQyLJCqZKA99SPMCv0Q==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "devDependencies": {
         "@opencode-ai/plugin": "^1.4.3",
         "@types/node": "^25.5.0",
-        "context-compress-algorithms": "1.2.1",
+        "context-compress-algorithms": "1.3.0",
         "fast-check": "^4.9.0",
         "prettier": "^3.8.1",
         "tsup": "^8.5.1",


### PR DESCRIPTION
## Summary

Bumps `context-compress-algorithms` from 1.2.1 → 1.3.0.

cc-alg 1.3.0 ships holistic TIER2/TIER3 compression prompts — summarize by theme instead of per-block. The old per-block format caused length overflow when compressing 70+ T1 blocks (issue #256).

## Changes

- `package.json`: dependency version bump
- No source code changes needed (prompts are consumed from the dependency)

## Verification

- `npm run build`: ✓ (383.94 KB)
- `npm run typecheck`: ✓
- `npm test`: 942 tests pass ✓