### PR TITLE
release: v1.14.9 — filterRecommendedRanges fix, cc-alg 1.3.0, multi-entry compress docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,17 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.9 — Stable Release (3 PRs since v1.14.8)
+
+Stable release with nudge loop fix, holistic T2/T3 compression prompts, and multi-entry compress format documentation.
+
+**PRs included**:
+- **#252** — Two fixes: (1) **Issue #251**: `filterRecommendedRanges` suppressed ALL recommendations when compressible content was below 5% of modelContextLimit. Rewrote to always show all ranges. (2) **Nudge loop fix**: `lastNudgeShownTokens` reset to `undefined` on `nothingToCompress` caused nudges firing every turn.
+- **#257** — Bump `context-compress-algorithms` 1.2.1 → 1.3.0. Holistic TIER2/TIER3 prompts — summarize by theme instead of per-block, fixing length overflow with 70+ T1 blocks (issue #256).
+- **#259** — Document multi-entry compress format in system prompt and T2/T3 nudge. The compress tool already supported `content` arrays (PR #156), but only single-entry was shown for block-based compression.
+
+**Install**: `opencode plugin opencode-acp@stable --global`
+
 ### v1.14.9-dev.1 — Dev Prerelease (1 PR since v1.14.8-dev.5)
 
 Dev prerelease covering PR #259. Published to `dev` npm tag for early testing.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,6 +446,17 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 ## 更新日志
 
+### v1.14.9 — 正式版（v1.14.8 以来 3 个 PR）
+
+正式版发布，包含 nudge 循环修复、整体式 T2/T3 压缩提示词、多条目 compress 格式文档。
+
+**包含的 PR**：
+- **#252** — 两个修复：(1) **Issue #251**：`filterRecommendedRanges` 在可压缩内容低于 modelContextLimit 的 5% 时抑制所有推荐。重写为始终显示所有范围。(2) **Nudge 循环修复**：`lastNudgeShownTokens` 在 `nothingToCompress` 时被重置为 `undefined`，导致每轮都触发 nudge。
+- **#257** — 升级 `context-compress-algorithms` 1.2.1 → 1.3.0。整体式 TIER2/TIER3 提示词 — 按主题综述而非逐块处理，修复 70+ T1 块时的长度溢出问题（issue #256）。
+- **#259** — 在系统提示词和 T2/T3 nudge 中文档化多条目 compress 格式。compress 工具已支持 `content` 数组（PR #156），但块压缩只展示了单条目格式。
+
+**安装**：`opencode plugin opencode-acp@stable --global`
+
 ### v1.14.9-dev.1 — Dev 预发布（v1.14.8-dev.5 以来 1 个 PR）
 
 Dev 预发布，涵盖 PR #259。发布到 `dev` npm tag 供早期测试。

--- a/devlog/2026-08-02_release-v1.14.9/REQ.md
+++ b/devlog/2026-08-02_release-v1.14.9/REQ.md
@@ -1,0 +1,21 @@
+# REQ: Release v1.14.9
+
+## Goal
+
+Stable release v1.14.9 covering 3 PRs since v1.14.8.
+
+## PRs Included
+
+1. **#252** — fix: filterRecommendedRanges suppresses all + nudge loop (issue #251)
+2. **#257** — chore: cc-alg 1.3.0 bump (holistic T2/T3 prompts)
+3. **#259** — docs: multi-entry compress format in system prompt + nudge
+
+## Checklist
+
+- [x] Bump version in package.json (1.14.8-dev.5 → 1.14.9)
+- [x] Add changelog to README.md
+- [x] Add changelog to README.zh-CN.md
+- [x] Create devlog entry
+- [ ] Commit, push, create PR
+- [ ] Wait for CI to pass
+- [ ] Report PR URL to user (human merges)

--- a/devlog/2026-08-02_release-v1.14.9/WORKLOG.md
+++ b/devlog/2026-08-02_release-v1.14.9/WORKLOG.md
@@ -1,0 +1,15 @@
+# WORKLOG: Release v1.14.9
+
+## Steps
+
+1. Created worktree `/tmp/opencode-acp-release-v1.14.9` on branch `2026-08-02_release-v1.14.9`
+2. Linked node_modules from main repo
+3. Bumped `package.json` version: `1.14.8-dev.5` → `1.14.9`
+4. Added changelog entry to `README.md` (3 PRs: #252, #257, #259)
+5. Added changelog entry to `README.zh-CN.md` (3 PRs: #252, #257, #259)
+6. Created devlog entry
+
+## Verification
+
+- Stable version (no `-` suffix) → CI publishes to `latest` tag
+- 3 PRs since v1.14.8: #252 (filterRecommendedRanges + nudge loop), #257 (cc-alg 1.3.0), #259 (multi-entry compress docs)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.9-dev.1",
+    "version": "1.14.9",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Stable release v1.14.9 covering 3 PRs since v1.14.8.

### PRs Included

1. **#252** — Two fixes: (1) **Issue #251**: `filterRecommendedRanges` suppressed ALL recommendations when compressible content was below 5% of modelContextLimit. Rewrote to always show all ranges. (2) **Nudge loop fix**: `lastNudgeShownTokens` reset to `undefined` on `nothingToCompress` caused nudges firing every turn.
2. **#257** — Bump `context-compress-algorithms` 1.2.1 → 1.3.0. Holistic TIER2/TIER3 prompts — summarize by theme instead of per-block, fixing length overflow with 70+ T1 blocks (issue #256).
3. **#259** — Document multi-entry compress format in system prompt and T2/T3 nudge. The compress tool already supported `content` arrays (PR #156), but only single-entry was shown for block-based compression.

### Changes

- `package.json`: version `1.14.8-dev.5` → `1.14.9`
- `README.md`: changelog entry added
- `README.zh-CN.md`: changelog entry added
- `devlog/2026-08-02_release-v1.14.9/`: REQ.md + WORKLOG.md

### Version Type

Stable release (no `-` suffix) → CI publishes to `latest` npm tag.