### PR TITLE
promote: stable v1.14.11 — sync stable tag with latest

### DIFF
--- a/devlog/2026-08-03_promote-stable-v1.14.11/REQ.md
+++ b/devlog/2026-08-03_promote-stable-v1.14.11/REQ.md
@@ -1,0 +1,10 @@
+# REQ: Promote v1.14.11 to npm stable tag
+
+## Goal
+Update npm `stable` dist-tag from 1.14.8 → 1.14.11.
+
+## Why
+`stable` tag is stale (still at 1.14.8). `latest` is already at 1.14.11. Users installing `opencode-acp@stable` should get the latest stable release.
+
+## How
+CI detects `promote: stable v1.14.11` commit message → runs `npm dist-tag add opencode-acp@1.14.11 stable`.

--- a/devlog/2026-08-03_promote-stable-v1.14.11/WORKLOG.md
+++ b/devlog/2026-08-03_promote-stable-v1.14.11/WORKLOG.md
@@ -1,0 +1,7 @@
+# WORKLOG: Promote v1.14.11 to stable
+
+## 2026-08-03
+
+- PR #269 (v1.14.11) merged by user, CI published to `latest`
+- Created promote-stable branch to update `stable` tag from 1.14.8 → 1.14.11
+- CI will run `npm dist-tag add opencode-acp@1.14.11 stable` on merge


### PR DESCRIPTION
## Promote v1.14.11 to npm `stable` tag

`stable` tag is stale at 1.14.8. `latest` is already at 1.14.11 (PR #269 merged).

CI will run:
```bash
npm dist-tag add opencode-acp@1.14.11 stable
```

After merge:
```
stable: 1.14.8 → 1.14.11
latest: 1.14.11 (unchanged)
dev:    1.14.9-dev.2 (unchanged)
```