### PR TITLE
release: v1.14.9-dev.1 — multi-entry compress format docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,15 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.9-dev.1 — Dev Prerelease (1 PR since v1.14.8-dev.5)
+
+Dev prerelease covering PR #259. Published to `dev` npm tag for early testing.
+
+**PRs included**:
+- **#259** — Document multi-entry compress format in system prompt and T2/T3 nudge. The compress tool already supported `content` arrays (PR #156), but only single-entry was shown for block-based compression. Now both formats are documented neutrally.
+
+**Install**: `opencode plugin opencode-acp@dev --global`
+
 ### v1.14.8-dev.5 — Dev Prerelease (1 PR since v1.14.8-dev.4)
 
 Dev prerelease covering PR #257. Published to `dev` npm tag for early testing.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,6 +446,15 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 ## 更新日志
 
+### v1.14.9-dev.1 — Dev 预发布（v1.14.8-dev.5 以来 1 个 PR）
+
+Dev 预发布，涵盖 PR #259。发布到 `dev` npm tag 供早期测试。
+
+**包含的 PR**：
+- **#259** — 在系统提示词和 T2/T3 nudge 中文档化多条目 compress 格式。compress 工具已支持 `content` 数组（PR #156），但块压缩只展示了单条目格式。现在两种格式都被中立地文档化。
+
+**安装**：`opencode plugin opencode-acp@dev --global`
+
 ### v1.14.8-dev.5 — Dev 预发布（v1.14.8-dev.4 以来 1 个 PR）
 
 Dev 预发布，涵盖 PR #257。发布到 `dev` npm tag 供早期测试。

--- a/devlog/2026-08-02_release-v1.14.9-dev.1/REQ.md
+++ b/devlog/2026-08-02_release-v1.14.9-dev.1/REQ.md
@@ -1,0 +1,17 @@
+# REQ: Release v1.14.9-dev.1
+
+## Goal
+
+Dev prerelease v1.14.9-dev.1 covering 1 PR since v1.14.8-dev.5.
+
+## PRs Included
+
+1. **#259** — Document multi-entry compress format in system prompt + nudge
+
+## Checklist
+
+- [x] Bump version in package.json (1.14.8-dev.5 → 1.14.9-dev.1)
+- [x] Add changelog to README.md
+- [x] Add changelog to README.zh-CN.md
+- [x] Create devlog entry
+- [ ] Commit, push, create PR

--- a/devlog/2026-08-02_release-v1.14.9-dev.1/WORKLOG.md
+++ b/devlog/2026-08-02_release-v1.14.9-dev.1/WORKLOG.md
@@ -1,0 +1,15 @@
+# WORKLOG: Release v1.14.9-dev.1
+
+## Steps
+
+1. Created worktree `/tmp/opencode-acp-release-v1.14.9-dev.1` on branch `2026-08-02_release-v1.14.9-dev.1`
+2. Linked node_modules from main repo
+3. Bumped `package.json` version: `1.14.8-dev.5` → `1.14.9-dev.1`
+4. Added changelog entry to `README.md` (1 PR: #259)
+5. Added changelog entry to `README.zh-CN.md` (1 PR: #259)
+6. Created devlog entry
+
+## Verification
+
+- Dev prerelease version (has `-` suffix) → CI publishes to `dev` tag
+- 1 PR since v1.14.8-dev.5: #259 (multi-entry compress docs)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.8-dev.5",
+    "version": "1.14.9-dev.1",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Dev prerelease v1.14.9-dev.1 covering 1 PR since v1.14.8-dev.5.

### PRs Included

1. **#259** — Document multi-entry compress format in system prompt and T2/T3 nudge.

### Changes

- `package.json`: version `1.14.8-dev.5` → `1.14.9-dev.1`
- `README.md`: changelog entry added
- `README.zh-CN.md`: changelog entry added
- `devlog/2026-08-02_release-v1.14.9-dev.1/`: REQ.md + WORKLOG.md

### Version Type

Dev prerelease (has `-` suffix) → CI publishes to `dev` npm tag.