### PR TITLE
release: v1.14.13-dev.1 — allowSubAgents promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,15 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.13-dev.1 — Dev Prerelease (1 PR since v1.14.12)
+
+Dev prerelease covering PR #276. Published to `dev` npm tag for early testing.
+
+**PRs included**:
+- **#276** — Promote `allowSubAgents` from experimental to top-level config field, change default from `false` to `true`. Subagent sessions now get compression by default. Fully backward compatible: old `experimental.allowSubAgents` configs still work (top-level takes priority). Updated all 4 hook sites, schema, config validation, and 6 documentation files. Dual-agent reviewed (Oracle + Explore, both APPROVE).
+
+**Install**: `opencode plugin opencode-acp@dev --global`
+
 ### v1.14.12 — Stable Release (1 PR since v1.14.11)
 
 Stable release with the omo-system-reminder filter fix that preserves user content when stripping `<system-reminder>` blocks.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,6 +446,15 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 ## 更新日志
 
+### v1.14.13-dev.1 — Dev 预发布版（v1.14.12 以来 1 个 PR）
+
+Dev 预发布版，包含 PR #276。发布到 `dev` npm tag 供早期测试。
+
+**包含的 PR**：
+- **#276** — 将 `allowSubAgents` 从实验性参数提升为顶级配置字段，默认值从 `false` 改为 `true`。子 Agent 会话默认开启压缩。完全向后兼容：旧的 `experimental.allowSubAgents` 配置仍然有效（顶级优先）。更新了 4 个 hook 调用点、schema、配置校验和 6 个文档文件。双 Agent Review（Oracle + Explore，均 APPROVE）。
+
+**安装**：`opencode plugin opencode-acp@dev --global`
+
 ### v1.14.12 — 正式版（v1.14.11 以来 1 个 PR）
 
 正式版发布，包含 omo-system-reminder 过滤器修复——剥离 `<system-reminder>` 块时保留用户正文。

--- a/devlog/2026-08-05_release-v1.14.13-dev.1/REQ.md
+++ b/devlog/2026-08-05_release-v1.14.13-dev.1/REQ.md
@@ -1,0 +1,9 @@
+# REQ — v1.14.13-dev.1 Dev Prerelease
+
+## Summary
+
+Dev prerelease covering PR #276 (allowSubAgents promotion to top-level config with default `true`).
+
+## Scope
+
+- **PR #276**: Promote `allowSubAgents` from `experimental` to top-level config field. Default changed from `false` to `true`. Backward compatible: old `experimental.allowSubAgents` configs still work.

--- a/devlog/2026-08-05_release-v1.14.13-dev.1/WORKLOG.md
+++ b/devlog/2026-08-05_release-v1.14.13-dev.1/WORKLOG.md
@@ -1,0 +1,13 @@
+# WORKLOG — v1.14.13-dev.1 Dev Prerelease
+
+## Steps
+
+1. Created worktree `/tmp/opencode-acp-release-v1.14.13-dev.1` from master `8f59d9f` (PR #276 merged)
+2. Bumped `package.json` version: `1.14.12` → `1.14.13-dev.1`
+3. Added changelog entries to `README.md` and `README.zh-CN.md`
+4. Created devlog
+
+## Verification
+
+- CI will run on PR creation (5 checks: pr-validation, test 22/24, build, e2e)
+- Version contains `-` → CI publishes to `dev` npm tag as prerelease

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.12",
+    "version": "1.14.13-dev.1",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
Dev prerelease covering PR #276 (allowSubAgents promotion to top-level config with default true).

**Version**: `1.14.13-dev.1` (has `-` → CI publishes to `dev` npm tag)

**PRs since v1.14.12**:
- #276 — Promote `allowSubAgents` from experimental to top-level config field, change default from `false` to `true`. Subagent sessions now get compression by default. Fully backward compatible: old `experimental.allowSubAgents` configs still work (top-level takes priority).

After merge, CI auto-publishes to npm `dev` tag as a prerelease GitHub Release.