### PR TITLE
fix: keep last 2 OMO system-reminder messages + configurable keepLast (issue #267)

### DIFF
--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -487,6 +487,11 @@
                                 "type": "boolean",
                                 "default": true,
                                 "description": "Enable or disable this specific filter."
+                            },
+                            "keepLast": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": "Override how many of the most recent matches to keep for keepLastOnly filters."
                             }
                         }
                     }

--- a/devlog/2026-08-03_system-reminder-background-task/REQ.md
+++ b/devlog/2026-08-03_system-reminder-background-task/REQ.md
@@ -1,0 +1,23 @@
+# REQ: Keep last 2 OMO system-reminder messages, drop older ones (issue #267)
+
+## Problem
+
+The `omo-system-reminder` filter stripped ALL `<system-reminder>` blocks from messages. This deleted `[BACKGROUND TASK COMPLETED]` notifications, preventing the main session from recovering subagent results.
+
+## Fix (revised approach per user feedback)
+
+User insight: instead of content-based filtering (maintaining a list of "important" markers), use a simple positional rule — keep the 2 most recent system-reminder messages, drop all older ones. This is:
+- Content-agnostic (no false positives/negatives)
+- Future-proof (new notification types automatically preserved if recent)
+- Simple (no regex stripping logic)
+
+### Framework change
+
+Added `keepLast?: number` field to `MessageFilter` interface (default: 1). Phase 2 of `applyMessageFilters` now counts matches and keeps the last N, drops earlier ones.
+
+### Filter change
+
+`omo-system-reminder` v1.0.0 → v1.2.0:
+- `keepLastOnly: true, keepLast: 2`
+- `filter()` returns `{ action: "drop" }` to identify matches for the keepLast dedup
+- Last 2 matching messages survive intact, older ones get emptied

--- a/devlog/2026-08-03_system-reminder-background-task/WORKLOG.md
+++ b/devlog/2026-08-03_system-reminder-background-task/WORKLOG.md
@@ -1,0 +1,40 @@
+# WORKLOG: Keep last 2 OMO system-reminder messages
+
+## Iteration 1 (abandoned): Content-based PRESERVE_MARKERS
+
+v1.1.0 — Added `PRESERVE_MARKERS = ["[BACKGROUND TASK COMPLETED]", "[BACKGROUND TASK FAILED]"]`. Filter stripped non-critical blocks but preserved blocks containing markers.
+
+User feedback: "你这个修复还会引入新的问题" — content-based approach requires maintaining a marker list, fragile to future OMO changes.
+
+## Iteration 2 (final): Positional keepLast(2)
+
+v1.2.0 — Completely different approach per user suggestion: "把除了最近两条之外的删除，历史上的都可以删除，最近的都让它显示出来"
+
+### Framework change (`types.ts` + `apply.ts`)
+
+- Added `keepLast?: number` to `MessageFilter` interface (default: 1)
+- Phase 2 changed from boolean `foundLast` to counter `kept`:
+  - `kept < keepCount` → keep match (no modification)
+  - `kept >= keepCount` → drop match (empty text)
+- Backward compatible: existing `keepLastOnly: true` filters default to `keepLast: 1`
+
+### Filter rewrite (`omo-system-reminder.ts`)
+
+v1.0.0 (strip all blocks) → v1.2.0 (keepLast=2):
+- `keepLastOnly: true, keepLast: 2`
+- `filter()` returns `{ action: "drop" }` when matching `<system-reminder>` or OMO marker
+- No content parsing, no regex stripping, no marker lists
+- Phase 2 keeps last 2 matches intact, drops older ones
+
+### Tests
+
+- 8 tests (was 11 in v1.1.0, was 8 in v1.0.0):
+  - Unit: `keepLastOnly`/`keepLast` fields, match/drop for user msgs, keep for assistant/plain
+  - Integration: 4 msgs → keeps last 2 + drops oldest + normal msg unaffected
+  - Integration: single occurrence → no dedup
+  - Integration: exactly 2 → both kept
+
+## Verification
+
+- `npm run typecheck`: clean
+- `npm run test`: 952 tests, 0 failures

--- a/lib/messages/filter/apply.ts
+++ b/lib/messages/filter/apply.ts
@@ -106,7 +106,9 @@ export function applyMessageFilters(
     // Phase 2: keep-last-only dedup (reverse pass)
     const keepLastFilters = allFilters.filter((f) => f.keepLastOnly)
     for (const filter of keepLastFilters) {
-        let foundLast = false
+        const fcKeepLast = config.filters?.[filter.name]?.keepLast
+        const keepCount = Math.max(1, fcKeepLast ?? filter.keepLast ?? 1)
+        let kept = 0
         for (let i = messages.length - 1; i >= 0; i--) {
             const msg = messages[i]
             const role = (msg.info as { role?: string }).role ?? "unknown"
@@ -124,13 +126,13 @@ export function applyMessageFilters(
                     continue
                 }
                 if (decision.action !== "drop" && decision.action !== "modify") continue
-                if (foundLast) {
-                    applyDecision(part as { text?: string }, { action: "drop", reason: `keepLastOnly: earlier occurrence` }, filter.name, i, text)
-                } else {
-                    foundLast = true
+                if (kept < keepCount) {
+                    kept++
                     if (decision.action === "modify" && decision.text !== undefined) {
                         applyDecision(part as { text?: string }, decision, filter.name, i, text)
                     }
+                } else {
+                    applyDecision(part as { text?: string }, { action: "drop", reason: `keepLastOnly(${keepCount}): earlier occurrence` }, filter.name, i, text)
                 }
             }
         }

--- a/lib/messages/filter/builtin/omo-system-reminder.ts
+++ b/lib/messages/filter/builtin/omo-system-reminder.ts
@@ -1,74 +1,21 @@
 import type { MessageFilter, MessageFilterContext, FilterResult } from "../types"
 
-/**
- * OMO (Oh My OpenCode) system-reminder filter.
- *
- * Strips `<system-reminder>` blocks injected by the OMO plugin framework.
- * These blocks contain background task notifications, todo continuation
- * directives, and other ephemeral metadata that accumulates as user messages.
- *
- * Each block looks like:
- * <system-reminder>
- * [BACKGROUND TASK COMPLETED]
- * ...
- * </system-reminder>
- * <!-- OMO_INTERNAL_INITIATOR -->
- *
- * By default, this filter strips ALL such blocks. Users can disable it
- * per-session via config if they need to see OMO notifications.
- */
-
 const SYSTEM_REMINDER_OPEN = "<system-reminder>"
-const SYSTEM_REMINDER_CLOSE = "</system-reminder>"
 const OMO_MARKER = "<!-- OMO_INTERNAL_INITIATOR -->"
-
-// Pre-compiled module-level regexes (hoisted from per-call construction per review).
-// None of these literals contain regex metacharacters, so no escaping needed.
-const PAIRED_BLOCK_RE = /<system-reminder>[\s\S]*?<\/system-reminder>\s*<!-- OMO_INTERNAL_INITIATOR -->/g
-const LONE_REMINDER_RE = /<system-reminder>[\s\S]*?<\/system-reminder>/g
-const LONE_MARKER_RE = /<!-- OMO_INTERNAL_INITIATOR -->/g
 
 const OMO_SYSTEM_REMINDER_FILTER: MessageFilter = {
     name: "omo-system-reminder",
-    version: "1.0.0",
-    description: "Strip OMO <system-reminder> blocks and OMO_INTERNAL_INITIATOR markers from user messages",
+    version: "1.2.0",
+    description: "Keep only the 2 most recent OMO <system-reminder> messages, drop older ones",
+    keepLastOnly: true,
+    keepLast: 2,
 
     filter(ctx: MessageFilterContext): FilterResult {
         if (ctx.role !== "user") return { action: "keep" }
         if (!ctx.text.includes(SYSTEM_REMINDER_OPEN) && !ctx.text.includes(OMO_MARKER)) {
             return { action: "keep" }
         }
-
-        let modified = ctx.text
-        let removedBlocks = 0
-
-        modified = modified.replace(PAIRED_BLOCK_RE, () => {
-            removedBlocks++
-            return ""
-        })
-
-        modified = modified.replace(LONE_REMINDER_RE, () => {
-            removedBlocks++
-            return ""
-        })
-
-        modified = modified.replace(LONE_MARKER_RE, "")
-
-        modified = modified.replace(/\n{3,}/g, "\n\n").trim()
-
-        if (modified.length === 0) {
-            return { action: "drop", reason: `Stripped ${removedBlocks} OMO system-reminder block(s)` }
-        }
-
-        if (modified !== ctx.text) {
-            return {
-                action: "modify",
-                text: modified,
-                reason: `Stripped ${removedBlocks} OMO system-reminder block(s)`,
-            }
-        }
-
-        return { action: "keep" }
+        return { action: "drop", reason: "OMO system-reminder match (keepLast dedup)" }
     },
 }
 

--- a/lib/messages/filter/types.ts
+++ b/lib/messages/filter/types.ts
@@ -65,19 +65,25 @@ export interface MessageFilter {
      */
     filter(ctx: MessageFilterContext): FilterResult
     /**
-     * When true, applyMessageFilters keeps only the LAST matching message
-     * and drops all earlier matches. Useful for repeating directives
+     * When true, applyMessageFilters keeps only the most recent N matching
+     * messages and drops all earlier matches. Useful for repeating directives
      * (e.g., TODO CONTINUATION) where only the latest is relevant.
      * The filter() function still runs per-part to identify matches;
      * the dedup pass then empties earlier occurrences.
      */
     keepLastOnly?: boolean
+    /**
+     * How many of the most recent matches to keep when keepLastOnly is true.
+     * Default: 1. Set to 2+ to preserve recent notifications (e.g., background
+     * task results) while still cleaning up historical accumulation.
+     */
+    keepLast?: number
 }
 
 /**
  * Per-filter configuration: whether the filter is enabled.
  */
-export type MessageFilterConfig = Record<string, { enabled: boolean }>
+export type MessageFilterConfig = Record<string, { enabled: boolean; keepLast?: number }>
 
 /**
  * Top-level configuration for the message filter subsystem.

--- a/tests/message-filter.test.ts
+++ b/tests/message-filter.test.ts
@@ -222,62 +222,73 @@ describe("applyMessageFilters", () => {
 })
 
 describe("OMO system-reminder filter", () => {
+    beforeEach(() => clearMessageFilters())
     const filter = OMO_SYSTEM_REMINDER_FILTER
 
-    it("keeps normal user messages", () => {
-        const result = filter.filter(makeCtx({ text: "hello world" }))
-        assert.equal(result.action, "keep")
+    it("has keepLastOnly and keepLast=2", () => {
+        assert.equal(filter.keepLastOnly, true)
+        assert.equal(filter.keepLast, 2)
     })
 
-    it("keeps assistant messages with system-reminder tags", () => {
-        const text = "<system-reminder>foo</system-reminder><!-- OMO_INTERNAL_INITIATOR -->"
-        const result = filter.filter(makeCtx({ text, role: "assistant" }))
-        assert.equal(result.action, "keep")
-    })
-
-    it("drops user message that is ONLY a system-reminder block", () => {
+    it("matches user message with system-reminder block", () => {
         const text = `<system-reminder>\n[BG COMPLETE]\n</system-reminder>\n<!-- OMO_INTERNAL_INITIATOR -->`
         const result = filter.filter(makeCtx({ text, role: "user" }))
         assert.equal(result.action, "drop")
     })
 
-    it("modifies user message with system-reminder + real content", () => {
-        const text = `Please help me.\n\n<system-reminder>\n[BG COMPLETE]\n</system-reminder>\n<!-- OMO_INTERNAL_INITIATOR -->`
-        const result = filter.filter(makeCtx({ text, role: "user" }))
-        assert.equal(result.action, "modify")
-        assert.ok(result.text!.includes("Please help me"))
-        assert.ok(!result.text!.includes("<system-reminder>"))
-        assert.ok(!result.text!.includes("OMO_INTERNAL_INITIATOR"))
-    })
-
-    it("strips lone system-reminder without OMO marker", () => {
-        const text = `Real content.\n\n<system-reminder>\nfoo\n</system-reminder>`
-        const result = filter.filter(makeCtx({ text, role: "user" }))
-        assert.equal(result.action, "modify")
-        assert.ok(!result.text!.includes("<system-reminder>"))
-        assert.ok(result.text!.includes("Real content"))
-    })
-
-    it("strips lone OMO marker without system-reminder", () => {
+    it("matches user message with lone OMO marker", () => {
         const text = `Real content.\n<!-- OMO_INTERNAL_INITIATOR -->`
         const result = filter.filter(makeCtx({ text, role: "user" }))
-        assert.equal(result.action, "modify")
-        assert.ok(!result.text!.includes("OMO_INTERNAL_INITIATOR"))
-    })
-
-    it("handles multiple system-reminder blocks in one message", () => {
-        const text = `Real content.\n<system-reminder>A</system-reminder>\n<!-- OMO_INTERNAL_INITIATOR -->\n<system-reminder>B</system-reminder>\n<!-- OMO_INTERNAL_INITIATOR -->`
-        const result = filter.filter(makeCtx({ text, role: "user" }))
-        assert.equal(result.action, "modify")
-        assert.ok(result.text!.includes("Real content"))
-        assert.ok(!result.text!.includes("system-reminder"))
-        assert.ok(!result.text!.includes("OMO_INTERNAL_INITIATOR"))
-    })
-
-    it("drops message that becomes empty after stripping", () => {
-        const text = `   \n\n<system-reminder>\nfoo\n</system-reminder>\n<!-- OMO_INTERNAL_INITIATOR -->\n\n   `
-        const result = filter.filter(makeCtx({ text, role: "user" }))
         assert.equal(result.action, "drop")
+    })
+
+    it("does not match assistant messages", () => {
+        const text = "<system-reminder>foo</system-reminder><!-- OMO_INTERNAL_INITIATOR -->"
+        const result = filter.filter(makeCtx({ text, role: "assistant" }))
+        assert.equal(result.action, "keep")
+    })
+
+    it("does not match plain user messages", () => {
+        const result = filter.filter(makeCtx({ text: "hello world" }))
+        assert.equal(result.action, "keep")
+    })
+
+    it("keeps last 2, drops older ones (issue #267)", () => {
+        registerMessageFilter(OMO_SYSTEM_REMINDER_FILTER)
+        const messages: WithParts[] = [
+            { info: { id: "m1", role: "user", time: 1 } as any, parts: [{ type: "text", text: "<system-reminder>old #1</system-reminder><!-- OMO_INTERNAL_INITIATOR -->" }] },
+            { info: { id: "m2", role: "user", time: 2 } as any, parts: [{ type: "text", text: "real user message" }] },
+            { info: { id: "m3", role: "user", time: 3 } as any, parts: [{ type: "text", text: "<system-reminder>recent #1 [BACKGROUND TASK COMPLETED]</system-reminder><!-- OMO_INTERNAL_INITIATOR -->" }] },
+            { info: { id: "m4", role: "user", time: 4 } as any, parts: [{ type: "text", text: "<system-reminder>recent #2 [BACKGROUND TASK FAILED]</system-reminder><!-- OMO_INTERNAL_INITIATOR -->" }] },
+        ]
+        const config = { enabled: true, filters: { "omo-system-reminder": { enabled: true } } }
+        applyMessageFilters(messages, config, makeLogger(), { sessionId: "s", isSubAgent: false })
+        assert.equal((messages[0].parts[0] as any).text, "", "oldest system-reminder dropped")
+        assert.equal((messages[1].parts[0] as any).text, "real user message", "normal message unaffected")
+        assert.ok((messages[2].parts[0] as any).text.includes("BACKGROUND TASK COMPLETED"), "2nd-most-recent kept")
+        assert.ok((messages[3].parts[0] as any).text.includes("BACKGROUND TASK FAILED"), "most-recent kept")
+    })
+
+    it("single occurrence: no dedup needed", () => {
+        registerMessageFilter(OMO_SYSTEM_REMINDER_FILTER)
+        const messages: WithParts[] = [
+            { info: { id: "m1", role: "user", time: 1 } as any, parts: [{ type: "text", text: "<system-reminder>only one</system-reminder><!-- OMO_INTERNAL_INITIATOR -->" }] },
+        ]
+        const config = { enabled: true, filters: { "omo-system-reminder": { enabled: true } } }
+        applyMessageFilters(messages, config, makeLogger(), { sessionId: "s", isSubAgent: false })
+        assert.equal((messages[0].parts[0] as any).text, "<system-reminder>only one</system-reminder><!-- OMO_INTERNAL_INITIATOR -->")
+    })
+
+    it("exactly 2 occurrences: both kept", () => {
+        registerMessageFilter(OMO_SYSTEM_REMINDER_FILTER)
+        const messages: WithParts[] = [
+            { info: { id: "m1", role: "user", time: 1 } as any, parts: [{ type: "text", text: "<system-reminder>first</system-reminder><!-- OMO_INTERNAL_INITIATOR -->" }] },
+            { info: { id: "m2", role: "user", time: 2 } as any, parts: [{ type: "text", text: "<system-reminder>second</system-reminder><!-- OMO_INTERNAL_INITIATOR -->" }] },
+        ]
+        const config = { enabled: true, filters: { "omo-system-reminder": { enabled: true } } }
+        applyMessageFilters(messages, config, makeLogger(), { sessionId: "s", isSubAgent: false })
+        assert.ok((messages[0].parts[0] as any).text.includes("first"), "first kept")
+        assert.ok((messages[1].parts[0] as any).text.includes("second"), "second kept")
     })
 })
 
@@ -287,7 +298,7 @@ describe("ensureBuiltinFiltersRegistered", () => {
     it("registers the OMO filter", () => {
         ensureBuiltinFiltersRegistered()
         assert.ok(getMessageFilter("omo-system-reminder"))
-        assert.equal(getMessageFilter("omo-system-reminder")!.version, "1.0.0")
+        assert.equal(getMessageFilter("omo-system-reminder")!.version, "1.2.0")
     })
 
     it("is idempotent", () => {
@@ -367,6 +378,22 @@ describe("keep-last-only dedup", () => {
         applyMessageFilters(messages, config, makeLogger(), { sessionId: "s", isSubAgent: false })
         assert.equal((messages[0].parts[0] as any).text, "")
         assert.equal((messages[1].parts[0] as any).text, "[CONTEXT] New context\n<!-- OMO_INTERNAL_INITIATOR -->")
+    })
+
+    it("configurable keepLast override keeps N most recent", () => {
+        registerMessageFilter(OMO_TODO_FILTER)
+        const messages: WithParts[] = [
+            { info: { id: "m1", role: "user", time: 1 } as any, parts: [{ type: "text", text: "[SYSTEM DIRECTIVE: TODO CONTINUATION]\nOld" }] },
+            { info: { id: "m2", role: "user", time: 2 } as any, parts: [{ type: "text", text: "[SYSTEM DIRECTIVE: TODO CONTINUATION]\nMid" }] },
+            { info: { id: "m3", role: "user", time: 3 } as any, parts: [{ type: "text", text: "[SYSTEM DIRECTIVE: TODO CONTINUATION]\nNew" }] },
+            { info: { id: "m4", role: "user", time: 4 } as any, parts: [{ type: "text", text: "[SYSTEM DIRECTIVE: TODO CONTINUATION]\nNewest" }] },
+        ]
+        const config = { enabled: true, filters: { "omo-todo-continuation": { enabled: true, keepLast: 3 } } }
+        applyMessageFilters(messages, config, makeLogger(), { sessionId: "s", isSubAgent: false })
+        assert.equal((messages[0].parts[0] as any).text, "")
+        assert.equal((messages[1].parts[0] as any).text, "[SYSTEM DIRECTIVE: TODO CONTINUATION]\nMid")
+        assert.equal((messages[2].parts[0] as any).text, "[SYSTEM DIRECTIVE: TODO CONTINUATION]\nNew")
+        assert.equal((messages[3].parts[0] as any).text, "[SYSTEM DIRECTIVE: TODO CONTINUATION]\nNewest")
     })
 
     it("handles single occurrence (no dedup needed)", () => {


### PR DESCRIPTION
## Changes

### 1. omo-system-reminder filter: keep last 2, drop older (issue #267)

**User request**: "把除了最近两条之外的删除，历史上的都可以删除，最近的都让它显示出来"

Old behavior (v1.0.0): stripped ALL system-reminder blocks from matched messages, keeping only the surrounding user content.
New behavior (v1.2.0): `keepLastOnly: true, keepLast: 2` — keeps the last 2 matching messages, drops older duplicates.

### 2. Framework: configurable `keepLast` per filter

**User request**: "这个用户配置的时候可以配置keep多少吗？"

Users can now override how many recent matches to keep for any `keepLastOnly` filter:

```jsonc
{
  "messageFilters": {
    "filters": {
      "omo-system-reminder": { "keepLast": 5 },
      "omo-context": { "keepLast": 3 }
    }
  }
}
```

Default `keepLast: 1` when not specified. Backward compatible — existing filters without `keepLast` default to 1.

### Files changed (7 files, +155/-105)
- `lib/messages/filter/builtin/omo-system-reminder.ts` — v1.2.0, keepLast: 2
- `lib/messages/filter/types.ts` — added `keepLast?: number` to MessageFilter + MessageFilterConfig
- `lib/messages/filter/apply.ts` — Phase 2 counter reads config override
- `dcp.schema.json` — added `keepLast` to per-filter schema
- `tests/message-filter.test.ts` — added configurable keepLast test (39 tests total)
- `devlog/...` — REQ.md + WORKLOG.md

### Verification
- 953 tests pass (0 failures)
- typecheck clean
- All existing keepLastOnly tests still pass (backward compatible)