### PR TITLE
fix(compress): per-block hide-consumed to stop summary leak in batched calls (#288)

### DIFF
--- a/devlog/2026-08-10_hide-consumed-per-block/REQ.md
+++ b/devlog/2026-08-10_hide-consumed-per-block/REQ.md
@@ -1,0 +1,38 @@
+# REQ: hide-consumed callID-aliasing leak under batched compress (issue #288)
+
+## Problem
+
+`hideConsumedCompressCalls` keyed its keep-set on `compressCallId`, which is a
+**1:N** key under batched `compress` calls: one tool invocation with multiple
+`content[]` entries creates multiple `CompressionBlock`s that all share a single
+`compressCallId`.
+
+When a higher-tier (T2) distillation consumes only SOME sibling blocks in a
+batch, the surviving sibling keeps the shared `compressCallId` in the
+active-keep-set. That rescues the WHOLE tool part, including the summaries of the
+already-consumed siblings — so those summaries leak back into context
+permanently. They are also **unreclaimable**: `compress` is in the default
+`protectedTools` list, so no later compression can touch them.
+
+Reported upstream: https://github.com/ranxianglei/opencode-acp/issues/288
+Real-session impact (from the report): 209 blocks / 176 unique callIds / 31
+sharing groups; 2 mixed-liveness groups wasting ~2379 tokens permanently.
+
+Same defect exists in `acp-kernel` `src/hide-consumed.ts` (separate PR).
+
+## Acceptance criteria
+
+- [x] A batched compress call where SOME sibling blocks are consumed: the tool
+      part is kept, but its `state.input.content` is rewritten to drop the
+      consumed entries' summaries (live entries retained).
+- [x] All siblings live → part kept unchanged (no spurious rewrite).
+- [x] All siblings consumed → part fully removed (existing behavior preserved).
+- [x] Regression test that FAILS with the pre-fix code and passes after.
+- [x] `npm run build` + `tsc --noEmit` + full test suite (957) green.
+- [x] No change to orphaned-call (last-2) behavior.
+
+## Non-goals
+
+- Changing the semantics of the `hidden` return count (still counts fully-removed
+  parts; rewrites are not counted — both call sites ignore the value anyway).
+- Message-mode (none in this version; range-mode only).

--- a/devlog/2026-08-10_hide-consumed-per-block/WORKLOG.md
+++ b/devlog/2026-08-10_hide-consumed-per-block/WORKLOG.md
@@ -1,0 +1,57 @@
+# WORKLOG: hide-consumed callID-aliasing leak (issue #288)
+
+## Root cause
+
+`lib/compress/hide-consumed.ts` built `activeCallIds` keyed on `compressCallId`,
+then kept/dropped whole tool parts atomically. Because `compressCallId` is shared
+by all sibling blocks from one batched `compress({content:[...]})` call, a single
+live sibling rescued the whole part → consumed siblings' summaries leaked and were
+unreclaimable (`compress` is in the default protected-tools list).
+
+Verified data model:
+- `CompressionBlock` carries `startId`/`endId` string refs (`lib/state/types.ts:57-58`).
+- `lib/compress/range.ts:347-348` writes `block.startId/endId = entry.startId/endId`
+  for every content[] entry, all sharing one `compressCallId`.
+- The leaked summary text lives at `part.state.input.content` (an array of
+  `{startId,endId,summary}` entries). SDK `ToolState.input` is `{[key:string]:unknown}`.
+- `hidden` return value is ignored at both call sites (`hooks.ts`, `status.ts`).
+
+## Fix
+
+`lib/compress/hide-consumed.ts`:
+
+1. Group every block by `compressCallId`; for each LIVE member record its
+   `rangeKey = ${startId}::${endId}`. A callId is kept iff >=1 live member.
+2. For kept batches with mixed liveness, `rewriteCompressInput(part, liveKeys)`
+   filters `part.state.input.content` to entries whose rangeKey is live. Returns
+   a shallow clone `{...part, state:{...state, input:{...input, content:kept}}}`
+   — never mutates the original part. Returns `null` when all entries are live
+   (`kept.length === content.length`) OR matching missed (`kept.length === 0`,
+   safe fallback leaving the part intact rather than risk dropping a live summary).
+3. All-consumed batch → part fully removed (unchanged).
+4. Orphan logic (keep last 2 failed calls) unchanged.
+
+Keyed per-block (on `startId::endId`), not per-callId, because callId is 1:N under
+batching. The invariant enabling per-block matching: a block's `startId`/`endId`
+equal the `content[]` entry's refs that created it (range.ts:347-348).
+
+## Tests (`tests/hide-consumed.test.ts`, +3)
+
+- `batched compress: rewrites kept part to drop consumed sibling entries (issue #288)`
+  — core regression. Verified FAILS with pre-fix code, PASSES after.
+- `batched compress: no rewrite when all sibling blocks are live`.
+- `batched compress: fully removed when all sibling blocks consumed`.
+
+## Verification
+
+- `tsc --noEmit`: clean.
+- `npm run build`: success (388 KB bundle).
+- Full suite: 957 pass / 0 fail.
+- §5.7 bug-fail check: reverting `hide-consumed.ts` to github/master makes the
+  core regression test fail (`✖`); restoring the fix → 14/14 in the file.
+
+## Counterpart
+
+Same defect in `acp-kernel` `src/hide-consumed.ts` — fixed in a separate PR
+(kernel types differ: `CoreMessage` has `toolName`/`toolCallId`, `state.blocks`
+is an array; returns new message array rather than in-place mutate).

--- a/lib/compress/hide-consumed.ts
+++ b/lib/compress/hide-consumed.ts
@@ -1,19 +1,79 @@
-import type { SessionState, WithParts } from "../state"
+import type { Part } from "@opencode-ai/sdk/v2"
+import type { CompressionBlock, SessionState, WithParts } from "../state"
 import { hasMeaningfulContent } from "./parts"
 
 const KEEP_LAST_ORPHANED = 2
 
-export function hideConsumedCompressCalls(state: SessionState, messages: WithParts[]): number {
+function isLiveBlock(block: CompressionBlock): boolean {
+    return block.active && !block.deactivatedByUser && !block.deactivatedByUserDeep
+}
 
-    const activeCallIds = new Set<string>()
+/**
+ * Blocks record the same `startId`/`endId` refs as the `content[]` entry that
+ * created them (see `lib/compress/range.ts`), so this pair maps an entry to its
+ * block within a batched call.
+ */
+function rangeKey(startId: string, endId: string): string {
+    return `${startId}::${endId}`
+}
+
+/**
+ * Filter a kept compress part's range-mode `content[]` to entries whose block
+ * is still live. Returns a shallow clone with rewritten `state.input.content`
+ * when entries were dropped, else `null` (all entries live, input isn't a
+ * filterable batch, or matching missed — in which case the part is left intact
+ * rather than risk dropping a live summary). Never mutates the original part.
+ */
+function rewriteCompressInput(part: Part, liveKeys: Set<string>): Part | null {
+    if (part.type !== "tool") return null
+    const state = part.state
+    const input = state?.input
+    if (!input || typeof input !== "object") return null
+    const content = (input as { content?: unknown }).content
+    if (!Array.isArray(content) || content.length === 0) return null
+
+    const kept = content.filter((entry): entry is Record<string, unknown> => {
+        if (!entry || typeof entry !== "object") return false
+        const s = typeof entry.startId === "string" ? entry.startId : ""
+        const e = typeof entry.endId === "string" ? entry.endId : ""
+        return liveKeys.has(rangeKey(s, e))
+    })
+
+    if (kept.length === content.length || kept.length === 0) return null
+
+    return {
+        ...part,
+        state: { ...state!, input: { ...input, content: kept } },
+    }
+}
+
+/**
+ * Hide compress tool calls whose blocks have all been consumed by a higher-tier
+ * distillation, and for batched calls where only some sibling blocks are
+ * consumed, rewrite the surviving tool part to carry only the still-live
+ * entries' summaries.
+ *
+ * Decided per-block, not per-callID: a single batched `compress` call (multiple
+ * `content[]` entries) creates multiple blocks sharing one `compressCallId`.
+ * Keying on the callId (1:N) lets one live sibling rescue consumed batch-mates,
+ * permanently leaking their summary text — unreclaimable because `compress` is
+ * in the default protected-tools list. See upstream issue #288.
+ */
+export function hideConsumedCompressCalls(state: SessionState, messages: WithParts[]): number {
     const allBlockCallIds = new Set<string>()
+    const liveRangeKeysByCallId = new Map<string, Set<string>>()
+    const activeCallIds = new Set<string>()
     for (const block of state.prune.messages.blocksById.values()) {
-        if (block.compressCallId) {
-            allBlockCallIds.add(block.compressCallId)
-            if (block.active && !block.deactivatedByUser && !block.deactivatedByUserDeep) {
-                activeCallIds.add(block.compressCallId)
-            }
+        if (!block.compressCallId) continue
+        allBlockCallIds.add(block.compressCallId)
+        if (!isLiveBlock(block)) continue
+        activeCallIds.add(block.compressCallId)
+        let keys = liveRangeKeysByCallId.get(block.compressCallId)
+        if (!keys) {
+            keys = new Set<string>()
+            liveRangeKeysByCallId.set(block.compressCallId, keys)
         }
+        keys.add(rangeKey(block.startId, block.endId))
     }
 
     const lastOrphanedCallIds: string[] = []
@@ -34,15 +94,28 @@ export function hideConsumedCompressCalls(state: SessionState, messages: WithPar
         const msg = messages[i]!
         const parts = Array.isArray(msg.parts) ? msg.parts : []
         let changed = false
-        const remaining = parts.filter((p) => {
+        const remaining: Part[] = []
+        for (const p of parts) {
             if (p.type === "tool" && p.tool === "compress") {
-                if (p.callID && keepCallIds.has(p.callID)) return true
-                hidden++
-                changed = true
-                return false
+                if (!p.callID || !keepCallIds.has(p.callID)) {
+                    hidden++
+                    changed = true
+                    continue
+                }
+                const liveKeys = liveRangeKeysByCallId.get(p.callID)
+                if (liveKeys && liveKeys.size > 0) {
+                    const rewritten = rewriteCompressInput(p, liveKeys)
+                    if (rewritten) {
+                        remaining.push(rewritten)
+                        changed = true
+                        continue
+                    }
+                }
+                remaining.push(p)
+            } else {
+                remaining.push(p)
             }
-            return true
-        })
+        }
 
         if (changed) {
             if (hasMeaningfulContent(remaining)) {

--- a/tests/hide-consumed.test.ts
+++ b/tests/hide-consumed.test.ts
@@ -482,4 +482,188 @@ describe("hideConsumedCompressCalls", () => {
         assert.equal(hidden, 3, "5 orphaned - 2 kept = 3 hidden")
         assert.equal(messages.length, 4, "user + 2 kept + user = 4 messages")
     })
+
+    it("batched compress: rewrites kept part to drop consumed sibling entries (issue #288)", () => {
+        const b5 = makeBlock({
+            blockId: 5,
+            active: true,
+            compressMessageId: "msg-batch",
+            compressCallId: "call-batch",
+            startId: "m5",
+            endId: "m6",
+            tier: 1,
+        })
+        const b8 = makeBlock({
+            blockId: 8,
+            active: false,
+            deactivatedByBlockId: 9,
+            compressMessageId: "msg-batch",
+            compressCallId: "call-batch",
+            startId: "m8",
+            endId: "m9",
+            tier: 1,
+        })
+        const b9 = makeBlock({
+            blockId: 9,
+            active: true,
+            compressMessageId: "msg-t2",
+            compressCallId: "call-t2",
+            tier: 2,
+        })
+
+        const state = makeState([b5, b8, b9])
+        const messages: WithParts[] = [
+            { info: { id: "msg-user-1", role: "user" } as any, parts: [{ type: "text", text: "Hi" }] },
+            {
+                info: { id: "msg-batch", role: "assistant" } as any,
+                parts: [
+                    {
+                        type: "tool",
+                        tool: "compress",
+                        callID: "call-batch",
+                        state: {
+                            status: "completed",
+                            input: {
+                                content: [
+                                    { startId: "m5", endId: "m6", summary: "live entry summary" },
+                                    { startId: "m8", endId: "m9", summary: "consumed entry summary" },
+                                ],
+                            },
+                        },
+                    },
+                ],
+            },
+            {
+                info: { id: "msg-t2", role: "assistant" } as any,
+                parts: [{ type: "tool", tool: "compress", callID: "call-t2", state: { status: "completed" } }],
+            },
+        ]
+
+        const hidden = hideConsumedCompressCalls(state as SessionState, messages)
+
+        assert.equal(hidden, 0, "kept batch is not fully removed")
+        const batchMsg = messages.find((m) => m.info.id === "msg-batch")!
+        assert.ok(batchMsg, "batch tool-call message survives (one live sibling)")
+        const part = batchMsg.parts.find((p: any) => p.type === "tool" && p.tool === "compress") as any
+        assert.ok(part, "compress part kept")
+        const content = part.state.input.content
+        assert.equal(content.length, 1, "consumed entry dropped, live entry retained")
+        assert.equal(content[0].startId, "m5", "retained entry is the live block's range")
+        assert.equal(content[0].summary, "live entry summary")
+    })
+
+    it("batched compress: no rewrite when all sibling blocks are live", () => {
+        const b5 = makeBlock({
+            blockId: 5,
+            active: true,
+            compressMessageId: "msg-batch",
+            compressCallId: "call-batch",
+            startId: "m5",
+            endId: "m6",
+        })
+        const b8 = makeBlock({
+            blockId: 8,
+            active: true,
+            compressMessageId: "msg-batch",
+            compressCallId: "call-batch",
+            startId: "m8",
+            endId: "m9",
+        })
+
+        const state = makeState([b5, b8])
+        const messages: WithParts[] = [
+            { info: { id: "msg-user-1", role: "user" } as any, parts: [{ type: "text", text: "Hi" }] },
+            {
+                info: { id: "msg-batch", role: "assistant" } as any,
+                parts: [
+                    {
+                        type: "tool",
+                        tool: "compress",
+                        callID: "call-batch",
+                        state: {
+                            status: "completed",
+                            input: {
+                                content: [
+                                    { startId: "m5", endId: "m6", summary: "S1" },
+                                    { startId: "m8", endId: "m9", summary: "S2" },
+                                ],
+                            },
+                        },
+                    },
+                ],
+            },
+        ]
+
+        const hidden = hideConsumedCompressCalls(state as SessionState, messages)
+
+        assert.equal(hidden, 0)
+        const part = messages
+            .find((m) => m.info.id === "msg-batch")!
+            .parts.find((p: any) => p.type === "tool" && p.tool === "compress") as any
+        assert.equal(part.state.input.content.length, 2, "both live entries retained, no rewrite")
+    })
+
+    it("batched compress: fully removed when all sibling blocks consumed", () => {
+        const b5 = makeBlock({
+            blockId: 5,
+            active: false,
+            deactivatedByBlockId: 9,
+            compressMessageId: "msg-batch",
+            compressCallId: "call-batch",
+            startId: "m5",
+            endId: "m6",
+        })
+        const b8 = makeBlock({
+            blockId: 8,
+            active: false,
+            deactivatedByBlockId: 9,
+            compressMessageId: "msg-batch",
+            compressCallId: "call-batch",
+            startId: "m8",
+            endId: "m9",
+        })
+        const b9 = makeBlock({
+            blockId: 9,
+            active: true,
+            compressMessageId: "msg-t2",
+            compressCallId: "call-t2",
+            tier: 2,
+        })
+
+        const state = makeState([b5, b8, b9])
+        const messages: WithParts[] = [
+            { info: { id: "msg-user-1", role: "user" } as any, parts: [{ type: "text", text: "Hi" }] },
+            {
+                info: { id: "msg-batch", role: "assistant" } as any,
+                parts: [
+                    { type: "text", text: "Batching" },
+                    {
+                        type: "tool",
+                        tool: "compress",
+                        callID: "call-batch",
+                        state: {
+                            status: "completed",
+                            input: {
+                                content: [
+                                    { startId: "m5", endId: "m6", summary: "S1" },
+                                    { startId: "m8", endId: "m9", summary: "S2" },
+                                ],
+                            },
+                        },
+                    },
+                ],
+            },
+        ]
+
+        const hidden = hideConsumedCompressCalls(state as SessionState, messages)
+
+        assert.equal(hidden, 1, "fully-consumed batch dropped")
+        const batchMsg = messages.find((m) => m.info.id === "msg-batch")!
+        assert.ok(batchMsg, "message survives via text part")
+        assert.equal(
+            batchMsg.parts.filter((p: any) => p.type === "tool" && p.tool === "compress").length,
+            0,
+            "no compress part remains",
+        )
+    })
 })


### PR DESCRIPTION
# fix: per-block hide-consumed to stop summary leak in batched compress calls

Fixes #288

## Problem

`hideConsumedCompressCalls` keyed its keep-set on `compressCallId`, which is a
**1:N** key under batched `compress` calls: one tool invocation with multiple
`content[]` entries creates multiple `CompressionBlock`s that all share a single
`compressCallId`.

When a higher-tier (T2) distillation consumes only SOME sibling blocks in a
batch, the surviving sibling keeps the shared `compressCallId` in the
active-keep-set. That rescues the WHOLE tool part — including the summaries of the
already-consumed siblings — so those summaries leak back into context
permanently. They are also **unreclaimable**: `compress` is in the default
`protectedTools` list, so no later compression can touch them.

Real-session impact (from #288): 209 blocks / 176 unique callIds / 31 sharing
groups; mixed-liveness groups waste tokens permanently.

## Fix

`lib/compress/hide-consumed.ts` — key visibility **per-block** (on
`${startId}::${endId}`) instead of per-callId:

1. Group every block by `compressCallId`; record each LIVE member's range key. A
   callId is kept iff ≥1 live member.
2. For kept batches with mixed liveness, `rewriteCompressInput(part, liveKeys)`
   filters `part.state.input.content` to entries whose range key is still live.
   Returns a shallow clone (never mutates the original); returns `null` on
   all-live or matching-miss (safe fallback — leaves the part intact).
3. All-consumed batch → part fully removed (unchanged).
4. Orphan logic (keep last 2 failed calls) unchanged.

Why per-block works: a block's `startId`/`endId` equal the `content[]` entry's
refs that created it (`lib/compress/range.ts:347-348`), so the pair maps an entry
to its block within a batch.

## Tests

`tests/hide-consumed.test.ts` (+3):
- `batched compress: rewrites kept part to drop consumed sibling entries (issue #288)` — core regression
- `batched compress: no rewrite when all sibling blocks are live`
- `batched compress: fully removed when all sibling blocks consumed`

**§5.7 compliance**: the core regression test was verified to **FAIL** with the
pre-fix code (`✖`) and **PASS** after the fix.

## Verification

- `tsc --noEmit`: clean
- `npm run build`: success (388 KB)
- Full suite: **957 pass / 0 fail**
- No version bump (fix branch, not a release branch — §5.1.1.1)

## Counterpart

Same defect exists in `acp-kernel` `src/hide-consumed.ts` — fixed in a separate
PR (kernel types differ: `CoreMessage` has `toolName`/`toolCallId`, `state.blocks`
is an array; returns a new message array rather than in-place mutate).
