### PR TITLE
fix: gate debug recommendation filter log behind shouldInject

### DIFF
--- a/devlog/2026-08-05_debug-nudge-log-noise/REQ.md
+++ b/devlog/2026-08-05_debug-nudge-log-noise/REQ.md
@@ -1,0 +1,9 @@
+# REQ — Debug Nudge Log Noise Fix
+
+## Problem
+
+When `config.debug: true`, the recommendation filter `logger.debug` fired on EVERY message transform hook call — even when no nudge was being injected. In normal sessions with compressible ranges (almost always), this produced a log entry per message. The user saw constant `[ACP Debug] Recommendation filter:` entries in the debug log and toast notifications, even when there was nothing meaningful to compress.
+
+## Fix
+
+Moved the recommendation filter `logger.debug` from its per-turn position (before the `shouldInject` decision) to inside the `shouldInject` block (after the nudge decision is finalized). The log now only fires when a nudge is actually being injected — i.e., when there is real compression to recommend.

--- a/devlog/2026-08-05_debug-nudge-log-noise/WORKLOG.md
+++ b/devlog/2026-08-05_debug-nudge-log-noise/WORKLOG.md
@@ -1,0 +1,12 @@
+# WORKLOG — Debug Nudge Log Noise Fix
+
+## Changes
+
+`lib/messages/inject/inject.ts`: Moved the recommendation filter `logger.debug` from line 350 (before `shouldInject` decision) to after line 476 (inside `shouldInject` block). Now gated by `shouldInject && config.debug`.
+
+## Verification
+
+- TypeScript: 0 errors
+- Tests: 954 pass, 0 fail
+- Build: 386.83 KB
+- Deployed to `~/.cache/opencode/packages/opencode-acp@latest/`

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -347,17 +347,6 @@ export const injectCompressNudges = (
     )
     const hasRecommendations = recommendedRanges.length > 0
 
-    if (config.debug && contextRanges.compressible.length > 0) {
-        const compressible = contextRanges.compressible
-        const fmt = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n))
-        const lines = [
-            `[ACP Debug] Recommendation filter:`,
-            `  Input: ${compressible.length} range(s), ${fmt(compressible.reduce((s, r) => s + r.tokens, 0))} tokens`,
-            `  Output: ${recommendedRanges.length} range(s) (last segment marked dangerous)`,
-        ]
-        logger.debug(lines.join("\n"))
-    }
-
     const allProtected = contextRanges.compressible.length === 0 && contextRanges.protected.length > 0
     const allInProtectedZone = protectedRefs.size > 0 && unprotectedCompressible.length === 0
     const nothingToCompress = allProtected || allInProtectedZone
@@ -485,6 +474,19 @@ export const injectCompressNudges = (
     }
 
     state.nudges.shouldInjectThisTurn = shouldInject
+
+    // Only log recommendation filter when a nudge is actually being injected —
+    // avoids noisy per-turn logging when there's nothing to compress.
+    if (shouldInject && config.debug && contextRanges.compressible.length > 0) {
+        const compressible = contextRanges.compressible
+        const fmt = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n))
+        const lines = [
+            `[ACP Debug] Recommendation filter:`,
+            `  Input: ${compressible.length} range(s), ${fmt(compressible.reduce((s, r) => s + r.tokens, 0))} tokens`,
+            `  Output: ${recommendedRanges.length} range(s) (last segment marked dangerous)`,
+        ]
+        logger.debug(lines.join("\n"))
+    }
 
     let tipsText: string | null = null
 


### PR DESCRIPTION
## Problem

When `config.debug: true`, the recommendation filter `logger.debug` fired on EVERY message transform hook call — even when no nudge was being injected. In normal sessions with compressible ranges (almost always), this produced a log entry per message. The user saw constant `[ACP Debug] Recommendation filter:` entries and toast notifications even when there was nothing to compress.

## Fix

Moved the recommendation filter `logger.debug` from its per-turn position (before `shouldInject` decision) to inside the `shouldInject` block. Now only fires when a nudge is actually being injected — i.e., when there is real compression to recommend.

## Verification

- TypeScript: 0 errors
- Tests: 954 pass, 0 fail
- Build: 386.83 KB
- Deployed locally