### PR TITLE
promote: stable v1.14.13

### DIFF
--- a/devlog/2026-08-06_promote-stable-v1.14.13/REQ.md
+++ b/devlog/2026-08-06_promote-stable-v1.14.13/REQ.md
@@ -1,0 +1,11 @@
+# REQ — Promote Stable v1.14.13
+
+## Purpose
+
+Sync the `stable` npm dist-tag to v1.14.13 (currently at 1.14.12).
+
+The `latest` tag is already at v1.14.13 (published via PR #282). This PR updates the `stable` tag so users on `opencode-acp@stable` get v1.14.13.
+
+## No code changes
+
+This is a tag-only release. No version bump, no changelog changes.

--- a/devlog/2026-08-06_promote-stable-v1.14.13/WORKLOG.md
+++ b/devlog/2026-08-06_promote-stable-v1.14.13/WORKLOG.md
@@ -1,0 +1,10 @@
+# WORKLOG — Promote Stable v1.14.13
+
+## Changes
+
+No code changes. Tag-only release to sync `stable` dist-tag to v1.14.13.
+
+CI workflow detects the branch name `promote-stable-v1.14.13` and runs:
+```bash
+npm dist-tag add opencode-acp@1.14.13 stable
+```


### PR DESCRIPTION
Sync `stable` npm dist-tag to v1.14.13 (currently at 1.14.12).

CI will run `npm dist-tag add opencode-acp@1.14.13 stable` on merge.

No code changes — tag-only release.