### PR TITLE
release: v1.14.10 — omo-mode-injection filter fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,15 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.10 — Stable Release (1 PR since v1.14.9)
+
+Stable release with the omo-mode-injection filter fix.
+
+**PRs included**:
+- **#263** — Fix: `omo-mode-injection` filter was dropping entire user messages when OMO mode injections (`<ultrawork-mode>`, `[search-mode]`, etc.) were prepended to user content. Mode injections are prepended via `UserPromptSubmit.additionalContext`, not standalone — the old filter (v1.0.0) matched the injection and returned `drop`, clearing the entire message including the user's actual request. Rewrote to v1.1.0: strips injection blocks and preserves user content via `modify`. Also fixes config validation (messageFilters.filters dynamic key skip) and adds messageFilters to dcp.schema.json.
+
+**Install**: `opencode plugin opencode-acp@stable --global`
+
 ### v1.14.9 — Stable Release (3 PRs since v1.14.8)
 
 Stable release with nudge loop fix, holistic T2/T3 compression prompts, and multi-entry compress format documentation.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,6 +446,15 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 ## 更新日志
 
+### v1.14.10 — 正式版（v1.14.9 以来 1 个 PR）
+
+正式版发布，包含 omo-mode-injection 过滤器修复。
+
+**包含的 PR**：
+- **#263** — 修复：`omo-mode-injection` 过滤器在 OMO 模式注入（`<ultrawork-mode>`、`[search-mode]` 等）被前置到用户消息时，会丢弃整个用户消息。模式注入通过 `UserPromptSubmit.additionalContext` 前置，不是独立消息——旧过滤器（v1.0.0）匹配到注入就返回 `drop`，清空了整个消息包括用户的实际请求。重写为 v1.1.0：剥离注入块、通过 `modify` 保留用户内容。同时修复配置校验（messageFilters.filters 动态键跳过）并补充 dcp.schema.json。
+
+**安装**：`opencode plugin opencode-acp@stable --global`
+
 ### v1.14.9 — 正式版（v1.14.8 以来 3 个 PR）
 
 正式版发布，包含 nudge 循环修复、整体式 T2/T3 压缩提示词、多条目 compress 格式文档。

--- a/devlog/2026-08-02_release-v1.14.10/REQ.md
+++ b/devlog/2026-08-02_release-v1.14.10/REQ.md
@@ -1,0 +1,5 @@
+# REQ: Release v1.14.10
+
+Stable release covering PR #263 (omo-mode-injection filter fix, issue #262).
+
+1 PR since v1.14.9.

--- a/devlog/2026-08-02_release-v1.14.10/WORKLOG.md
+++ b/devlog/2026-08-02_release-v1.14.10/WORKLOG.md
@@ -1,0 +1,6 @@
+# WORKLOG: Release v1.14.10
+
+- Bumped version to 1.14.10
+- Added changelog entries to README.md and README.zh-CN.md
+- Created devlog
+- Based on master 65fd8c6 (PRs #263 + #264 merged)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.9-dev.2",
+    "version": "1.14.10",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
Stable release covering PR #263 (issue #262: omo-mode-injection filter was dropping user messages).

1 PR since v1.14.9:
- #263 — Fix omo-mode-injection filter: strip injection blocks, preserve user content. Also fixes config validation and schema.

Version: `1.14.10` (no `-` → CI publishes to `latest` npm tag).

**Install**: `opencode plugin opencode-acp@stable --global`