### PR TITLE
release: v1.14.9-dev.2 — omo-mode-injection filter fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,15 @@ Stable release with nudge loop fix, holistic T2/T3 compression prompts, and mult
 
 **Install**: `opencode plugin opencode-acp@stable --global`
 
+### v1.14.9-dev.2 — Dev Prerelease (1 PR since v1.14.9-dev.1)
+
+Dev prerelease covering PR #263. Published to `dev` npm tag for early testing.
+
+**PRs included**:
+- **#263** — Fix: `omo-mode-injection` filter was dropping entire user messages when OMO mode injections (`<ultrawork-mode>`, `[search-mode]`, etc.) were prepended to user content. Mode injections are prepended via `UserPromptSubmit.additionalContext`, not standalone — the old filter (v1.0.0) matched the injection and returned `drop`, clearing the entire message including the user's actual request. Rewrote to v1.1.0: strips injection blocks and preserves user content via `modify`. Also fixes config validation (messageFilters.filters dynamic key skip) and adds messageFilters to dcp.schema.json.
+
+**Install**: `opencode plugin opencode-acp@dev --global`
+
 ### v1.14.9-dev.1 — Dev Prerelease (1 PR since v1.14.8-dev.5)
 
 Dev prerelease covering PR #259. Published to `dev` npm tag for early testing.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -457,6 +457,15 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 **安装**：`opencode plugin opencode-acp@stable --global`
 
+### v1.14.9-dev.2 — Dev 预发布（v1.14.9-dev.1 以来 1 个 PR）
+
+Dev 预发布，覆盖 PR #263。已发布到 `dev` npm 标签供早期测试。
+
+**包含的 PR**：
+- **#263** — 修复：`omo-mode-injection` 过滤器在 OMO 模式注入（`<ultrawork-mode>`、`[search-mode]` 等）被前置到用户消息时，会丢弃整个用户消息。模式注入通过 `UserPromptSubmit.additionalContext` 前置，不是独立消息——旧过滤器（v1.0.0）匹配到注入就返回 `drop`，清空了整个消息包括用户的实际请求。重写为 v1.1.0：剥离注入块、通过 `modify` 保留用户内容。同时修复配置校验（messageFilters.filters 动态键跳过）并补充 dcp.schema.json。
+
+**安装**：`opencode plugin opencode-acp@dev --global`
+
 ### v1.14.9-dev.1 — Dev 预发布（v1.14.8-dev.5 以来 1 个 PR）
 
 Dev 预发布，涵盖 PR #259。发布到 `dev` npm tag 供早期测试。

--- a/devlog/2026-08-02_release-v1.14.9-dev.2/REQ.md
+++ b/devlog/2026-08-02_release-v1.14.9-dev.2/REQ.md
@@ -1,0 +1,5 @@
+# REQ: Release v1.14.9-dev.2
+
+Dev prerelease covering PR #263 (omo-mode-injection filter fix, issue #262).
+
+1 PR since v1.14.9-dev.1.

--- a/devlog/2026-08-02_release-v1.14.9-dev.2/WORKLOG.md
+++ b/devlog/2026-08-02_release-v1.14.9-dev.2/WORKLOG.md
@@ -1,0 +1,6 @@
+# WORKLOG: Release v1.14.9-dev.2
+
+- Bumped version to 1.14.9-dev.2
+- Added changelog entries to README.md and README.zh-CN.md
+- Created devlog
+- Based on master 917155d (PR #263 merged)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.9",
+    "version": "1.14.9-dev.2",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
Dev prerelease covering PR #263 (issue #262: omo-mode-injection filter was dropping user messages).

1 PR since v1.14.9-dev.1:
- #263 — Fix omo-mode-injection filter: strip injection blocks, preserve user content. Also fixes config validation and schema.

Version: `1.14.9-dev.2` (contains `-` → CI publishes to `dev` npm tag).