### PR TITLE
release: v1.14.13 — allowSubAgents promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,16 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.13 — Stable Release (3 PRs since v1.14.12)
+
+Stable release with `allowSubAgents` promoted to a top-level config field (default: `true`), plus config documentation updates.
+
+**PRs included**:
+- **#276** — Promote `allowSubAgents` from `experimental` to top-level config field, change default from `false` to `true`. Subagent sessions now get compression by default. Fully backward compatible: old `experimental.allowSubAgents` configs still work (top-level takes priority). Updated all 4 hook sites, schema, config validation, and 6 documentation files. Dual-agent reviewed (Oracle + Explore, both APPROVE).
+- **#280, #281** — Update recommended config in documentation: `maxContextLimit: 70%`, `minContextLimit: 70%`, simplified `protectedTools`.
+
+**Install**: `opencode plugin opencode-acp@stable --global`
+
 ### v1.14.13-dev.1 — Dev Prerelease (1 PR since v1.14.12)
 
 Dev prerelease covering PR #276. Published to `dev` npm tag for early testing.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,6 +446,16 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 ## 更新日志
 
+### v1.14.13 — 正式版（v1.14.12 以来 3 个 PR）
+
+正式版发布，`allowSubAgents` 从实验性参数提升为正式参数（默认：`true`），并更新了配置文档的推荐设置。
+
+**包含的 PR**：
+- **#276** — 将 `allowSubAgents` 从 `experimental` 提升为顶层配置字段，默认值从 `false` 改为 `true`。子 Agent 会话现在默认启用压缩。完全向后兼容：旧的 `experimental.allowSubAgents` 配置仍然有效（顶层优先级更高）。更新了全部 4 个 hook 调用点、schema、配置验证和 6 个文档文件。双 Agent 审查通过（Oracle + Explore，均 APPROVE）。
+- **#280, #281** — 更新文档中的推荐配置：`maxContextLimit: 70%`、`minContextLimit: 70%`，简化 `protectedTools`。
+
+**安装**：`opencode plugin opencode-acp@stable --global`
+
 ### v1.14.13-dev.1 — Dev 预发布版（v1.14.12 以来 1 个 PR）
 
 Dev 预发布版，包含 PR #276。发布到 `dev` npm tag 供早期测试。

--- a/devlog/2026-08-05_release-v1.14.13/REQ.md
+++ b/devlog/2026-08-05_release-v1.14.13/REQ.md
@@ -1,0 +1,3 @@
+# REQ — Release v1.14.13
+
+Stable release covering 3 PRs since v1.14.12.

--- a/devlog/2026-08-05_release-v1.14.13/WORKLOG.md
+++ b/devlog/2026-08-05_release-v1.14.13/WORKLOG.md
@@ -1,0 +1,10 @@
+# WORKLOG — Release v1.14.13
+
+## Changes
+- package.json: version 1.14.13-dev.1 → 1.14.13
+- README.md: v1.14.13 changelog entry added
+- README.zh-CN.md: v1.14.13 changelog entry added
+
+## PRs Included
+- #276 — allowSubAgents promotion to top-level, default true
+- #280, #281 — config documentation updates

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.13-dev.1",
+    "version": "1.14.13",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Stable Release v1.14.13

3 PRs since v1.14.12.

### PRs Included
- **#276** — Promote `allowSubAgents` from `experimental` to top-level config field, default `true`. Subagent sessions now get compression by default. Fully backward compatible.
- **#280, #281** — Update recommended config in documentation.

### Verification
- TypeScript: 0 errors
- Tests: 954 pass, 0 fail
- Build: 386 KB

**After merge**: CI auto-publishes to `latest` npm tag + creates GitHub Release.