### PR TITLE
docs: document multi-entry compress format in system prompt and T2/T3 nudge

### DIFF
--- a/devlog/2026-08-01_t2-batch-suggestions/REQ.md
+++ b/devlog/2026-08-01_t2-batch-suggestions/REQ.md
@@ -1,0 +1,26 @@
+# REQ: Document multi-entry compress format for block-based compression
+
+## Problem
+
+The compress tool supports two usage modes: single entry and multiple entries
+(`content` array). The system prompt already documented both for message-based
+compression, but only showed single-entry for block-based (T2/T3) compression.
+The T2/T3 trigger nudge also only showed single-entry.
+
+When 70+ T1 blocks accumulated (issue #256), the model only knew the single-entry
+format and tried to compress everything into one summary — risking
+`maxSummaryLengthHard` overflow.
+
+## Solution
+
+Document both formats in two places:
+
+1. System prompt (`system.ts`): add multi-entry example to MULTI-TIER section
+2. T2/T3 trigger nudge (`inject.ts`): add multi-entry format alongside single-entry
+
+No threshold hints — the model decides how to split based on block sizes and topics.
+
+## Scope
+
+- `lib/prompts/system.ts`: add multi-entry format example
+- `lib/messages/inject/inject.ts`: add multi-entry format to tier trigger text

--- a/devlog/2026-08-01_t2-batch-suggestions/WORKLOG.md
+++ b/devlog/2026-08-01_t2-batch-suggestions/WORKLOG.md
@@ -1,0 +1,23 @@
+# WORKLOG: Document multi-entry compress format for block-based compression
+
+## Changes
+
+1. `lib/prompts/system.ts`: Added multi-entry format example to MULTI-TIER
+   COMPRESSION section. Now shows both single-entry and multi-entry formats
+   for block-based compression.
+
+2. `lib/messages/inject/inject.ts`: Added multi-entry format to T2/T3 trigger
+   nudge text. The nudge now shows both formats alongside each other so the
+   model knows it can use multiple content entries at trigger time.
+
+## Iteration history
+
+- v1: Pre-computed batch boundaries via `buildTierBatches()` — over-engineered
+- v2: Conditional multi-entry format in T2/T3 trigger (threshold 15+) — unnecessary hinting
+- v3: Just document in system prompt — user pointed out nudge also needs it
+- v4 (final): Document both formats in system prompt AND nudge, no threshold hints
+
+## Verification
+
+- typecheck: clean
+- tests: 942 pass (no logic changes, prompt-only)

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -471,7 +471,7 @@ export const injectCompressNudges = (
                 .join("\n")
             const extraCount = candidates.length > 10 ? `\n...and ${candidates.length - 10} more` : ""
 
-            const tierText = `\n\n[Tier ${tc.triggerTier} Trigger] ${sourceTier} summaries accumulated (${fmt(candidateTokens)} tokens across ${candidates.length} blocks). ${action} them to free context.\n\nTarget blocks (oldest first):\n${blockList}${extraCount}\n\nCompress range: \`content: [{ startId: "b${firstBlock.blockId}", endId: "b${lastBlock.blockId}", summary: "..." }]\`\n\n${rules}`
+            const tierText = `\n\n[Tier ${tc.triggerTier} Trigger] ${sourceTier} summaries accumulated (${fmt(candidateTokens)} tokens across ${candidates.length} blocks). ${action} them to free context.\n\nTarget blocks (oldest first):\n${blockList}${extraCount}\n\nCompress range: \`content: [{ startId: "b${firstBlock.blockId}", endId: "b${lastBlock.blockId}", summary: "..." }]\`\nMultiple entries create separate blocks: \`content: [{ startId: "b${firstBlock.blockId}", endId: "b...", summary: "..." }, { startId: "b...", endId: "b${lastBlock.blockId}", summary: "..." }]\`\n\n${rules}`
 
             appendToLastTextPart(suffixMessage, tierText)
             shouldInject = true

--- a/lib/prompts/system.ts
+++ b/lib/prompts/system.ts
@@ -65,7 +65,7 @@ Summaries accumulate as the session grows. When tier-1 summaries pile up, the sy
 - Tier 2: Distillation of old tier-1 block summaries. Uses TIER 2 DISTILLATION rules (decisions/outcomes only, drop paths/code/process).
 - Tier 3: Ultra-condensation of tier-2 summaries. Uses TIER 3 CONDENSATION rules (bare facts, 1-3 lines per block).
 
-To compress blocks: use block IDs as boundaries: \`compress({ content: [{ startId: "b3", endId: "b15", summary: "..." }] })\`. This deactivates the consumed blocks and creates a new higher-tier block. The system prompt at the trigger tells you which rules to follow.
+To compress blocks: use block IDs as boundaries: \`compress({ content: [{ startId: "b3", endId: "b15", summary: "..." }] })\`. Multiple entries create separate blocks: \`compress({ content: [{ startId: "b3", endId: "b10", summary: "..." }, { startId: "b11", endId: "b20", summary: "..." }] })\`. This deactivates the consumed blocks and creates a new higher-tier block per entry. The system prompt at the trigger tells you which rules to follow.
 
 If you are unsure which \`mNNNNN\` refs are still compressible, or which blocks have already consumed which ranges, call \`acp_status\` first. It returns the visible context breakdown and the compressed block list.
 


### PR DESCRIPTION
## Summary

The compress tool supports two usage modes: single entry and multiple entries (`content` array). The system prompt already documented both for message-based compression, but only showed single-entry for block-based (T2/T3) compression. The T2/T3 trigger nudge also only showed single-entry.

When 70+ T1 blocks accumulated (issue #256), the model only knew the single-entry format and tried to compress everything into one summary — risking `maxSummaryLengthHard` overflow.

## Fix

Document both formats in two places:

1. **System prompt** (`system.ts`): Added multi-entry example to MULTI-TIER COMPRESSION section
2. **T2/T3 trigger nudge** (`inject.ts`): Added multi-entry format alongside the single-entry suggestion

No threshold hints — the model decides how to split based on block sizes and topics.

## Files

- `lib/prompts/system.ts`: added batch format example (1 line)
- `lib/messages/inject/inject.ts`: added multi-entry format to tier trigger text (1 line)

No code logic changes. 942 tests pass.