### PR TITLE
release: v1.14.11 — omo-system-reminder keepLast=2 + configurable keepLast

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,15 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.11 — Stable Release (1 PR since v1.14.10)
+
+Stable release with the omo-system-reminder filter fix and configurable `keepLast`.
+
+**PRs included**:
+- **#268** — Fix (issue #267): `omo-system-reminder` filter was stripping ALL `<system-reminder>` blocks from messages, deleting background task notifications and preventing the main session from recovering subagent results. Rewrote to v1.2.0: `keepLastOnly: true, keepLast: 2` — keeps the 2 most recent matches, drops older duplicates. Also adds framework-level configurable `keepLast` field so users can override how many recent matches to keep per `keepLastOnly` filter (default 1, clamped to minimum 1).
+
+**Install**: `opencode plugin opencode-acp@stable --global`
+
 ### v1.14.10 — Stable Release (1 PR since v1.14.9)
 
 Stable release with the omo-mode-injection filter fix.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,6 +446,15 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 ## 更新日志
 
+### v1.14.11 — 正式版（v1.14.10 以来 1 个 PR）
+
+正式版发布，包含 omo-system-reminder 过滤器修复和可配置 `keepLast`。
+
+**包含的 PR**：
+- **#268** — 修复（issue #267）：`omo-system-reminder` 过滤器删除所有 `<system-reminder>` 块，导致后台任务通知丢失、主会话无法恢复子代理结果。改为 v1.2.0：`keepLastOnly: true, keepLast: 2` — 保留最近 2 条匹配，丢弃更早的重复。同时添加框架级可配置 `keepLast` 字段，用户可覆盖每个 `keepLastOnly` 过滤器保留最近几条（默认 1，最小 1）。
+
+**安装**：`opencode plugin opencode-acp@stable --global`
+
 ### v1.14.10 — 正式版（v1.14.9 以来 1 个 PR）
 
 正式版发布，包含 omo-mode-injection 过滤器修复。

--- a/devlog/2026-08-03_release-v1.14.11/REQ.md
+++ b/devlog/2026-08-03_release-v1.14.11/REQ.md
@@ -1,0 +1,11 @@
+# REQ: Release v1.14.11
+
+## Goal
+Publish stable release v1.14.11 to npm `latest` tag.
+
+## Scope
+1 PR since v1.14.10:
+- **#268** — omo-system-reminder filter keepLast=2 + configurable keepLast (issue #267)
+
+## Version
+`1.14.11` (stable, no `-` → CI publishes to `latest`)

--- a/devlog/2026-08-03_release-v1.14.11/WORKLOG.md
+++ b/devlog/2026-08-03_release-v1.14.11/WORKLOG.md
@@ -1,0 +1,8 @@
+# WORKLOG: Release v1.14.11
+
+## 2026-08-03
+
+- Created release branch `2026-08-03_release-v1.14.11` from master `3bbd9b7`
+- Bumped version `1.14.10` → `1.14.11`
+- Added changelog entries to README.md and README.zh-CN.md
+- PR #268 (omo-system-reminder keepLast=2 + configurable keepLast) was dual-agent reviewed (Oracle APPROVE, Explore APPROVE), merged by user

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.10",
+    "version": "1.14.11",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Release v1.14.11 (stable → latest)

1 PR since v1.14.10:
- **#268** — omo-system-reminder filter keepLast=2 + configurable keepLast (issue #267)

### Install
```bash
opencode plugin opencode-acp@stable --global
```

### Changelog
See README.md → Changelog → v1.14.11

### Verification
- 953 tests pass
- typecheck clean
- Dual-agent review on #268: Oracle APPROVE, Explore APPROVE
- CI will run on this PR