### PR TITLE
release: v1.14.12 — omo-system-reminder filter preserves user content (#271)

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,15 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.12 — Stable Release (1 PR since v1.14.11)
+
+Stable release with the omo-system-reminder filter fix that preserves user content when stripping `<system-reminder>` blocks.
+
+**PRs included**:
+- **#271** — Fix (follow-up to #268): `omo-system-reminder` filter v1.2.0 returned `{ action: "drop" }` for ANY user message containing `<system-reminder>`, losing user text when OMO prepends system-reminder blocks to user messages. Rewrote to v1.3.0: strips `<system-reminder>` blocks + OMO markers, preserves remaining user content via `modify`. Pure OMO messages still return `drop`. Phase 2 `keepLastOnly` now applies the filter's actual decision (drop or modify) to older matches instead of unconditional drop. Recent N matches kept fully untouched (semantically correct). Backward compatible with other 3 `keepLastOnly` filters (they only return `drop`). Dual-agent reviewed (Oracle + Explore, both APPROVE).
+
+**Install**: `opencode plugin opencode-acp@stable --global`
+
 ### v1.14.11 — Stable Release (1 PR since v1.14.10)
 
 Stable release with the omo-system-reminder filter fix and configurable `keepLast`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,6 +446,15 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 ## 更新日志
 
+### v1.14.12 — 正式版（v1.14.11 以来 1 个 PR）
+
+正式版发布，包含 omo-system-reminder 过滤器修复——剥离 `<system-reminder>` 块时保留用户正文。
+
+**包含的 PR**：
+- **#271** — 修复（#268 后续）：`omo-system-reminder` 过滤器 v1.2.0 对任何含 `<system-reminder>` 的用户消息直接返回 `drop`，当 OMO 将 system-reminder 块注入到用户消息前面时丢失用户正文。改为 v1.3.0：剥离 `<system-reminder>` 块 + OMO 标记，保留剩余用户内容（`modify`）。纯 OMO 消息仍返回 `drop`。Phase 2 `keepLastOnly` 现在对较旧的匹配应用过滤器实际决策（drop 或 modify），不再无条件丢弃。最近 N 条保持不动（语义正确）。与其他 3 个 `keepLastOnly` 过滤器向后兼容（它们只返回 `drop`）。双 Agent Review（Oracle + Explore，全部 APPROVE）。
+
+**安装**：`opencode plugin opencode-acp@stable --global`
+
 ### v1.14.11 — 正式版（v1.14.10 以来 1 个 PR）
 
 正式版发布，包含 omo-system-reminder 过滤器修复和可配置 `keepLast`。

--- a/devlog/2026-08-04_release-v1.14.12/REQ.md
+++ b/devlog/2026-08-04_release-v1.14.12/REQ.md
@@ -1,0 +1,18 @@
+# REQ: Release v1.14.12
+
+## Goal
+Publish stable release v1.14.12 to npm `latest` tag, superseding v1.14.11.
+
+## Scope
+1 PR since v1.14.11:
+- **#271** — omo-system-reminder filter v1.3.0: strips `<system-reminder>` blocks, preserves user content. Phase 2 keepLastOnly applies actual decision.
+
+## Checklist
+- [x] Bump version in `package.json`
+- [x] Add changelog to `README.md`
+- [x] Add changelog to `README.zh-CN.md`
+- [x] Create devlog (REQ.md + WORKLOG.md)
+- [ ] Verify CI locally
+- [ ] Commit, push, create PR
+- [ ] Wait for CI
+- [ ] User merges PR

--- a/devlog/2026-08-04_release-v1.14.12/WORKLOG.md
+++ b/devlog/2026-08-04_release-v1.14.12/WORKLOG.md
@@ -1,0 +1,11 @@
+# WORKLOG: Release v1.14.12
+
+## Steps
+1. Created worktree `/tmp/opencode-acp-release-v1.14.12` from `github/master` (411fe4f)
+2. Created branch `2026-08-04_release-v1.14.12`
+3. Bumped version 1.14.11 → 1.14.12
+4. Added changelog entries to README.md and README.zh-CN.md
+5. Created devlog REQ.md + WORKLOG.md
+
+## PRs Included
+- #271 — omo-system-reminder filter strips blocks, preserves user content (Oracle + Explore APPROVE)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.11",
+    "version": "1.14.12",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## v1.14.12 — Stable Release

1 PR since v1.14.11:
- **#271** — omo-system-reminder filter v1.3.0: strips `<system-reminder>` blocks + OMO markers, preserves remaining user content via `modify`. Phase 2 `keepLastOnly` applies actual decision (drop/modify) instead of unconditional drop. Recent N matches kept untouched. Backward compatible. Oracle + Explore both APPROVE.

**Install**: `opencode plugin opencode-acp@stable --global`

CI will auto-publish to npm `latest` tag on merge.