### PR TITLE
promote: stable v1.14.12 — sync stable tag with latest

### DIFF
--- a/devlog/2026-08-04_promote-stable-v1.14.12/REQ.md
+++ b/devlog/2026-08-04_promote-stable-v1.14.12/REQ.md
@@ -1,0 +1,5 @@
+# REQ: Promote stable v1.14.12
+
+Sync npm `stable` tag with `latest` (v1.14.12).
+
+CI runs `npm dist-tag add opencode-acp@1.14.12 stable` on merge.

--- a/devlog/2026-08-04_promote-stable-v1.14.12/WORKLOG.md
+++ b/devlog/2026-08-04_promote-stable-v1.14.12/WORKLOG.md
@@ -1,0 +1,3 @@
+# WORKLOG: Promote stable v1.14.12
+
+Created promote-stable branch. CI will run `npm dist-tag add opencode-acp@1.14.12 stable` on merge.


### PR DESCRIPTION
Sync npm `stable` tag with `latest` (v1.14.12).

CI runs `npm dist-tag add opencode-acp@1.14.12 stable` on merge.