### PR TITLE
fix: omo-mode-injection filter preserves user content (issue #262)

### DIFF
--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -465,6 +465,36 @@
                     }
                 }
             }
+        },
+        "messageFilters": {
+            "type": "object",
+            "description": "Pluggable message filter system for cleaning up third-party (e.g. OMO) injected messages that accumulate duplicates.",
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Master switch for all message filters."
+                },
+                "filters": {
+                    "type": "object",
+                    "description": "Per-filter config map. Keyed by filter name. Each filter can be individually enabled/disabled.",
+                    "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "enabled": {
+                                "type": "boolean",
+                                "default": true,
+                                "description": "Enable or disable this specific filter."
+                            }
+                        }
+                    }
+                }
+            },
+            "default": {
+                "enabled": true
+            }
         }
     }
 }

--- a/devlog/2026-08-02_message-filter-fix/REQ.md
+++ b/devlog/2026-08-02_message-filter-fix/REQ.md
@@ -1,0 +1,49 @@
+# REQ: Fix omo-mode-injection filter dropping user content
+
+## Problem (Issue #262)
+
+The `omo-mode-injection` filter (v1.0.0) matched OMO mode injection patterns at the start of user messages and returned `action: "drop"` — clearing the ENTIRE message. But OMO mode injections are **prepended** to the user's actual message, not standalone.
+
+This meant: when a user sent "Fix the bug" with OMO ultrawork mode active, the message arrived as:
+
+```
+<ultrawork-mode>
+
+Mode instructions...
+
+</ultrawork-mode>
+
+Fix the bug
+```
+
+The filter matched `<ultrawork-mode>`, dropped the whole message, and the model saw nothing — losing the user's actual request.
+
+## Root Cause
+
+The filter was written assuming mode injections are standalone messages (like `omo-context` and `omo-task-directive`). But mode injections are **prepended** to user content via the `UserPromptSubmit` hook's `additionalContext`.
+
+Confirmed via oh-my-openagent source: `getPlannerUltraworkMessage()` returns `<ultrawork-mode>\n\n...\n</ultrawork-mode>\n\n` — the trailing `\n\n` is where user content follows.
+
+## Secondary Bug: Config Validation
+
+`lib/config-validation.ts` did not skip recursion into `messageFilters.filters` (a dynamic key map keyed by filter name). Users who set `messageFilters.filters.omo-mode-injection.enabled` in their config got a spurious "unknown config key" warning.
+
+## Fix
+
+### Filter (`omo-mode-injection.ts` v1.0.0 → v1.1.0)
+
+Rewrote to strip injection blocks and preserve user content:
+- XML tags (`<ultrawork-mode>...</ultrawork-mode>`): find closing tag, strip block, keep remainder
+- Bracket patterns (`[search-mode]`): strip marker, keep rest
+- Stacked injections (hyperplan wrapping ultrawork): loop up to 5x
+- Returns `modify` when user content survives; `drop` only when nothing remains
+
+Pattern matches `omo-system-reminder.ts` (strip + modify), not the pure-injection filters (drop).
+
+### Config Validation (`config-validation.ts`)
+
+Added `messageFilters.filters` to the dynamic-key skip list alongside `compress.modelMaxLimits` / `compress.modelMinLimits`.
+
+### Schema (`dcp.schema.json`)
+
+Added `messageFilters` with `enabled` (boolean) + `filters` (additionalProperties map).

--- a/devlog/2026-08-02_message-filter-fix/WORKLOG.md
+++ b/devlog/2026-08-02_message-filter-fix/WORKLOG.md
@@ -1,0 +1,54 @@
+# WORKLOG: Fix omo-mode-injection filter dropping user content
+
+## Investigation
+
+1. Read issue #262 — user reports filter is dropping user messages
+2. Read `lib/messages/filter/builtin/omo-mode-injection.ts` (v1.0.0) — confirmed it returns `action: "drop"` on any match
+3. Searched oh-my-openagent source via grep_app:
+   - `packages/omo-opencode/src/hooks/keyword-detector/ultrawork/planner.ts`: `getPlannerUltraworkMessage()` returns `<ultrawork-mode>\n\n...\n</ultrawork-mode>\n\n`
+   - Injection is prepended via `UserPromptSubmit` hook `additionalContext`
+   - User's actual message follows AFTER `</ultrawork-mode>`
+4. Confirmed: mode injections are NOT standalone — they're prepended to user content
+
+## Implementation
+
+### Filter rewrite (`omo-mode-injection.ts`)
+
+- Extracted `stripLeadingModeInjections()`: loops up to 5x to handle stacked injections
+- XML tags: finds closing tag via `indexOf`, strips entire block
+- Bracket patterns: strips marker prefix
+- Returns remaining text or null (if nothing was stripped)
+- Filter returns `modify` with remaining text, or `drop` if empty
+
+### Config validation fix (`config-validation.ts`)
+
+Added `messageFilters.filters` to the `continue` skip list at line 75.
+
+### Schema fix (`dcp.schema.json`)
+
+Added `messageFilters` object with `enabled` boolean + `filters` map.
+
+### Tests (`message-filter.test.ts`)
+
+- Updated existing test "mode injection strips all occurrences" → "strips tag, preserves user content" (asserts user content survives)
+- Added 9 new tests in `omo-mode-injection filter (v1.1.0)` describe block:
+  - Keeps normal messages, assistant messages
+  - Strips ultrawork XML block, bracket patterns
+  - Handles stacked hyperplan+ultrawork
+  - Drops pure injection with no user content
+  - Handles unclosed XML tag
+  - Preserves angle brackets that aren't mode tags
+
+## Verification
+
+- `npm run typecheck`: clean
+- `npm run test`: 951 tests, 0 failures (was 941 before + 10 new tests)
+
+## Files Changed
+
+- `lib/messages/filter/builtin/omo-mode-injection.ts` — rewritten (v1.0.0 → v1.1.0)
+- `lib/config-validation.ts` — added messageFilters.filters to skip list
+- `dcp.schema.json` — added messageFilters schema
+- `tests/message-filter.test.ts` — updated 1 test + added 9 new tests
+- `devlog/2026-08-02_message-filter-fix/REQ.md` — this file
+- `devlog/2026-08-02_message-filter-fix/WORKLOG.md` — this file

--- a/lib/config-validation.ts
+++ b/lib/config-validation.ts
@@ -71,8 +71,11 @@ function getConfigKeyPaths(obj: Record<string, any>, prefix = ""): string[] {
         const fullKey = prefix ? `${prefix}.${key}` : key
         keys.push(fullKey)
 
-        // model*Limits are dynamic maps keyed by providerID/modelID; do not recurse into arbitrary IDs.
-        if (fullKey === "compress.modelMaxLimits" || fullKey === "compress.modelMinLimits") {
+        if (
+            fullKey === "compress.modelMaxLimits" ||
+            fullKey === "compress.modelMinLimits" ||
+            fullKey === "messageFilters.filters"
+        ) {
             continue
         }
 

--- a/lib/messages/filter/builtin/omo-mode-injection.ts
+++ b/lib/messages/filter/builtin/omo-mode-injection.ts
@@ -1,19 +1,81 @@
 import type { MessageFilter, MessageFilterContext, FilterResult } from "../types"
 
-const MODE_PATTERNS = ["[search-mode]", "[analyze-mode]", "<ultrawork-mode>", "[ultrawork-mode]"]
+/**
+ * OMO mode injection filter.
+ *
+ * Unlike pure-injection filters (omo-context, omo-task-directive), mode
+ * injections are *prepended* to the user's actual message. This filter
+ * strips only the injection block(s) and preserves user content.
+ */
+const XML_MODE_TAGS: Array<{ open: string; close: string }> = [
+    { open: "<hyperplan-ultrawork-mode>", close: "</hyperplan-ultrawork-mode>" },
+    { open: "<ultrawork-mode>", close: "</ultrawork-mode>" },
+]
+
+const BRACKET_MODE_PATTERNS = ["[search-mode]", "[analyze-mode]", "[ultrawork-mode]"]
+
+function stripLeadingModeInjections(text: string): string | null {
+    let current = text
+    let strippedAny = false
+
+    for (let iter = 0; iter < 5; iter++) {
+        current = current.trimStart()
+        let matched = false
+
+        for (const { open, close } of XML_MODE_TAGS) {
+            if (current.startsWith(open)) {
+                const closeIdx = current.indexOf(close)
+                if (closeIdx !== -1) {
+                    current = current.slice(closeIdx + close.length)
+                } else {
+                    current = current.slice(open.length)
+                }
+                matched = true
+                break
+            }
+        }
+
+        if (!matched) {
+            for (const pattern of BRACKET_MODE_PATTERNS) {
+                if (current.startsWith(pattern)) {
+                    current = current.slice(pattern.length)
+                    matched = true
+                    break
+                }
+            }
+        }
+
+        if (matched) {
+            strippedAny = true
+        } else {
+            break
+        }
+    }
+
+    return strippedAny ? current.trim() : null
+}
 
 const OMO_MODE_FILTER: MessageFilter = {
     name: "omo-mode-injection",
-    version: "1.0.0",
-    description: "Strip OMO mode injection blocks ([search-mode], [analyze-mode], <ultrawork-mode>)",
+    version: "1.1.0",
+    description:
+        "Strip OMO mode injection blocks (<ultrawork-mode>...</ultrawork-mode>, [search-mode], etc.) from user messages, preserving user content",
 
     filter(ctx: MessageFilterContext): FilterResult {
         if (ctx.role !== "user") return { action: "keep" }
-        const stripped = ctx.text.trimStart()
-        const isModeInjection = MODE_PATTERNS.some((p) => stripped.startsWith(p))
-        if (!isModeInjection) return { action: "keep" }
 
-        return { action: "drop", reason: "OMO mode injection" }
+        const remaining = stripLeadingModeInjections(ctx.text)
+        if (remaining === null) return { action: "keep" }
+
+        if (remaining.length === 0) {
+            return { action: "drop", reason: "OMO mode injection (no user content after stripping)" }
+        }
+
+        return {
+            action: "modify",
+            text: remaining,
+            reason: "Stripped OMO mode injection block(s), preserved user content",
+        }
     },
 }
 

--- a/tests/config-validation.test.ts
+++ b/tests/config-validation.test.ts
@@ -48,6 +48,13 @@ test("getInvalidConfigKeys does not recurse into modelMaxLimits dynamic keys", (
     assert.deepEqual(result, [])
 })
 
+test("getInvalidConfigKeys does not recurse into messageFilters.filters dynamic keys", () => {
+    const result = getInvalidConfigKeys({
+        messageFilters: { filters: { "omo-mode-injection": { enabled: true } } },
+    })
+    assert.deepEqual(result, [])
+})
+
 test("validateConfigTypes returns empty array for valid config", () => {
     const result = validateConfigTypes({
         enabled: true,

--- a/tests/message-filter.test.ts
+++ b/tests/message-filter.test.ts
@@ -434,7 +434,7 @@ describe("keep-last-only dedup", () => {
         assert.equal(stats.partsFiltered, 0)
     })
 
-    it("mode injection strips all occurrences", () => {
+    it("mode injection strips tag, preserves user content", () => {
         registerMessageFilter(OMO_MODE_FILTER)
         const messages: WithParts[] = [
             { info: { id: "m1", role: "user", time: 1 } as any, parts: [{ type: "text", text: "[search-mode]\nSearch for X" }] },
@@ -442,7 +442,66 @@ describe("keep-last-only dedup", () => {
         ]
         const config = { enabled: true, filters: { "omo-mode-injection": { enabled: true } } }
         applyMessageFilters(messages, config, makeLogger(), { sessionId: "s", isSubAgent: false })
-        assert.equal((messages[0].parts[0] as any).text, "")
-        assert.equal((messages[1].parts[0] as any).text, "")
+        assert.equal((messages[0].parts[0] as any).text, "Search for X")
+        assert.equal((messages[1].parts[0] as any).text, "Analyze Y")
+    })
+})
+
+describe("omo-mode-injection filter (v1.1.0)", () => {
+    const filter = OMO_MODE_FILTER
+
+    it("keeps normal user messages without mode tags", () => {
+        const result = filter.filter(makeCtx({ text: "Fix the bug in auth.ts" }))
+        assert.equal(result.action, "keep")
+    })
+
+    it("keeps assistant messages even with mode tags", () => {
+        const result = filter.filter(makeCtx({ text: "<ultrawork-mode>", role: "assistant" }))
+        assert.equal(result.action, "keep")
+    })
+
+    it("strips ultrawork-mode XML block, preserves user content", () => {
+        const text = `<ultrawork-mode>\n\nMode instructions here.\n\n</ultrawork-mode>\n\nFix the bug in auth.ts`
+        const result = filter.filter(makeCtx({ text }))
+        assert.equal(result.action, "modify")
+        assert.equal(result.text, "Fix the bug in auth.ts")
+    })
+
+    it("strips bracket mode pattern, preserves user content", () => {
+        const text = `[search-mode]\nFind all uses of deprecated API`
+        const result = filter.filter(makeCtx({ text }))
+        assert.equal(result.action, "modify")
+        assert.equal(result.text, "Find all uses of deprecated API")
+    })
+
+    it("strips stacked hyperplan + ultrawork injections", () => {
+        const text = `<hyperplan-ultrawork-mode>\n<ultrawork-mode>\n\nInstructions.\n\n</ultrawork-mode>\n\n</hyperplan-ultrawork-mode>\n\nDo the actual work`
+        const result = filter.filter(makeCtx({ text }))
+        assert.equal(result.action, "modify")
+        assert.equal(result.text, "Do the actual work")
+    })
+
+    it("drops pure mode injection with no user content", () => {
+        const text = `<ultrawork-mode>\n\nInstructions only, no user message.\n\n</ultrawork-mode>`
+        const result = filter.filter(makeCtx({ text }))
+        assert.equal(result.action, "drop")
+    })
+
+    it("drops pure bracket mode with no user content", () => {
+        const result = filter.filter(makeCtx({ text: "[ultrawork-mode]" }))
+        assert.equal(result.action, "drop")
+    })
+
+    it("handles unclosed XML tag gracefully (strips opening tag only)", () => {
+        const text = `<ultrawork-mode>\nThis is the user content without closing tag`
+        const result = filter.filter(makeCtx({ text }))
+        assert.equal(result.action, "modify")
+        assert.equal(result.text, "This is the user content without closing tag")
+    })
+
+    it("preserves user content with angle brackets that are not mode tags", () => {
+        const text = `Use <template> in the code`
+        const result = filter.filter(makeCtx({ text }))
+        assert.equal(result.action, "keep")
     })
 })


### PR DESCRIPTION
## Summary

Fixes #262 — the `omo-mode-injection` filter was dropping entire user messages when OMO mode injections (`<ultrawork-mode>`, `[search-mode]`, etc.) were prepended to user content.

## Problem

OMO mode injections are **prepended** to user messages (via `UserPromptSubmit` hook `additionalContext`), not standalone messages. The old filter (v1.0.0) matched the injection pattern and returned `action: "drop"` — clearing the entire message including the user's actual request.

Confirmed via oh-my-openagent source: `getPlannerUltraworkMessage()` returns `<ultrawork-mode>\n\n...\n</ultrawork-mode>\n\n` — user content follows after the closing tag.

## Fix

### Filter (`omo-mode-injection.ts` v1.0.0 → v1.1.0)

Rewrote to strip injection blocks and preserve user content:
- **XML tags** (`<ultrawork-mode>...</ultrawork-mode>`): find closing tag, strip block, keep remainder
- **Bracket patterns** (`[search-mode]`): strip marker, keep rest
- **Stacked injections** (hyperplan wrapping ultrawork): loop up to 5x
- Returns `modify` when user content survives; `drop` only when nothing remains after stripping

Pattern matches `omo-system-reminder.ts` (strip + modify), not the pure-injection filters (drop).

### Config validation (`config-validation.ts`)

Added `messageFilters.filters` to the dynamic-key skip list. Without this, users setting `messageFilters.filters.omo-mode-injection.enabled` got spurious "unknown config key" warnings.

### Schema (`dcp.schema.json`)

Added `messageFilters` field to the JSON schema (was completely missing).

## Tests

- Updated existing test (was asserting the buggy "drop all" behavior)
- Added 9 new tests covering: normal messages, assistant messages, XML block stripping, bracket pattern stripping, stacked injections, pure injection (drop), unclosed tags, non-mode angle brackets
- **951 tests pass**, 0 failures

## Files Changed

- `lib/messages/filter/builtin/omo-mode-injection.ts` — rewritten
- `lib/config-validation.ts` — dynamic key skip
- `dcp.schema.json` — messageFilters schema
- `tests/message-filter.test.ts` — 1 updated + 9 new tests