### PR TITLE
feat: promote allowSubAgents to top-level with default true

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,7 +265,8 @@ Three-layer config merging (later layers override earlier):
     pruneNotification: "detailed",
     pruneNotificationType: "toast",
     commands: { enabled: true, protectedTools: ["task", "skill", "todowrite", "todoread", "compress", "batch", "plan_enter", "plan_exit", "write", "edit"] },
-    experimental: { allowSubAgents: false, customPrompts: false },
+    allowSubAgents: true,
+    experimental: { customPrompts: false },
     protectedFilePatterns: [],
     compress: {
         mode: "range",

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -103,15 +103,19 @@ Controls ACP slash commands (`/acp context`, `/acp stats`, etc.).
 
 ---
 
+### `allowSubAgents`
+
+- **Type:** `boolean`
+- **Default:** `true`
+- **Status:** ACTIVE
+- **Description:** Allow ACP to run in sub-agent sessions. When enabled, subagent sessions get full compression, nudge, and context-management capabilities. Set to `false` to restrict ACP to the main session only.
+- **Migration:** Moved from `experimental.allowSubAgents` (default `false`) to top-level `allowSubAgents` (default `true`) in v1.14.13. The old `experimental.allowSubAgents` key is still read for backward compatibility — top-level takes priority.
+
+---
+
 ### `experimental`
 
 Experimental features that may change or be removed.
-
-#### `experimental.allowSubAgents`
-- **Type:** `boolean`
-- **Default:** `false`
-- **Status:** EXPERIMENTAL
-- **Description:** Allow ACP to run in sub-agent sessions. By default, ACP only activates in the main session to avoid interference with delegated tasks.
 
 #### `experimental.customPrompts`
 - **Type:** `boolean`

--- a/CONFIGURATION.zh-CN.md
+++ b/CONFIGURATION.zh-CN.md
@@ -103,15 +103,19 @@ ACP 从最多三层配置文件中读取（后加载的覆盖先加载的）：
 
 ---
 
+### `allowSubAgents`
+
+- **类型：** `boolean`
+- **默认值：** `true`
+- **状态：** ACTIVE
+- **说明：** 允许 ACP 在子代理（sub-agent）会话中运行。开启后，子代理会话获得完整的压缩、nudge 和上下文管理能力。设为 `false` 可将 ACP 限制在主会话中。
+- **迁移：** v1.14.13 从 `experimental.allowSubAgents`（默认 `false`）移至顶层 `allowSubAgents`（默认 `true`）。旧的 `experimental.allowSubAgents` 仍可读取以保持向后兼容 —— 顶层优先。
+
+---
+
 ### `experimental`
 
 实验性功能，可能变更或移除。
-
-#### `experimental.allowSubAgents`
-- **类型：** `boolean`
-- **默认值：** `false`
-- **状态：** EXPERIMENTAL
-- **说明：** 允许 ACP 在子代理（sub-agent）会话中运行。默认情况下，ACP 仅在主会话中激活，以避免干扰委托任务。
 
 #### `experimental.customPrompts`
 - **类型：** `boolean`

--- a/README.md
+++ b/README.md
@@ -298,10 +298,10 @@ Each level overrides the previous, so project settings take priority over global
     },
     // Manual mode: disables autonomous context management,
     // tools only run when explicitly triggered via /acp commands
+    // Allow ACP processing in subagent sessions (default: true)
+    "allowSubAgents": true,
     // Experimental settings
     "experimental": {
-        // Allow ACP processing in subagent sessions
-        "allowSubAgents": false,
         // Enable user-editable prompt overrides under dcp-prompts directories
         // When false (default), prompt override files/directories are ignored
         "customPrompts": false,

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -253,10 +253,10 @@ ACP 使用自己的配置文件，按以下顺序搜索：
     },
     // Manual mode: disables autonomous context management,
     // tools only run when explicitly triggered via /acp commands
+    // 允许在子代理会话中运行 ACP（默认：开启）
+    "allowSubAgents": true,
     // Experimental settings
     "experimental": {
-        // Allow ACP processing in subagent sessions
-        "allowSubAgents": false,
         // Enable user-editable prompt overrides under dcp-prompts directories
         // When false (default), prompt override files/directories are ignored
         "customPrompts": false,

--- a/TESTING.md
+++ b/TESTING.md
@@ -152,7 +152,8 @@ function buildConfig(mode: "message" | "range" = "message"): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "toast",
         commands: { enabled: true, protectedTools: [] },
-        experimental: { allowSubAgents: false, customPrompts: false },
+        allowSubAgents: false,
+        experimental: { customPrompts: false },
         protectedFilePatterns: [],
         compress: {
             mode,
@@ -443,7 +444,8 @@ function buildConfig(): PluginConfig {
         pruneNotification: "off",
         pruneNotificationType: "toast",
         commands: { enabled: true, protectedTools: [] },
-        experimental: { allowSubAgents: false, customPrompts: false },
+        allowSubAgents: false,
+        experimental: { customPrompts: false },
         protectedFilePatterns: [],
         compress: {
             mode: "range",

--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -68,6 +68,11 @@
                 "protectedTools": []
             }
         },
+        "allowSubAgents": {
+            "type": "boolean",
+            "default": true,
+            "description": "Allow ACP processing in subagent sessions. When true, subagent sessions get full compression/nudge capabilities. (Moved from experimental in v1.14.13; old experimental.allowSubAgents still read for backward compat.)"
+        },
         "experimental": {
             "type": "object",
             "description": "Experimental settings that may change in future releases",
@@ -76,7 +81,7 @@
                 "allowSubAgents": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Allow DCP processing in subagent sessions"
+                    "description": "[DEPRECATED — use top-level allowSubAgents] Allow ACP processing in subagent sessions. Kept for backward compat; top-level takes priority."
                 },
                 "customPrompts": {
                     "type": "boolean",
@@ -85,7 +90,6 @@
                 }
             },
             "default": {
-                "allowSubAgents": false,
                 "customPrompts": false
             }
         },

--- a/devlog/2026-08-04_allow-subagents-default/REQ.md
+++ b/devlog/2026-08-04_allow-subagents-default/REQ.md
@@ -1,0 +1,26 @@
+# REQ: Promote allowSubAgents to Top-Level + Default True
+
+## Problem
+
+`allowSubAgents` was under `experimental` config namespace with default `false`. The feature is stable, tested, and useful — subagent sessions benefit from compression just like main sessions. Keeping it experimental and off by default prevents users from discovering it.
+
+## Requirements
+
+1. Move `allowSubAgents` from `experimental.allowSubAgents` to top-level `allowSubAgents`
+2. Change default from `false` to `true`
+3. Full backward compatibility: old `experimental.allowSubAgents` still read (top-level takes priority)
+4. Update all documentation (README, CONFIGURATION, AGENTS.md)
+5. Update JSON schema (dcp.schema.json)
+
+## Acceptance Criteria
+
+- [x] `config.allowSubAgents` is a top-level boolean field
+- [x] Default is `true` (was `false`)
+- [x] Old `experimental.allowSubAgents` configs still work (backward compat)
+- [x] All 4 hooks sites updated (`index.ts` line 111, `hooks.ts` lines 89/110/166)
+- [x] JSON schema updated with top-level field + deprecated experimental field
+- [x] README.md, README.zh-CN.md, CONFIGURATION.md, CONFIGURATION.zh-CN.md updated
+- [x] AGENTS.md §2.4 default config updated
+- [x] Typecheck passes
+- [x] All 954 tests pass
+- [x] Dual-agent review

--- a/devlog/2026-08-04_allow-subagents-default/WORKLOG.md
+++ b/devlog/2026-08-04_allow-subagents-default/WORKLOG.md
@@ -1,0 +1,49 @@
+# WORKLOG: Promote allowSubAgents to Top-Level + Default True
+
+## Implementation
+
+### Code Changes
+
+1. **`lib/config.ts`**:
+   - Removed `allowSubAgents` from `ExperimentalConfig` interface
+   - Added `allowSubAgents: boolean` to top-level `PluginConfig`
+   - Default: `true` (was `experimental.allowSubAgents: false`)
+   - `mergeLayer`: reads `data.allowSubAgents ?? data.experimental?.allowSubAgents ?? config.allowSubAgents` (backward compat)
+   - `mergeExperimental`: removed `allowSubAgents` from merge
+
+2. **`lib/config-validation.ts`**:
+   - Added `"allowSubAgents"` to top-level VALID_CONFIG_KEYS
+   - Kept `"experimental.allowSubAgents"` for backward compat (no false warnings)
+
+3. **`lib/hooks.ts`** (3 sites):
+   - Line 89: `!config.allowSubAgents` (system prompt hook, subagent guard)
+   - Line 110: `config.allowSubAgents` (subagent mode prompt text)
+   - Line 166: `!config.allowSubAgents` (message transform hook, subagent guard)
+
+4. **`index.ts`** (1 site):
+   - Line 111: `!config.allowSubAgents` (primary_tools restriction when subagents disallowed)
+
+5. **`dcp.schema.json`**:
+   - Added top-level `allowSubAgents` (boolean, default `true`)
+   - Marked `experimental.allowSubAgents` as DEPRECATED (kept for backward compat)
+   - Removed `allowSubAgents` from `experimental.default`
+
+### Documentation Changes
+
+- `README.md`: Updated default config block
+- `README.zh-CN.md`: Updated default config block
+- `CONFIGURATION.md`: Moved `allowSubAgents` from experimental section to main section
+- `CONFIGURATION.zh-CN.md`: Same
+- `AGENTS.md` §2.4: Updated default config example
+
+### Backward Compatibility
+
+Old configs work without changes:
+- `{ "experimental": { "allowSubAgents": true } }` → mergeLayer reads `data.experimental?.allowSubAgents` → works
+- `{ "experimental": { "allowSubAgents": false } }` → same, disables subagents
+- No config: defaults to `true` (behavior change — was `false`)
+
+### Verification
+
+- Typecheck: PASS
+- Tests: 954/954 PASS

--- a/index.ts
+++ b/index.ts
@@ -108,7 +108,7 @@ const server: Plugin = (async (ctx) => {
             }
 
             const toolsToAdd: string[] = []
-            if (config.compress.permission !== "deny" && !config.experimental.allowSubAgents) {
+            if (config.compress.permission !== "deny" && !config.allowSubAgents) {
                 toolsToAdd.push("compress", "decompress", "search_context", "acp_status")
             }
 

--- a/lib/config-validation.ts
+++ b/lib/config-validation.ts
@@ -113,6 +113,10 @@ export function validateConfigTypes(config: Record<string, any>): ValidationErro
         errors.push({ key: "debug", expected: "boolean", actual: typeof config.debug })
     }
 
+    if (config.allowSubAgents !== undefined && typeof config.allowSubAgents !== "boolean") {
+        errors.push({ key: "allowSubAgents", expected: "boolean", actual: typeof config.allowSubAgents })
+    }
+
     if (config.pruneNotification !== undefined) {
         const validValues = ["off", "minimal", "detailed"]
         if (!validValues.includes(config.pruneNotification)) {

--- a/lib/config-validation.ts
+++ b/lib/config-validation.ts
@@ -9,6 +9,7 @@ export const VALID_CONFIG_KEYS = new Set([
     "autoUpdate",
     "debug",
     "showUpdateToasts",
+    "allowSubAgents",
     "pruneNotification",
     "pruneNotificationType",
     "experimental",

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -47,7 +47,6 @@ export interface Commands {
 }
 
 export interface ExperimentalConfig {
-    allowSubAgents: boolean
     customPrompts: boolean
 }
 
@@ -85,6 +84,7 @@ export interface PluginConfig {
     enabled: boolean
     autoUpdate: boolean
     debug: boolean
+    allowSubAgents: boolean
     pruneNotification: "off" | "minimal" | "detailed"
     pruneNotificationType: "chat" | "toast"
     commands: Commands
@@ -174,6 +174,7 @@ const defaultConfig: PluginConfig = {
     enabled: true,
     autoUpdate: true,
     debug: false,
+    allowSubAgents: true,
     pruneNotification: "off",
     // [FIX #20] Default to toast — chat-mode notifications inject an empty
     // user message that freezes the session on providers that reject empty
@@ -184,7 +185,6 @@ const defaultConfig: PluginConfig = {
         protectedTools: [...DEFAULT_PROTECTED_TOOLS],
     },
     experimental: {
-        allowSubAgents: false,
         customPrompts: false,
     },
     protectedFilePatterns: [],
@@ -411,7 +411,6 @@ function mergeExperimental(
     if (override === undefined) return base
 
     return {
-        allowSubAgents: override.allowSubAgents ?? base.allowSubAgents,
         customPrompts: override.customPrompts ?? base.customPrompts,
     }
 }
@@ -498,6 +497,7 @@ function mergeLayer(config: PluginConfig, data: Record<string, any>): PluginConf
         enabled: data.enabled ?? config.enabled,
         autoUpdate: data.autoUpdate ?? config.autoUpdate,
         debug: data.debug ?? config.debug,
+        allowSubAgents: data.allowSubAgents ?? data.experimental?.allowSubAgents ?? config.allowSubAgents,
         pruneNotification: data.pruneNotification ?? config.pruneNotification,
         pruneNotificationType: data.pruneNotificationType ?? config.pruneNotificationType,
         commands: mergeCommands(config.commands, data.commands as any),

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -86,7 +86,7 @@ export function createSystemPromptHandler(
             state.modelContextLimit = input.model.limit.context
         }
 
-        if (!state || (state.isSubAgent && !config.experimental.allowSubAgents)) {
+        if (!state || (state.isSubAgent && !config.allowSubAgents)) {
             return
         }
 
@@ -107,7 +107,7 @@ export function createSystemPromptHandler(
         const newPrompt = renderSystemPrompt(
             runtimePrompts,
             buildProtectedToolsExtension(config.compress.protectedTools),
-            state.isSubAgent && config.experimental.allowSubAgents,
+            state.isSubAgent && config.allowSubAgents,
         )
         if (output.system.length > 0) {
             output.system[output.system.length - 1] += "\n\n" + newPrompt
@@ -163,7 +163,7 @@ export function createChatMessageTransformHandler(
 
         syncCompressPermissionState(state, config, hostPermissions, output.messages)
 
-        if (state.isSubAgent && !config.experimental.allowSubAgents) {
+        if (state.isSubAgent && !config.allowSubAgents) {
             return
         }
 


### PR DESCRIPTION
## Summary

Promotes `allowSubAgents` from the experimental namespace to a top-level config field, and changes the default from `false` to `true`.

## Changes

- **Top-level field**: `config.allowSubAgents: boolean` (was `config.experimental.allowSubAgents`)
- **Default**: `true` (was `false`) — subagent compression is now on by default
- **Backward compat**: old `experimental.allowSubAgents` configs still work (top-level takes priority)
- **Updated 4 hook sites**: `index.ts:111`, `hooks.ts:89/110/166`
- **Type validation**: added boolean check for top-level `allowSubAgents` in `validateConfigTypes`
- **Updated schema**: top-level `allowSubAgents` + deprecated `experimental.allowSubAgents`
- **Updated docs**: README, README.zh-CN, CONFIGURATION, CONFIGURATION.zh-CN, AGENTS.md, TESTING.md

## Why

The feature is stable and well-tested. Subagent sessions benefit from compression just like main sessions.

## Dual-Agent Review

- **Oracle**: APPROVE — backward compat verified, type-safe, all consumers updated
- **Explore**: APPROVE — exhaustive grep confirms no missed references, merge logic correct

## Test Results

- Typecheck: PASS
- Tests: 954/954 PASS
- Build: PASS (386.62 KB)