### PR TITLE
fix: omo-system-reminder filter strips blocks, preserves user content

### DIFF
--- a/devlog/2026-08-04_filter-strip-user-content/REQ.md
+++ b/devlog/2026-08-04_filter-strip-user-content/REQ.md
@@ -1,0 +1,13 @@
+# REQ: Fix omo-system-reminder filter dropping user content
+
+## Problem
+The `omo-system-reminder` filter (v1.2.0, PR #268) returns `{ action: "drop" }` for ANY user message containing `<system-reminder>` blocks. Phase 2 `keepLastOnly` then hard-drops older matches entirely — including the user's actual text.
+
+When OMO injects `<system-reminder>` blocks into user messages via `additionalContext`, the user's text and the OMO block share the same message part. Dropping the part loses both.
+
+## Fix
+Two changes:
+
+1. **Filter (`omo-system-reminder.ts` v1.3.0)**: Strip `<system-reminder>` blocks and OMO markers. Return `modify` when user content remains after stripping. Return `drop` only when the message is pure OMO content (no user text).
+
+2. **Phase 2 (`apply.ts`)**: For older matches (beyond last N), apply the filter's actual decision (`modify` or `drop`) instead of unconditional `{ action: "drop" }`. This preserves user text in older messages while still stripping stale OMO blocks.

--- a/devlog/2026-08-04_filter-strip-user-content/WORKLOG.md
+++ b/devlog/2026-08-04_filter-strip-user-content/WORKLOG.md
@@ -1,0 +1,12 @@
+# WORKLOG: Fix omo-system-reminder filter dropping user content
+
+## 2026-08-04
+
+- User identified the bug: "看看这个会删除的时候剥离出错，把正确的用户历史消息剥离错误吗？"
+- Root cause: `omo-system-reminder` v1.2.0 filter returned `{ action: "drop" }` for entire message when `<system-reminder>` blocks present. Phase 2 `keepLastOnly` hard-dropped older matches, losing user content.
+- Fix 1: Rewrote filter to v1.3.0 — strips blocks, returns `modify` when user text remains, `drop` only for pure OMO content
+- Fix 2: Phase 2 now applies filter's actual decision for older matches instead of unconditional drop
+- Added regression test: 4 messages with mixed user content + blocks, oldest 2 stripped (user text preserved), latest 2 kept as-is
+- Updated test: lone OMO marker with user content → `modify` (was `drop`)
+- Updated version check: 1.2.0 → 1.3.0
+- 954 tests pass, typecheck clean

--- a/lib/messages/filter/apply.ts
+++ b/lib/messages/filter/apply.ts
@@ -128,11 +128,8 @@ export function applyMessageFilters(
                 if (decision.action !== "drop" && decision.action !== "modify") continue
                 if (kept < keepCount) {
                     kept++
-                    if (decision.action === "modify" && decision.text !== undefined) {
-                        applyDecision(part as { text?: string }, decision, filter.name, i, text)
-                    }
                 } else {
-                    applyDecision(part as { text?: string }, { action: "drop", reason: `keepLastOnly(${keepCount}): earlier occurrence` }, filter.name, i, text)
+                    applyDecision(part as { text?: string }, decision, filter.name, i, text)
                 }
             }
         }

--- a/lib/messages/filter/builtin/omo-system-reminder.ts
+++ b/lib/messages/filter/builtin/omo-system-reminder.ts
@@ -1,12 +1,19 @@
 import type { MessageFilter, MessageFilterContext, FilterResult } from "../types"
 
 const SYSTEM_REMINDER_OPEN = "<system-reminder>"
+const SYSTEM_REMINDER_CLOSE = "</system-reminder>"
 const OMO_MARKER = "<!-- OMO_INTERNAL_INITIATOR -->"
+
+// Pre-compiled regexes for stripping OMO system-reminder blocks.
+const PAIRED_BLOCK_RE = /<system-reminder>[\s\S]*?<\/system-reminder>\s*<!-- OMO_INTERNAL_INITIATOR -->/g
+const LONE_REMINDER_RE = /<system-reminder>[\s\S]*?<\/system-reminder>/g
+const LONE_MARKER_RE = /<!-- OMO_INTERNAL_INITIATOR -->/g
 
 const OMO_SYSTEM_REMINDER_FILTER: MessageFilter = {
     name: "omo-system-reminder",
-    version: "1.2.0",
-    description: "Keep only the 2 most recent OMO <system-reminder> messages, drop older ones",
+    version: "1.3.0",
+    description:
+        "Keep recent OMO <system-reminder> messages; for older ones, strip blocks but preserve user content",
     keepLastOnly: true,
     keepLast: 2,
 
@@ -15,7 +22,30 @@ const OMO_SYSTEM_REMINDER_FILTER: MessageFilter = {
         if (!ctx.text.includes(SYSTEM_REMINDER_OPEN) && !ctx.text.includes(OMO_MARKER)) {
             return { action: "keep" }
         }
-        return { action: "drop", reason: "OMO system-reminder match (keepLast dedup)" }
+
+        let modified = ctx.text
+        let removedBlocks = 0
+
+        modified = modified.replace(PAIRED_BLOCK_RE, () => {
+            removedBlocks++
+            return ""
+        })
+        modified = modified.replace(LONE_REMINDER_RE, () => {
+            removedBlocks++
+            return ""
+        })
+        modified = modified.replace(LONE_MARKER_RE, "")
+        modified = modified.replace(/\n{3,}/g, "\n\n").trim()
+
+        if (modified.length === 0) {
+            return { action: "drop", reason: `Pure OMO system-reminder (${removedBlocks} block(s), no user content)` }
+        }
+
+        return {
+            action: "modify",
+            text: modified,
+            reason: `Stripped ${removedBlocks} OMO system-reminder block(s), preserved user content (${modified.length} chars)`,
+        }
     },
 }
 

--- a/tests/message-filter.test.ts
+++ b/tests/message-filter.test.ts
@@ -236,10 +236,11 @@ describe("OMO system-reminder filter", () => {
         assert.equal(result.action, "drop")
     })
 
-    it("matches user message with lone OMO marker", () => {
+    it("matches user message with lone OMO marker, preserves user content", () => {
         const text = `Real content.\n<!-- OMO_INTERNAL_INITIATOR -->`
         const result = filter.filter(makeCtx({ text, role: "user" }))
-        assert.equal(result.action, "drop")
+        assert.equal(result.action, "modify")
+        assert.equal(result.text, "Real content.")
     })
 
     it("does not match assistant messages", () => {
@@ -290,6 +291,22 @@ describe("OMO system-reminder filter", () => {
         assert.ok((messages[0].parts[0] as any).text.includes("first"), "first kept")
         assert.ok((messages[1].parts[0] as any).text.includes("second"), "second kept")
     })
+
+    it("preserves user content when stripping older system-reminder messages", () => {
+        registerMessageFilter(OMO_SYSTEM_REMINDER_FILTER)
+        const messages: WithParts[] = [
+            { info: { id: "m1", role: "user", time: 1 } as any, parts: [{ type: "text", text: "<system-reminder>[BG DONE] old task</system-reminder>\n\nFix the login bug please" }] },
+            { info: { id: "m2", role: "user", time: 2 } as any, parts: [{ type: "text", text: "<system-reminder>[BG DONE] task 2</system-reminder>\n\nThanks for the help" }] },
+            { info: { id: "m3", role: "user", time: 3 } as any, parts: [{ type: "text", text: "<system-reminder>[BG DONE] task 3</system-reminder><!-- OMO_INTERNAL_INITIATOR -->" }] },
+            { info: { id: "m4", role: "user", time: 4 } as any, parts: [{ type: "text", text: "<system-reminder>[BG DONE] task 4</system-reminder><!-- OMO_INTERNAL_INITIATOR -->" }] },
+        ]
+        const config = { enabled: true, filters: { "omo-system-reminder": { enabled: true } } }
+        applyMessageFilters(messages, config, makeLogger(), { sessionId: "s", isSubAgent: false })
+        assert.equal((messages[0].parts[0] as any).text, "Fix the login bug please", "oldest: user content preserved, blocks stripped")
+        assert.equal((messages[1].parts[0] as any).text, "Thanks for the help", "2nd oldest: user content preserved, blocks stripped")
+        assert.ok((messages[2].parts[0] as any).text.includes("task 3"), "2nd-most-recent kept as-is")
+        assert.ok((messages[3].parts[0] as any).text.includes("task 4"), "most-recent kept as-is")
+    })
 })
 
 describe("ensureBuiltinFiltersRegistered", () => {
@@ -298,7 +315,7 @@ describe("ensureBuiltinFiltersRegistered", () => {
     it("registers the OMO filter", () => {
         ensureBuiltinFiltersRegistered()
         assert.ok(getMessageFilter("omo-system-reminder"))
-        assert.equal(getMessageFilter("omo-system-reminder")!.version, "1.2.0")
+        assert.equal(getMessageFilter("omo-system-reminder")!.version, "1.3.0")
     })
 
     it("is idempotent", () => {


### PR DESCRIPTION
## Bug: Filter drops user content with `<system-reminder>` blocks

### Problem
The `omo-system-reminder` filter (v1.2.0) returned `{ action: "drop" }` for ANY user message containing `<system-reminder>` blocks — even when user text was also present. Phase 2 `keepLastOnly` then hard-dropped older matches entirely, losing the user's actual message content.

### Fix (2 changes)

**1. Filter v1.3.0**: Strip `<system-reminder>` blocks, return `modify` when user content remains, `drop` only for pure OMO messages.

**2. Phase 2**: Apply filter's actual decision for older matches instead of unconditional drop.

### Tests
- 954 tests pass, typecheck clean
- New regression test: mixed user content + blocks, oldest stripped (text preserved), latest kept