### PR TITLE
release: v1.14.8-dev.5 — cc-alg 1.3.0 bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,15 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.8-dev.5 — Dev Prerelease (1 PR since v1.14.8-dev.4)
+
+Dev prerelease covering PR #257. Published to `dev` npm tag for early testing.
+
+**PRs included**:
+- **#257** — Bump `context-compress-algorithms` from 1.2.1 to 1.3.0. cc-alg 1.3.0 ships holistic TIER2/TIER3 compression prompts — summarize by theme instead of per-block. The old per-block format (Source header + 3-5 bullets + 50-150 tokens per block) caused length overflow when compressing 70+ T1 blocks (~30K chars exceeding `maxSummaryLengthHard`). No source code changes needed (prompts consumed from dependency).
+
+**Install**: `opencode plugin opencode-acp@dev --global`
+
 ### v1.14.8-dev.4 — Dev Prerelease (1 PR since v1.14.8-dev.3)
 
 Dev prerelease covering PR #252. Published to `dev` npm tag for early testing.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,6 +446,15 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 ## 更新日志
 
+### v1.14.8-dev.5 — Dev 预发布（v1.14.8-dev.4 以来 1 个 PR）
+
+Dev 预发布，涵盖 PR #257。发布到 `dev` npm tag 供早期测试。
+
+**包含的 PR**：
+- **#257** — 升级 `context-compress-algorithms` 从 1.2.1 到 1.3.0。cc-alg 1.3.0 提供整体式 TIER2/TIER3 压缩提示——按主题综合而非逐块处理。旧的逐块格式（Source 头 + 每块 3-5 条 + 每块 50-150 tokens）在压缩 70+ 个 T1 块时导致长度溢出（~30K 字符超过 `maxSummaryLengthHard`）。无需源码修改（提示从依赖中获取）。
+
+**安装**: `opencode plugin opencode-acp@dev --global`
+
 ### v1.14.8-dev.4 — Dev 预发布（v1.14.8-dev.3 以来 1 个 PR）
 
 Dev 预发布，涵盖 PR #252。发布到 `dev` npm tag 供早期测试。

--- a/devlog/2026-08-01_release-v1.14.8-dev.5/REQ.md
+++ b/devlog/2026-08-01_release-v1.14.8-dev.5/REQ.md
@@ -1,0 +1,25 @@
+# REQ — v1.14.8-dev.5 Release
+
+## Summary
+
+Dev prerelease bumping `context-compress-algorithms` from 1.2.1 to 1.3.0.
+
+## Motivation
+
+cc-alg 1.3.0 ships holistic TIER2/TIER3 compression prompts that summarize by
+theme instead of per-block. This fixes the length overflow issue when compressing
+70+ T1 blocks (Issue #256) — the old per-block format produced ~30K char summaries
+that exceeded `maxSummaryLengthHard` (20000).
+
+## Scope
+
+- PR #257: bump cc-alg dependency from 1.2.1 → 1.3.0
+- No source code changes (prompts consumed from dependency)
+- Dev prerelease for early testing on `dev` npm tag
+
+## Acceptance Criteria
+
+- [x] Version bumped to `1.14.8-dev.5`
+- [x] README.md + README.zh-CN.md changelog updated
+- [x] CI passes (5/5 checks)
+- [x] PR created

--- a/devlog/2026-08-01_release-v1.14.8-dev.5/WORKLOG.md
+++ b/devlog/2026-08-01_release-v1.14.8-dev.5/WORKLOG.md
@@ -1,0 +1,18 @@
+# WORKLOG — v1.14.8-dev.5 Release
+
+## 2026-08-01
+
+1. Created release branch `2026-08-01_release-v1.14.8-dev.5` from master `0f8898e`
+2. Bumped `package.json` version 1.14.8-dev.4 → 1.14.8-dev.5
+3. Added changelog entries to README.md and README.zh-CN.md
+4. PR #257 (cc-alg 1.3.0 bump) already merged — this is the sole new PR since dev.4
+5. Verified: no source changes needed, cc-alg 1.3.0 prompts consumed from dependency
+6. Committed, pushed, created PR
+
+## Notes
+
+- cc-alg 1.3.0 was manually published to npm (cc-alg repo has no auto-publish CI)
+- The TIER2/TIER3 prompt rewrite in cc-alg 1.3.0 fixes Issue #256 (length overflow
+  when compressing 70+ T1 blocks)
+- No dual-agent code review needed — this is a dependency version bump with no
+  source code changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.8-dev.4",
+    "version": "1.14.8-dev.5",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Dev prerelease bumping `context-compress-algorithms` from 1.2.1 to 1.3.0.

cc-alg 1.3.0 ships holistic TIER2/TIER3 compression prompts — summarize by theme instead of per-block. The old per-block format (Source header + 3-5 bullets + 50-150 tokens per block) caused length overflow when compressing 70+ T1 blocks (~30K chars exceeding `maxSummaryLengthHard`). Issue #256.

No source code changes needed (prompts consumed from dependency).

**Install**: `opencode plugin opencode-acp@dev --global`