### PR TITLE
fix(compress): partial-failure batch compress + phantom diagnostics (#290)

### DIFF
--- a/devlog/2026-08-11_batch-phantom-partial/REQ.md
+++ b/devlog/2026-08-11_batch-phantom-partial/REQ.md
@@ -1,0 +1,94 @@
+# REQ: partial-failure batch compress + phantom diagnostics (issue #290)
+
+- Task ID: `2026-08-11_batch-phantom-partial`
+- Home Repo: `opencode-acp`
+- Created: 2026-08-11
+- Status: InProgress
+- Priority: P1
+- Owner: awork
+- References: upstream issue https://github.com/ranxianglei/opencode-acp/issues/290 ; local dog/opencode-acp#47 ; builds on #288/#289
+
+## 1. Background & Problem Statement
+
+- **Context**: Batch `compress` calls (5–6 entries in `content[]`) are the
+  recommended way to compress unrelated ranges in one turn. They share one
+  tool invocation and produce multiple `CompressionBlock`s.
+- **Current behavior (symptom)**: When ANY single entry in a batch contains
+  only already-compressed messages, `checkPhantomBlock` throws on the first
+  phantom plan and the ENTIRE batch is aborted — the remaining valid entries
+  are never executed. The error message is also generic: it names the entry
+  index ("range N") but not the conflicting message IDs or the owning block
+  IDs, forcing trial-and-error retry loops.
+- **Expected behavior**:
+  - A. Partial-failure batches: skip the phantom entries, compress the valid
+       ones, and surface which entries were skipped + why.
+  - C. Diagnostics: the error / skip notice includes the conflicting entry
+       index, a sample of the consumed message IDs, and the owning block IDs.
+  - B. Clamp warning: when `clampMessageRef` silently clamps a beyond-last-
+       visible ref, log a warning (defense-in-depth; the partial-failure path
+       already handles the downstream phantom case).
+- **Impact**: Models abandon batch compression entirely on the first stale-ref
+  hit, leaving large uncompressed ranges in context. Real-session report:
+  35 blocks / 3190 indexed messages, batches of 5–6 entries failing wholesale.
+
+## 2. Reproduction
+
+- **Environment**: opencode-acp 1.14.13 (stable), Windows desktop, OpenCode 1.18.15.
+- **Minimal reproduction**:
+  1. Session with one active compression block covering messages X..Y.
+  2. Model issues `compress({ content: [ {valid range}, {range entirely inside X..Y}, {valid range} ] })`.
+  3. Entire call throws "Compression range 2 contains only already-compressed
+     messages ...". Entries 1 and 3 are not executed.
+- **Relevant configuration**: default range mode; no special config required.
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+  - Backward compatibility: `checkPhantomBlock`'s existing public contract
+    (returns `Error | null`, error message matches `/already-compressed/`,
+    `/0 new direct messages/`, `/range N/i`) MUST be preserved — existing
+    tests in `tests/phantom-block.test.ts` must pass unchanged.
+  - No persisted-state schema changes.
+  - No new dependencies.
+  - State integrity: phantom entries must be dropped BEFORE any state
+    mutation (snapshot/apply), so a partial batch never leaves ghost blocks.
+- **Non-Goals**:
+  - D (unify nudge judging): the reporter confirmed the nudge list is already
+    correct; ghost IDs that appear there are genuinely compressible
+    individually. The defect is purely batch atomicity + missing diagnostics.
+    D is out of scope for this iteration.
+  - Message-mode (removed from this codebase; range-mode only).
+
+## 4. Acceptance Criteria (must be testable)
+
+- **Correctness**:
+  - [ ] Batch with 1 phantom + N valid entries: valid entries compress
+        normally; phantom entry skipped; result message lists the skipped entry.
+  - [ ] Batch where ALL entries are phantom: throws a detailed error (entry
+        index + consumed IDs + owning blocks) and no state is mutated.
+  - [ ] Single-entry phantom batch: throws (same as pre-fix, plus richer msg).
+  - [ ] `checkPhantomBlock` existing behavior/tests unchanged.
+- **Performance / Stability**:
+  - [ ] No new O(n²); phantom identification is O(plans × effective-set).
+- **Regression**:
+  - [ ] New tests added covering partial-failure + diagnostics.
+  - [ ] `npm run typecheck`, `npm test`, `npm run build` all green.
+
+## 5. Proposed Approach
+
+- **Affected modules & entry files**:
+  - `lib/compress/pipeline.ts` — add `identifyPhantomPlans` (returns
+    per-plan diagnostics) + `buildPhantomErrorMessage`. Keep
+    `checkPhantomBlock` as a legacy single-error wrapper (unchanged contract).
+  - `lib/compress/range.ts` — switch the pre-mutation check from
+    `checkPhantomBlock` to `identifyPhantomPlans`; drop phantom entries,
+    compress the rest; hard-fail only when ALL entries are phantom; surface
+    skip notice in the result string.
+  - `lib/compress/search.ts` — thread optional `logger` through
+    `resolveBoundaryIds`/`resolveRanges`; warn when `clampMessageRef` clamps.
+- **Risks**:
+  - Dropping entries changes batch semantics. Mitigation: the model sees a
+    clear skip notice naming the dropped entries + owning blocks, so it can
+    correct boundaries without guessing.
+- **Rollback strategy**: revert the three file changes; no state migration
+  needed (no schema change).

--- a/devlog/2026-08-11_batch-phantom-partial/WORKLOG.md
+++ b/devlog/2026-08-11_batch-phantom-partial/WORKLOG.md
@@ -38,10 +38,13 @@ Verified call sites:
 Replaced the `checkPhantomBlock` throw with:
 - `identifyPhantomPlans` runs BEFORE `snapshotCompressionState`/apply (ordering
   invariant: dropped entries must leave no ghost blocks).
-- ALL phantom → `throw buildPhantomErrorMessage(details)`.
-- SOME phantom → filter them out, set `phantomSkipNotice`, continue. The
-  notice is appended to the success return so the model sees which entries
-  were dropped + why.
+- ALL phantom → `throw buildPhantomErrorMessage(details)` (verbose diagnostics
+  — entry index + consumed IDs + owning blocks — so the model can correct).
+- SOME phantom → filter them out, `ctx.logger.warn(...)` with full details,
+  and a CONCISE skip notice in the success return (one line: which entry
+  numbers were dropped + "no-ops, remaining compressed"). Verbose diagnostics
+  stay only on the all-fail throw; the success path is warn-flavored, not a
+  verbose dump (per reviewer direction: "warn 最好").
 
 ### B. Clamp warning — `lib/compress/search.ts`
 

--- a/devlog/2026-08-11_batch-phantom-partial/WORKLOG.md
+++ b/devlog/2026-08-11_batch-phantom-partial/WORKLOG.md
@@ -93,3 +93,34 @@ first — the old `checkPhantomBlock` could not express "skip these, keep those"
 - `lib/compress/search.ts` — optional logger warn on clamp.
 - `lib/compress/range-utils.ts` — thread optional logger through `resolveRanges`.
 - `tests/phantom-block.test.ts` — 11 new tests.
+
+## Dual-agent review (AGENTS.md §5.3 / §5.6) — both APPROVE, no blockers
+
+Reviewer 1 (oracle) and Reviewer 2 (general) independently verified correctness,
+backward-compat, state-integrity, and type safety. Convergent actionable concern:
+the partial-failure SUCCESS path in `range.ts` (the PR's headline behavior) and
+the clamp warn (fix B) were untested — only the underlying helpers were covered.
+
+### Review-driven refinement (commits 3)
+
+- Extracted `partitionPhantomPlans(identification, totalPlans): PhantomPartition`
+  (discriminated union `clean | all-phantom | partial`) and
+  `buildPhantomSkipNotice(identification)` into `lib/compress/pipeline.ts`.
+  `range.ts` now consumes the helper instead of an inline branch. Pure function →
+  the all-vs-some-vs-clean decision + skip-notice format are now unit-testable
+  and guard against refactor regressions (e.g. silently switching the comparison
+  to a filtered-list length).
+- Added 6 tests in `tests/phantom-block.test.ts` (clean / all-phantom / partial /
+  multi-phantom plural / details-survive-filtering / singular-vs-plural notice).
+- Added 2 tests in `tests/compress-search.test.ts` (clamp warn fires on
+  out-of-range endId; no warn on in-range resolve).
+
+Verification after refinement: `tsc --noEmit` 0 errors; full suite 976 pass / 0
+fail (+8 from the 968 baseline); build success (dist/index.js 391 KB).
+
+### Review concern NOT addressed here (follow-up)
+
+`tsconfig.json` excludes `tests/**` from typecheck, so test-factory completeness
+(§5.6 "config completeness") is structurally unenforceable — same gap class as
+the PR #207 baseline-reset bug. This is pre-existing and out of scope for #290;
+tracked as a follow-up.

--- a/devlog/2026-08-11_batch-phantom-partial/WORKLOG.md
+++ b/devlog/2026-08-11_batch-phantom-partial/WORKLOG.md
@@ -1,0 +1,92 @@
+# WORKLOG: partial-failure batch compress + phantom diagnostics (issue #290)
+
+## Root cause
+
+`lib/compress/pipeline.ts` `checkPhantomBlock` validated each batch entry and
+returned an `Error` on the FIRST phantom plan. `lib/compress/range.ts` threw on
+that error, aborting the ENTIRE batch — the remaining valid entries were never
+executed. The error named the entry index but not the conflicting message IDs
+or owning blocks, forcing trial-and-error retries. Separately,
+`lib/compress/search.ts` `clampMessageRef` silently clamped beyond-last-visible
+refs, which could shift boundaries onto consumed ranges.
+
+Verified call sites:
+- `checkPhantomBlock` was called once, at `lib/compress/range.ts:280`.
+- `clampMessageRef` is invoked from `resolveBoundaryIds` (start + end).
+- `checkPhantomBlock`'s contract is covered by `tests/phantom-block.test.ts`
+  (must keep returning `Error | null` with `/range N/i`, `/already-compressed/`,
+  `/0 new direct messages/`).
+
+## Fix
+
+### A + C. Partial-failure batches with diagnostics — `lib/compress/pipeline.ts`
+
+1. Extracted the per-plan loop into `identifyPhantomPlans(state, plans)` →
+   `{ phantomIndices: number[], details: PhantomPlanDetail[] }`. Each detail
+   carries `{ index, consumedMessageIds (sample of 8), owningBlockIds (sorted) }`.
+   Preserves the multi-consumed single-tier carve-out and the "new iff
+   activeBlockIds empty" rule (mirrors `applyCompressionState`).
+2. `buildPhantomErrorMessage(details)` renders a multi-entry message listing
+   `Entry N`, consumed IDs sample, owning `bN` block refs, and a stale-ref
+   fallback for empty owning sets.
+3. `checkPhantomBlock` now delegates to `identifyPhantomPlans` and renders the
+   legacy single-error string (first phantom only) — exact backward-compat
+   contract preserved, existing tests pass unchanged.
+
+### A. Batch caller — `lib/compress/range.ts`
+
+Replaced the `checkPhantomBlock` throw with:
+- `identifyPhantomPlans` runs BEFORE `snapshotCompressionState`/apply (ordering
+  invariant: dropped entries must leave no ghost blocks).
+- ALL phantom → `throw buildPhantomErrorMessage(details)`.
+- SOME phantom → filter them out, set `phantomSkipNotice`, continue. The
+  notice is appended to the success return so the model sees which entries
+  were dropped + why.
+
+### B. Clamp warning — `lib/compress/search.ts`
+
+`resolveBoundaryIds` now takes an optional `logger` and emits
+`compress startId/endId mNNNNN not available — clamped to mNNNNN` when
+`clampMessageRef` shifts a boundary. Threaded through `resolveRanges`
+(`lib/compress/range-utils.ts`); `range.ts` passes `ctx.logger`. The logger is
+optional + structural so existing callers (`rebuild.ts`, `decompress.ts`) and
+pure unit tests need no changes.
+
+D (unify nudge judging) explicitly out of scope — the reporter confirmed the
+nudge list is already correct; ghost IDs that appear there are genuinely
+compressible individually.
+
+## Tests — `tests/phantom-block.test.ts`
+
+11 new tests, all asserting real behavior (no tautologies):
+- `identifyPhantomPlans`: empty when all new; reports owning block + consumed
+  IDs; reports ALL phantoms in a mixed batch (not just first); keeps the
+  single-tier carve-out; treats deactivated (GC'd) msgs as new; dedups owning
+  blocks.
+- `buildPhantomErrorMessage`: includes Entry N + bN + already-compressed;
+  lists multiple entries; handles stale-ref (empty owning) case.
+- `checkPhantomBlock` delegation preserved (both branches).
+
+Verified the bug→fix relationship: the partial-failure path
+(`phantomId.phantomIndices.length < preparedPlans.length`) only exists because
+`identifyPhantomPlans` returns ALL phantoms rather than short-circuiting on the
+first — the old `checkPhantomBlock` could not express "skip these, keep those".
+
+## Verification
+
+- `npx tsc --noEmit` → 0 errors.
+- `node --import tsx --test tests/*.test.ts` → 968 pass / 0 fail (was 957;
+  +11 new).
+- `npm run build` → dist/index.js 390 KB, success.
+- Bundle grep: `identifyPhantomPlans` (2), `phantomSkipNotice` (4),
+  `clamped to` (4) — all fixes present in shipped bundle.
+- `prettier --check` on 5 changed files → clean.
+
+## Files changed
+
+- `lib/compress/pipeline.ts` — `identifyPhantomPlans`, `buildPhantomErrorMessage`,
+  `checkPhantomBlock` delegate, `PhantomPlanDetail`/`PhantomIdentification` types.
+- `lib/compress/range.ts` — partial-failure batch logic + skip-notice return.
+- `lib/compress/search.ts` — optional logger warn on clamp.
+- `lib/compress/range-utils.ts` — thread optional logger through `resolveRanges`.
+- `tests/phantom-block.test.ts` — 11 new tests.

--- a/lib/compress/pipeline.ts
+++ b/lib/compress/pipeline.ts
@@ -275,6 +275,57 @@ export function buildPhantomErrorMessage(details: PhantomPlanDetail[]): string {
 }
 
 /**
+ * Outcome of classifying a batch against its phantom identification (issue #290).
+ * - `clean`: no phantom entries — compress everything.
+ * - `all-phantom`: every entry is phantom — caller throws via {@link buildPhantomErrorMessage}.
+ * - `partial`: some entries are phantom — caller drops `dropIndices`, compresses the rest,
+ *   and surfaces `notice` in the success return.
+ */
+export type PhantomPartition =
+    | { kind: "clean" }
+    | { kind: "all-phantom"; details: PhantomPlanDetail[] }
+    | { kind: "partial"; dropIndices: number[]; details: PhantomPlanDetail[]; notice: string }
+
+/**
+ * Partition a batch of plans based on its phantom identification. Pure helper
+ * extracted so the all-vs-some-vs-clean decision and skip-notice construction
+ * are independently unit-testable (issue #290 review concern C1).
+ *
+ * @param identification Result of {@link identifyPhantomPlans}.
+ * @param totalPlans     Count of plans in the batch (before any filtering).
+ */
+export function partitionPhantomPlans(
+    identification: PhantomIdentification,
+    totalPlans: number,
+): PhantomPartition {
+    if (identification.phantomIndices.length === 0) {
+        return { kind: "clean" }
+    }
+    if (identification.phantomIndices.length === totalPlans) {
+        return { kind: "all-phantom", details: identification.details }
+    }
+    return {
+        kind: "partial",
+        dropIndices: identification.phantomIndices,
+        details: identification.details,
+        notice: buildPhantomSkipNotice(identification),
+    }
+}
+
+/**
+ * Build the concise skip-notice shown when a partial batch drops phantom entries
+ * (issue #290 fix A — model-facing success return).
+ */
+export function buildPhantomSkipNotice(identification: PhantomIdentification): string {
+    const skippedNums = identification.details.map((d) => `#${d.index + 1}`).join(", ")
+    const noun = identification.phantomIndices.length === 1 ? "entry" : "entries"
+    return (
+        `Skipped ${identification.phantomIndices.length} already-compressed ${noun} (${skippedNums}) ` +
+        `— they are no-ops; the remaining entries were compressed.`
+    )
+}
+
+/**
  * Stateless check: reject compression plans that would produce phantom blocks
  * (0 new direct messages, 0 compressed tokens). A phantom block occurs when
  * every message in the effective range is already active under an existing

--- a/lib/compress/pipeline.ts
+++ b/lib/compress/pipeline.ts
@@ -23,10 +23,7 @@ export function snapshotCompressionState(state: SessionState): CompressionSnapsh
     }
 }
 
-export function restoreCompressionState(
-    state: SessionState,
-    snapshot: CompressionSnapshot,
-): void {
+export function restoreCompressionState(state: SessionState, snapshot: CompressionSnapshot): void {
     state.prune.messages = structuredClone(snapshot.messages)
     state.stats = { ...snapshot.stats }
 }
@@ -106,9 +103,7 @@ export async function finalizeSession(
             ctx.logger,
         )
         for (const failure of qualityReport.failures) {
-            const metrics = Object.fromEntries(
-                failure.result.metrics.map((m) => [m.name, m.value]),
-            )
+            const metrics = Object.fromEntries(failure.result.metrics.map((m) => [m.name, m.value]))
             ctx.logger.warn("Compression quality gate FAILED", {
                 blockId: failure.blockId,
                 algorithm: ctx.config.qualityGate.algorithm,
@@ -160,29 +155,55 @@ export function getLastVisibleMessageId(
 }
 
 /**
- * Stateless check: reject compression plans that would produce phantom blocks
- * (0 new direct messages, 0 compressed tokens). A phantom block occurs when
- * every message in the effective range is already active under an existing
- * compression block. Returns an Error to throw if any plan is phantom.
- *
- * Fix for issue #93: empty compression blocks waste context (summary overhead
- * with no token savings) and cause compression loops — the model sees 0 tokens
- * removed, retries the same range, creates another phantom, endlessly.
- *
- * A message is "new" (will be newly compressed) if it is NOT currently active
- * under any block. Messages active under consumed blocks are still "already
- * compressed" — re-labeling them under a new block does not newly hide them
- * (matches applyCompressionState's newlyCompressedMessageIds computation).
+ * Per-phantom diagnostics used in error / skip-notice messages (issue #290).
  */
-export function checkPhantomBlock(
+export interface PhantomPlanDetail {
+    /** 0-based index in the input plans array. */
+    index: number
+    /** Sample of message IDs in the effective set that are already compressed. */
+    consumedMessageIds: string[]
+    /** Block IDs owning those messages (sorted ascending). */
+    owningBlockIds: number[]
+}
+
+export interface PhantomIdentification {
+    /** Indices of plans that are phantom (no new messages to compress). */
+    phantomIndices: number[]
+    /** Per-phantom diagnostics for error / skip-notice messages. */
+    details: PhantomPlanDetail[]
+}
+
+/**
+ * Identify which plans in a batch are phantom (would produce 0 new compressed
+ * messages). Stateless pre-check mirroring applyCompressionState's
+ * newlyCompressedMessageIds computation: a message is "new" iff it has no
+ * byMessageId entry OR its activeBlockIds is empty.
+ *
+ * Returns per-plan diagnostics so callers can implement partial-failure
+ * batches (issue #290 fix A): skip phantom entries, compress the valid ones,
+ * and report which entries / IDs / blocks conflicted (fix C).
+ *
+ * Multi-consumed single-tier carve-out: a higher-tier distillation that merges
+ * sibling blocks of the SAME tier is allowed even when every message is
+ * already active under those siblings (the merge itself is the value).
+ * Matches the historical exception in checkPhantomBlock.
+ *
+ * Fix for issue #93/#290: empty compression blocks waste context (summary
+ * overhead with no token savings) and cause compression loops.
+ */
+export function identifyPhantomPlans(
     state: SessionState,
     plans: Array<{ messageIds: string[]; consumedBlockIds: number[] }>,
-): Error | null {
+): PhantomIdentification {
+    const phantomIndices: number[] = []
+    const details: PhantomPlanDetail[] = []
+
     for (let i = 0; i < plans.length; i++) {
         const plan = plans[i]
+        if (!plan) continue
 
         // Build effective message set: selection messages + inherited from
-        // consumed blocks (mirrors applyCompressionState lines 79-93).
+        // consumed blocks (mirrors applyCompressionState).
         const effective = new Set(plan.messageIds)
         for (const consumedId of plan.consumedBlockIds) {
             const block = state.prune.messages.blocksById.get(consumedId)
@@ -198,26 +219,93 @@ export function checkPhantomBlock(
             return !entry || entry.activeBlockIds.length === 0
         })
 
-        if (!hasNew) {
-            if (plan.consumedBlockIds.length >= 2) {
-                const tiers = new Set(
-                    plan.consumedBlockIds.map(
-                        (id) => state.prune.messages.blocksById.get(id)?.tier ?? 1,
-                    ),
-                )
-                if (tiers.size === 1) {
-                    continue
-                }
-            }
-            return new Error(
-                `Compression range ${i + 1} contains only already-compressed messages ` +
-                    "(0 new direct messages, 0 tokens saved). Nothing to compress — " +
-                    'pick a range with visible, uncompressed content. Use `acp_status({scope:"uncompressed"})` ' +
-                    "to see which ranges are still compressible.",
+        if (hasNew) continue
+
+        // Multi-consumed single-tier exception (T2+ distillation merging
+        // same-tier sibling blocks) — not phantom.
+        if (plan.consumedBlockIds.length >= 2) {
+            const tiers = new Set(
+                plan.consumedBlockIds.map(
+                    (id) => state.prune.messages.blocksById.get(id)?.tier ?? 1,
+                ),
             )
+            if (tiers.size === 1) continue
         }
+
+        phantomIndices.push(i)
+
+        const consumedMessageIds: string[] = []
+        const owningBlockIds = new Set<number>()
+        for (const mid of effective) {
+            const entry = state.prune.messages.byMessageId.get(mid)
+            if (entry && entry.activeBlockIds.length > 0) {
+                consumedMessageIds.push(mid)
+                for (const bid of entry.activeBlockIds) owningBlockIds.add(bid)
+            }
+        }
+        details.push({
+            index: i,
+            consumedMessageIds: consumedMessageIds.slice(0, 8),
+            owningBlockIds: [...owningBlockIds].sort((a, b) => a - b),
+        })
     }
-    return null
+
+    return { phantomIndices, details }
+}
+
+export function buildPhantomErrorMessage(details: PhantomPlanDetail[]): string {
+    const lines = details.map((d) => {
+        const ids =
+            d.consumedMessageIds.length > 0
+                ? d.consumedMessageIds.join(", ")
+                : "(empty effective set)"
+        const blocks =
+            d.owningBlockIds.length > 0
+                ? d.owningBlockIds.map((b) => `b${b}`).join(", ")
+                : "(no active block — likely a stale ref)"
+        return `  • Entry ${d.index + 1}: all messages already compressed. Consumed IDs (sample): ${ids}. Owning block(s): ${blocks}.`
+    })
+    const noun = details.length === 1 ? "One compress entry" : `${details.length} compress entries`
+    return (
+        `${noun} contain only already-compressed messages (0 new direct messages, 0 tokens saved):\n` +
+        lines.join("\n") +
+        `\nNothing to compress in those entries — pick ranges with visible, uncompressed content. ` +
+        `Use \`acp_status({scope:"uncompressed"})\` to see which ranges are still compressible.`
+    )
+}
+
+/**
+ * Stateless check: reject compression plans that would produce phantom blocks
+ * (0 new direct messages, 0 compressed tokens). A phantom block occurs when
+ * every message in the effective range is already active under an existing
+ * compression block. Returns an Error for the FIRST phantom plan, or null.
+ *
+ * Legacy single-error API — kept for backward compatibility. Batch-aware
+ * callers should use {@link identifyPhantomPlans} + {@link buildPhantomErrorMessage}
+ * to implement partial-failure batches (issue #290 fix A).
+ *
+ * Fix for issue #93: empty compression blocks waste context (summary overhead
+ * with no token savings) and cause compression loops — the model sees 0 tokens
+ * removed, retries the same range, creates another phantom, endlessly.
+ *
+ * A message is "new" (will be newly compressed) if it is NOT currently active
+ * under any block. Messages active under consumed blocks are still "already
+ * compressed" — re-labeling them under a new block does not newly hide them
+ * (matches applyCompressionState's newlyCompressedMessageIds computation).
+ */
+export function checkPhantomBlock(
+    state: SessionState,
+    plans: Array<{ messageIds: string[]; consumedBlockIds: number[] }>,
+): Error | null {
+    const { details } = identifyPhantomPlans(state, plans)
+    if (details.length === 0) return null
+    const first = details[0]!
+    return new Error(
+        `Compression range ${first.index + 1} contains only already-compressed messages ` +
+            "(0 new direct messages, 0 tokens saved). Nothing to compress — " +
+            'pick a range with visible, uncompressed content. Use `acp_status({scope:"uncompressed"})` ' +
+            "to see which ranges are still compressible.",
+    )
 }
 
 /**

--- a/lib/compress/range-utils.ts
+++ b/lib/compress/range-utils.ts
@@ -13,8 +13,7 @@ import type {
 const BLOCK_PLACEHOLDER_REGEX = /\(b(\d+)\)|\{block_(\d+)\}/gi
 
 export function validateArgs(args: CompressRangeToolArgs): void {
-    const hasTopLevelTopic =
-        typeof args.topic === "string" && args.topic.trim().length > 0
+    const hasTopLevelTopic = typeof args.topic === "string" && args.topic.trim().length > 0
 
     if (!Array.isArray(args.content) || args.content.length === 0) {
         throw new Error("content is required and must be a non-empty array")
@@ -36,8 +35,7 @@ export function validateArgs(args: CompressRangeToolArgs): void {
             throw new Error(`${prefix}.summary is required and must be a non-empty string`)
         }
 
-        const hasEntryTopic =
-            typeof entry?.topic === "string" && entry.topic.trim().length > 0
+        const hasEntryTopic = typeof entry?.topic === "string" && entry.topic.trim().length > 0
         if (!hasEntryTopic && !hasTopLevelTopic) {
             throw new Error(
                 `${prefix} needs a topic — provide ${prefix}.topic or the top-level topic`,
@@ -50,6 +48,7 @@ export function resolveRanges(
     args: CompressRangeToolArgs,
     searchContext: SearchContext,
     state: SessionState,
+    logger?: { warn(message: string, data?: any): void },
 ): ResolvedRangeCompression[] {
     return args.content.map((entry, index) => {
         const normalizedEntry = {
@@ -67,6 +66,7 @@ export function resolveRanges(
             state,
             normalizedEntry.startId,
             normalizedEntry.endId,
+            logger,
         )
         const selection = resolveSelection(searchContext, startReference, endReference)
 
@@ -215,4 +215,3 @@ export function appendMissingBlockSummaries(
         consumedBlockIds: [...consumedBlockIds],
     }
 }
-

--- a/lib/compress/range.ts
+++ b/lib/compress/range.ts
@@ -7,7 +7,8 @@ import {
     prepareSession,
     snapshotCompressionState,
     restoreCompressionState,
-    checkPhantomBlock,
+    identifyPhantomPlans,
+    buildPhantomErrorMessage,
     type NotificationEntry,
 } from "./pipeline"
 import {
@@ -126,7 +127,7 @@ export function createCompressRangeTool(factoryCtx: ToolFactoryContext): ReturnT
                 toolCtx,
                 `Compress Range: ${input.topic ?? "(batch)"}`,
             )
-            const resolvedPlans = resolveRanges(input, searchContext, ctx.state)
+            const resolvedPlans = resolveRanges(input, searchContext, ctx.state, ctx.logger)
             validateNonOverlapping(resolvedPlans)
 
             const filteredPlans = resolvedPlans
@@ -190,7 +191,7 @@ export function createCompressRangeTool(factoryCtx: ToolFactoryContext): ReturnT
             }
 
             const notifications: NotificationEntry[] = []
-            const preparedPlans: Array<{
+            let preparedPlans: Array<{
                 entry: (typeof filteredPlans)[number]["entry"]
                 selection: (typeof filteredPlans)[number]["selection"]
                 anchorMessageId: string
@@ -277,17 +278,31 @@ export function createCompressRangeTool(factoryCtx: ToolFactoryContext): ReturnT
                 })
             }
 
-            const phantomError = checkPhantomBlock(
+            // Issue #290: drop phantom entries and compress the rest. Must run
+            // BEFORE snapshot/apply so dropped entries leave no ghost blocks.
+            const phantomId = identifyPhantomPlans(
                 ctx.state,
                 preparedPlans.map((p) => ({
                     messageIds: p.selection.messageIds,
                     consumedBlockIds: p.consumedBlockIds,
                 })),
             )
-            if (phantomError) throw phantomError
+            let phantomSkipNotice: string | null = null
+            if (phantomId.phantomIndices.length > 0) {
+                ctx.logger.warn("Batch compress: phantom entries detected", {
+                    phantomCount: phantomId.phantomIndices.length,
+                    totalCount: preparedPlans.length,
+                    phantomIndices: phantomId.phantomIndices,
+                })
+                if (phantomId.phantomIndices.length === preparedPlans.length) {
+                    throw new Error(buildPhantomErrorMessage(phantomId.details))
+                }
+                const dropSet = new Set(phantomId.phantomIndices)
+                preparedPlans = preparedPlans.filter((_, i) => !dropSet.has(i))
+                phantomSkipNotice = buildPhantomErrorMessage(phantomId.details)
+            }
 
-            const acknowledgeRisk =
-                (args as { acknowledgeRisk?: boolean }).acknowledgeRisk === true
+            const acknowledgeRisk = (args as { acknowledgeRisk?: boolean }).acknowledgeRisk === true
 
             const qualityGateRetryPendingBefore = ctx.state.qualityGateRetryPending
 
@@ -370,20 +385,15 @@ export function createCompressRangeTool(factoryCtx: ToolFactoryContext): ReturnT
                     })
                 }
 
-                await finalizeSession(
-                    ctx,
-                    toolCtx,
-                    rawMessages,
-                    notifications,
-                    input.topic,
-                )
+                await finalizeSession(ctx, toolCtx, rawMessages, notifications, input.topic)
             } catch (error) {
                 restoreCompressionState(ctx.state, snapshot)
                 ctx.state.qualityGateRetryPending = qualityGateRetryPendingBefore
                 throw error
             }
 
-            return `Compressed ${totalCompressedMessages} messages into ${COMPRESSED_BLOCK_HEADER}.\nIMPORTANT: This was an automatic context compression. You MUST continue your previous task exactly where you left off. Do NOT ask the user what to do next.\n💡 Tip: Use search_context('keyword') to find compressed content when you need it later.`
+            const skippedNote = phantomSkipNotice !== null ? `\n⚠️ ${phantomSkipNotice}\n` : ""
+            return `Compressed ${totalCompressedMessages} messages into ${COMPRESSED_BLOCK_HEADER}.${skippedNote}\nIMPORTANT: This was an automatic context compression. You MUST continue your previous task exactly where you left off. Do NOT ask the user what to do next.\n💡 Tip: Use search_context('keyword') to find compressed content when you need it later.`
         },
     })
 }

--- a/lib/compress/range.ts
+++ b/lib/compress/range.ts
@@ -293,13 +293,16 @@ export function createCompressRangeTool(factoryCtx: ToolFactoryContext): ReturnT
                     phantomCount: phantomId.phantomIndices.length,
                     totalCount: preparedPlans.length,
                     phantomIndices: phantomId.phantomIndices,
+                    details: phantomId.details,
                 })
                 if (phantomId.phantomIndices.length === preparedPlans.length) {
                     throw new Error(buildPhantomErrorMessage(phantomId.details))
                 }
                 const dropSet = new Set(phantomId.phantomIndices)
                 preparedPlans = preparedPlans.filter((_, i) => !dropSet.has(i))
-                phantomSkipNotice = buildPhantomErrorMessage(phantomId.details)
+                const skippedNums = phantomId.details.map((d) => `#${d.index + 1}`).join(", ")
+                const noun = phantomId.phantomIndices.length === 1 ? "entry" : "entries"
+                phantomSkipNotice = `Skipped ${phantomId.phantomIndices.length} already-compressed ${noun} (${skippedNums}) — they are no-ops; the remaining entries were compressed.`
             }
 
             const acknowledgeRisk = (args as { acknowledgeRisk?: boolean }).acknowledgeRisk === true

--- a/lib/compress/range.ts
+++ b/lib/compress/range.ts
@@ -8,6 +8,7 @@ import {
     snapshotCompressionState,
     restoreCompressionState,
     identifyPhantomPlans,
+    partitionPhantomPlans,
     buildPhantomErrorMessage,
     type NotificationEntry,
 } from "./pipeline"
@@ -280,29 +281,34 @@ export function createCompressRangeTool(factoryCtx: ToolFactoryContext): ReturnT
 
             // Issue #290: drop phantom entries and compress the rest. Must run
             // BEFORE snapshot/apply so dropped entries leave no ghost blocks.
-            const phantomId = identifyPhantomPlans(
-                ctx.state,
-                preparedPlans.map((p) => ({
-                    messageIds: p.selection.messageIds,
-                    consumedBlockIds: p.consumedBlockIds,
-                })),
+            const partition = partitionPhantomPlans(
+                identifyPhantomPlans(
+                    ctx.state,
+                    preparedPlans.map((p) => ({
+                        messageIds: p.selection.messageIds,
+                        consumedBlockIds: p.consumedBlockIds,
+                    })),
+                ),
+                preparedPlans.length,
             )
             let phantomSkipNotice: string | null = null
-            if (phantomId.phantomIndices.length > 0) {
-                ctx.logger.warn("Batch compress: phantom entries detected", {
-                    phantomCount: phantomId.phantomIndices.length,
+            if (partition.kind === "all-phantom") {
+                ctx.logger.warn("Batch compress: ALL entries phantom", {
                     totalCount: preparedPlans.length,
-                    phantomIndices: phantomId.phantomIndices,
-                    details: phantomId.details,
+                    details: partition.details,
                 })
-                if (phantomId.phantomIndices.length === preparedPlans.length) {
-                    throw new Error(buildPhantomErrorMessage(phantomId.details))
-                }
-                const dropSet = new Set(phantomId.phantomIndices)
+                throw new Error(buildPhantomErrorMessage(partition.details))
+            }
+            if (partition.kind === "partial") {
+                ctx.logger.warn("Batch compress: phantom entries detected", {
+                    phantomCount: partition.dropIndices.length,
+                    totalCount: preparedPlans.length,
+                    phantomIndices: partition.dropIndices,
+                    details: partition.details,
+                })
+                const dropSet = new Set(partition.dropIndices)
                 preparedPlans = preparedPlans.filter((_, i) => !dropSet.has(i))
-                const skippedNums = phantomId.details.map((d) => `#${d.index + 1}`).join(", ")
-                const noun = phantomId.phantomIndices.length === 1 ? "entry" : "entries"
-                phantomSkipNotice = `Skipped ${phantomId.phantomIndices.length} already-compressed ${noun} (${skippedNums}) — they are no-ops; the remaining entries were compressed.`
+                phantomSkipNotice = partition.notice
             }
 
             const acknowledgeRisk = (args as { acknowledgeRisk?: boolean }).acknowledgeRisk === true

--- a/lib/compress/search.ts
+++ b/lib/compress/search.ts
@@ -55,6 +55,7 @@ export function resolveBoundaryIds(
     state: SessionState,
     startId: string,
     endId: string,
+    logger?: { warn(message: string, data?: any): void },
 ): { startReference: BoundaryReference; endReference: BoundaryReference } {
     const lookup = buildBoundaryLookup(context, state)
     const issues: string[] = []
@@ -86,21 +87,33 @@ export function resolveBoundaryIds(
     // (model guessed m00019 but only m00018 exists), clamp to the last visible
     // message instead of failing hard. Only applies to numeric message refs (mN),
     // not block refs (bN) — block refs must match exactly.
+    //
+    // Issue #290 fix B: warn when clamping so the shift is observable. Silent
+    // clamping can re-select consumed ranges downstream and trigger phantom
+    // rejection; logging makes the cause traceable.
     if (!startReference && parsedStartId.kind === "message") {
+        const requestedRef = parsedStartId.ref
         const clamped = clampMessageRef(parsedStartId, context, state)
         if (clamped) {
             startReference = lookup.get(clamped.ref)
             if (startReference) {
                 parsedStartId.ref = clamped.ref
+                logger?.warn(
+                    `compress startId ${requestedRef} not available — clamped to ${clamped.ref}`,
+                )
             }
         }
     }
     if (!endReference && parsedEndId.kind === "message") {
+        const requestedRef = parsedEndId.ref
         const clamped = clampMessageRef(parsedEndId, context, state)
         if (clamped) {
             endReference = lookup.get(clamped.ref)
             if (endReference) {
                 parsedEndId.ref = clamped.ref
+                logger?.warn(
+                    `compress endId ${requestedRef} not available — clamped to ${clamped.ref}`,
+                )
             }
         }
     }
@@ -134,7 +147,7 @@ export function resolveBoundaryIds(
     // but anchor message ordering can differ. Auto-swap prevents compress failures
     // that cause models to give up without compressing.
     if (startReference.rawIndex > endReference.rawIndex) {
-        [startReference, endReference] = [endReference, startReference]
+        ;[startReference, endReference] = [endReference, startReference]
     }
 
     // [FIX Issue #247] Auto-extend range boundaries to prevent splitting
@@ -153,10 +166,7 @@ export function resolveBoundaryIds(
         endReference.rawIndex,
     )
 
-    if (
-        adjusted.startIndex < startReference.rawIndex &&
-        startReference.kind === "message"
-    ) {
+    if (adjusted.startIndex < startReference.rawIndex && startReference.kind === "message") {
         const msg = context.rawMessages[adjusted.startIndex]
         if (msg) {
             startReference = {
@@ -167,10 +177,7 @@ export function resolveBoundaryIds(
         }
     }
 
-    if (
-        adjusted.endIndex > endReference.rawIndex &&
-        endReference.kind === "message"
-    ) {
+    if (adjusted.endIndex > endReference.rawIndex && endReference.kind === "message") {
         const msg = context.rawMessages[adjusted.endIndex]
         if (msg) {
             endReference = {
@@ -481,9 +488,7 @@ function buildSearchPreview(text: string, firstTerm: string): string {
         const start = Math.max(0, matchIdx - 50)
         const end = Math.min(text.length, matchIdx + 150)
         return (
-            (start > 0 ? "..." : "") +
-            text.substring(start, end) +
-            (end < text.length ? "..." : "")
+            (start > 0 ? "..." : "") + text.substring(start, end) + (end < text.length ? "..." : "")
         )
     }
     return text.substring(0, 200) + (text.length > 200 ? "..." : "")
@@ -495,9 +500,7 @@ export function createSearchContextTool(factoryCtx: ToolFactoryContext): ReturnT
     return tool({
         description: SEARCH_CONTEXT_TOOL_DESCRIPTION,
         args: {
-            query: tool.schema
-                .string()
-                .describe("Search query — keywords or phrase to find"),
+            query: tool.schema.string().describe("Search query — keywords or phrase to find"),
             limit: tool.schema
                 .number()
                 .optional()
@@ -505,7 +508,9 @@ export function createSearchContextTool(factoryCtx: ToolFactoryContext): ReturnT
             deep: tool.schema
                 .boolean()
                 .optional()
-                .describe("If true, also search visible (uncompressed) messages. Slower but more thorough (default: false)"),
+                .describe(
+                    "If true, also search visible (uncompressed) messages. Slower but more thorough (default: false)",
+                ),
         },
         async execute(args, toolCtx) {
             const ctx = resolveToolContext(factoryCtx, toolCtx.sessionID)
@@ -518,7 +523,7 @@ export function createSearchContextTool(factoryCtx: ToolFactoryContext): ReturnT
 
             const queryTerms = query.split(/\s+/).filter((t) => t.length > 0)
             const results: SearchResult[] = []
-            const MIN_RELEVANCE = 0.10
+            const MIN_RELEVANCE = 0.1
 
             const blocksById = ctx.state.prune.messages.blocksById
             for (const [blockId, block] of blocksById) {
@@ -541,7 +546,7 @@ export function createSearchContextTool(factoryCtx: ToolFactoryContext): ReturnT
                     // Summary matches (lower weight, compounds with frequency)
                     const summaryCount = countOccurrences(summary, term)
                     if (summaryCount > 0) {
-                        relevance += Math.min(summaryCount * 0.04, 0.20)
+                        relevance += Math.min(summaryCount * 0.04, 0.2)
                         termHit = true
                     }
                     if (termHit) termsHit++

--- a/tests/compress-search.test.ts
+++ b/tests/compress-search.test.ts
@@ -7,7 +7,12 @@ import {
     resolveAnchorMessageId,
 } from "../lib/compress/search"
 import type { BoundaryReference, SearchContext } from "../lib/compress/types"
-import type { CompressionBlock, PrunedMessageEntry, SessionState, WithParts } from "../lib/state/types"
+import type {
+    CompressionBlock,
+    PrunedMessageEntry,
+    SessionState,
+    WithParts,
+} from "../lib/state/types"
 
 // --- Factory helpers ---
 
@@ -130,7 +135,7 @@ function makeState(overrides: Partial<SessionState> = {}): SessionState {
         stats: { pruneTokenCounter: 0, totalPruneTokens: 0 },
         compressionTiming: {} as any,
         toolParameters: new Map(),
-            toolIdList: [],
+        toolIdList: [],
         messageIds: { byRawId: new Map(), byRef: new Map(), nextRef: 1 },
         lastCompaction: 0,
         currentTurn: 0,
@@ -140,7 +145,10 @@ function makeState(overrides: Partial<SessionState> = {}): SessionState {
     }
 }
 
-function makeContext(rawMessages: WithParts[], blocks: Map<number, CompressionBlock> = new Map()): SearchContext {
+function makeContext(
+    rawMessages: WithParts[],
+    blocks: Map<number, CompressionBlock> = new Map(),
+): SearchContext {
     const rawMessagesById = new Map<string, WithParts>()
     const rawIndexById = new Map<string, number>()
     for (let i = 0; i < rawMessages.length; i++) {
@@ -255,19 +263,13 @@ test("resolveBoundaryIds resolves block IDs correctly", () => {
 test("resolveBoundaryIds throws on invalid startId format", () => {
     const ctx = makeContext([])
     const state = makeState()
-    assert.throws(
-        () => resolveBoundaryIds(ctx, state, "invalid", "m00001"),
-        /startId is invalid/,
-    )
+    assert.throws(() => resolveBoundaryIds(ctx, state, "invalid", "m00001"), /startId is invalid/)
 })
 
 test("resolveBoundaryIds throws on unknown message ref", () => {
     const ctx = makeContext([])
     const state = makeState()
-    assert.throws(
-        () => resolveBoundaryIds(ctx, state, "m00099", "m00100"),
-        /not available/,
-    )
+    assert.throws(() => resolveBoundaryIds(ctx, state, "m00099", "m00100"), /not available/)
 })
 
 test("resolveBoundaryIds failure error includes visible range and acp_status pointer", () => {
@@ -347,6 +349,45 @@ test("resolveBoundaryIds clamps out-of-range startId to last visible message", (
     const { startReference, endReference } = resolveBoundaryIds(ctx, state, "m00019", "m00020")
     assert.equal(startReference.messageId, "raw-b")
     assert.equal(endReference.messageId, "raw-b")
+})
+
+test("resolveBoundaryIds warns via logger when clamping out-of-range boundaries (issue #290 fix B)", () => {
+    const msg1 = makeAssistantMessage("raw-a", "first")
+    const msg2 = makeAssistantMessage("raw-b", "second")
+    const ctx = makeContext([msg1, msg2])
+
+    const state = makeState()
+    state.messageIds.byRef.set("m00001", "raw-a")
+    state.messageIds.byRef.set("m00002", "raw-b")
+    state.messageIds.byRawId.set("raw-a", "m00001")
+    state.messageIds.byRawId.set("raw-b", "m00002")
+
+    const warns: string[] = []
+    const logger = { warn: (msg: string) => warns.push(msg) }
+
+    resolveBoundaryIds(ctx, state, "m00001", "m00019", logger)
+
+    assert.equal(warns.length, 1)
+    assert.match(warns[0]!, /compress endId m00019 not available — clamped to m00002/)
+})
+
+test("resolveBoundaryIds does not warn when boundaries resolve without clamping", () => {
+    const msg1 = makeAssistantMessage("raw-a", "first")
+    const msg2 = makeAssistantMessage("raw-b", "second")
+    const ctx = makeContext([msg1, msg2])
+
+    const state = makeState()
+    state.messageIds.byRef.set("m00001", "raw-a")
+    state.messageIds.byRef.set("m00002", "raw-b")
+    state.messageIds.byRawId.set("raw-a", "m00001")
+    state.messageIds.byRawId.set("raw-b", "m00002")
+
+    const warns: string[] = []
+    const logger = { warn: (msg: string) => warns.push(msg) }
+
+    resolveBoundaryIds(ctx, state, "m00001", "m00002", logger)
+
+    assert.equal(warns.length, 0)
 })
 
 test("resolveBoundaryIds auto-swaps reversed boundaries (Bug 34)", () => {
@@ -473,10 +514,7 @@ test("resolveSelection throws on empty selection", () => {
     const startRef: BoundaryReference = { kind: "message", rawIndex: 0, messageId: "a" }
     const endRef: BoundaryReference = { kind: "message", rawIndex: 0, messageId: "a" }
 
-    assert.throws(
-        () => resolveSelection(ctx, startRef, endRef),
-        /Failed to map boundary matches/,
-    )
+    assert.throws(() => resolveSelection(ctx, startRef, endRef), /Failed to map boundary matches/)
 })
 
 test("resolveSelection includes messageTokenById for selected messages", () => {
@@ -510,16 +548,10 @@ test("resolveAnchorMessageId returns anchorMessageId for compressed-block kind",
 
 test("resolveAnchorMessageId throws for compressed-block without anchorMessageId", () => {
     const ref: BoundaryReference = { kind: "compressed-block", rawIndex: 5, blockId: 3 }
-    assert.throws(
-        () => resolveAnchorMessageId(ref),
-        /Failed to map boundary matches/,
-    )
+    assert.throws(() => resolveAnchorMessageId(ref), /Failed to map boundary matches/)
 })
 
 test("resolveAnchorMessageId throws for message kind without messageId", () => {
     const ref: BoundaryReference = { kind: "message", rawIndex: 0 }
-    assert.throws(
-        () => resolveAnchorMessageId(ref),
-        /Failed to map boundary matches/,
-    )
+    assert.throws(() => resolveAnchorMessageId(ref), /Failed to map boundary matches/)
 })

--- a/tests/phantom-block.test.ts
+++ b/tests/phantom-block.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict"
 import test from "node:test"
-import { checkPhantomBlock } from "../lib/compress/pipeline"
+import {
+    buildPhantomErrorMessage,
+    checkPhantomBlock,
+    identifyPhantomPlans,
+} from "../lib/compress/pipeline"
 import type { CompressionBlock, PrunedMessageEntry, SessionState } from "../lib/state/types"
 
 function makeBlock(overrides: Partial<CompressionBlock> = {}): CompressionBlock {
@@ -59,7 +63,7 @@ function makeState(overrides: Partial<SessionState> = {}): SessionState {
         stats: { pruneTokenCounter: 0, totalPruneTokens: 0 },
         compressionTiming: {} as any,
         toolParameters: new Map(),
-            toolIdList: [],
+        toolIdList: [],
         messageIds: { byRawId: new Map(), byRef: new Map(), nextRef: 1 },
         lastCompaction: 0,
         currentTurn: 0,
@@ -69,7 +73,12 @@ function makeState(overrides: Partial<SessionState> = {}): SessionState {
     }
 }
 
-function activateMessage(state: SessionState, messageId: string, blockId: number, tokenCount = 50): void {
+function activateMessage(
+    state: SessionState,
+    messageId: string,
+    blockId: number,
+    tokenCount = 50,
+): void {
     const existing = state.prune.messages.byMessageId.get(messageId)
     if (existing) {
         if (!existing.allBlockIds.includes(blockId)) existing.allBlockIds.push(blockId)
@@ -87,7 +96,9 @@ function activateMessage(state: SessionState, messageId: string, blockId: number
 
 test("checkPhantomBlock returns null when all messages are new (not in any block)", () => {
     const state = makeState()
-    const result = checkPhantomBlock(state, [{ messageIds: ["m1", "m2", "m3"], consumedBlockIds: [] }])
+    const result = checkPhantomBlock(state, [
+        { messageIds: ["m1", "m2", "m3"], consumedBlockIds: [] },
+    ])
     assert.equal(result, null)
 })
 
@@ -151,7 +162,9 @@ test("checkPhantomBlock returns null when consuming a block plus adding a new me
     activateMessage(state, "m2", 10)
 
     // m3 is new → not phantom
-    const result = checkPhantomBlock(state, [{ messageIds: ["m1", "m2", "m3"], consumedBlockIds: [10] }])
+    const result = checkPhantomBlock(state, [
+        { messageIds: ["m1", "m2", "m3"], consumedBlockIds: [10] },
+    ])
     assert.equal(result, null)
 })
 
@@ -218,4 +231,136 @@ test("checkPhantomBlock error message includes range index for multi-plan batche
     ])
     assert.ok(result instanceof Error)
     assert.match(result!.message, /range 3/i)
+})
+
+// --- identifyPhantomPlans: batch-aware diagnostics (issue #290 fix A/C) ---
+
+test("identifyPhantomPlans returns no phantoms when all plans have new messages", () => {
+    const state = makeState()
+    const result = identifyPhantomPlans(state, [
+        { messageIds: ["m1"], consumedBlockIds: [] },
+        { messageIds: ["m2", "m3"], consumedBlockIds: [] },
+    ])
+    assert.deepEqual(result.phantomIndices, [])
+    assert.deepEqual(result.details, [])
+})
+
+test("identifyPhantomPlans marks a phantom entry and reports owning block + consumed IDs", () => {
+    const state = makeState()
+    activateMessage(state, "m2", 7)
+    const result = identifyPhantomPlans(state, [
+        { messageIds: ["m1"], consumedBlockIds: [] },
+        { messageIds: ["m2"], consumedBlockIds: [] },
+    ])
+    assert.deepEqual(result.phantomIndices, [1])
+    assert.equal(result.details.length, 1)
+    const detail = result.details[0]!
+    assert.equal(detail.index, 1)
+    assert.deepEqual(detail.consumedMessageIds, ["m2"])
+    assert.deepEqual(detail.owningBlockIds, [7])
+})
+
+test("identifyPhantomPlans reports ALL phantom entries in a mixed batch (not just the first)", () => {
+    const state = makeState()
+    activateMessage(state, "m1", 2)
+    activateMessage(state, "m3", 3)
+    const result = identifyPhantomPlans(state, [
+        { messageIds: ["m1"], consumedBlockIds: [] },
+        { messageIds: ["m2"], consumedBlockIds: [] },
+        { messageIds: ["m3"], consumedBlockIds: [] },
+    ])
+    assert.deepEqual(result.phantomIndices, [0, 2])
+    assert.equal(result.details.length, 2)
+    assert.equal(result.details[0]!.index, 0)
+    assert.deepEqual(result.details[0]!.owningBlockIds, [2])
+    assert.equal(result.details[1]!.index, 2)
+    assert.deepEqual(result.details[1]!.owningBlockIds, [3])
+})
+
+test("identifyPhantomPlans keeps the multi-consumed single-tier carve-out (not phantom)", () => {
+    const state = makeState()
+    const blockA = makeBlock({ blockId: 10, tier: 1, effectiveMessageIds: ["m1", "m2"] })
+    const blockB = makeBlock({ blockId: 11, tier: 1, effectiveMessageIds: ["m3", "m4"] })
+    state.prune.messages.blocksById.set(10, blockA)
+    state.prune.messages.blocksById.set(11, blockB)
+    for (const mid of ["m1", "m2", "m3", "m4"]) activateMessage(state, mid, 10)
+
+    const result = identifyPhantomPlans(state, [
+        { messageIds: ["m1", "m2", "m3", "m4"], consumedBlockIds: [10, 11] },
+    ])
+    assert.deepEqual(result.phantomIndices, [])
+})
+
+test("identifyPhantomPlans treats deactivated (GC'd) messages as new", () => {
+    const state = makeState()
+    state.prune.messages.byMessageId.set("m1", {
+        tokenCount: 50,
+        allBlockIds: [1],
+        activeBlockIds: [],
+    })
+    const result = identifyPhantomPlans(state, [{ messageIds: ["m1"], consumedBlockIds: [] }])
+    assert.deepEqual(result.phantomIndices, [])
+})
+
+test("identifyPhantomPlans dedups owning block IDs across multiple consumed messages", () => {
+    const state = makeState()
+    activateMessage(state, "m1", 5)
+    activateMessage(state, "m2", 5)
+    activateMessage(state, "m2", 9)
+    const result = identifyPhantomPlans(state, [{ messageIds: ["m1", "m2"], consumedBlockIds: [] }])
+    assert.deepEqual(result.phantomIndices, [0])
+    const detail = result.details[0]!
+    assert.deepEqual(detail.owningBlockIds, [5, 9])
+})
+
+// --- buildPhantomErrorMessage: diagnostics surface (issue #290 fix C) ---
+
+test("buildPhantomErrorMessage includes entry index, consumed IDs, and owning block refs", () => {
+    const msg = buildPhantomErrorMessage([
+        { index: 1, consumedMessageIds: ["m2", "m3"], owningBlockIds: [7] },
+    ])
+    assert.match(msg, /Entry 2/)
+    assert.match(msg, /m2, m3/)
+    assert.match(msg, /b7/)
+    assert.match(msg, /already-compressed/)
+    assert.match(msg, /0 new direct messages/)
+})
+
+test("buildPhantomErrorMessage lists multiple phantom entries", () => {
+    const msg = buildPhantomErrorMessage([
+        { index: 0, consumedMessageIds: ["m1"], owningBlockIds: [2] },
+        { index: 2, consumedMessageIds: ["m3"], owningBlockIds: [3] },
+    ])
+    assert.match(msg, /2 compress entries/)
+    assert.match(msg, /Entry 1/)
+    assert.match(msg, /Entry 3/)
+    assert.match(msg, /b2/)
+    assert.match(msg, /b3/)
+})
+
+test("buildPhantomErrorMessage handles empty owning blocks (stale ref) without throwing", () => {
+    const msg = buildPhantomErrorMessage([{ index: 0, consumedMessageIds: [], owningBlockIds: [] }])
+    assert.match(msg, /stale ref/)
+    assert.match(msg, /Entry 1/)
+})
+
+// --- checkPhantomBlock delegation preserved ---
+
+test("checkPhantomBlock delegates to identifyPhantomPlans (first phantom → Error)", () => {
+    const state = makeState()
+    activateMessage(state, "m2", 1)
+    const result = checkPhantomBlock(state, [
+        { messageIds: ["m1"], consumedBlockIds: [] },
+        { messageIds: ["m2"], consumedBlockIds: [] },
+    ])
+    assert.ok(result instanceof Error)
+    assert.match(result!.message, /range 2/i)
+    assert.match(result!.message, /already-compressed/)
+})
+
+test("checkPhantomBlock returns null when identifyPhantomPlans finds nothing", () => {
+    const state = makeState()
+    activateMessage(state, "m1", 1)
+    const result = checkPhantomBlock(state, [{ messageIds: ["m1", "m2"], consumedBlockIds: [] }])
+    assert.equal(result, null)
 })

--- a/tests/phantom-block.test.ts
+++ b/tests/phantom-block.test.ts
@@ -2,8 +2,10 @@ import assert from "node:assert/strict"
 import test from "node:test"
 import {
     buildPhantomErrorMessage,
+    buildPhantomSkipNotice,
     checkPhantomBlock,
     identifyPhantomPlans,
+    partitionPhantomPlans,
 } from "../lib/compress/pipeline"
 import type { CompressionBlock, PrunedMessageEntry, SessionState } from "../lib/state/types"
 
@@ -363,4 +365,108 @@ test("checkPhantomBlock returns null when identifyPhantomPlans finds nothing", (
     activateMessage(state, "m1", 1)
     const result = checkPhantomBlock(state, [{ messageIds: ["m1", "m2"], consumedBlockIds: [] }])
     assert.equal(result, null)
+})
+
+// --- partitionPhantomPlans: the batch all-vs-some-vs-clean decision (issue #290) ---
+
+test("partitionPhantomPlans returns clean when no entries are phantom", () => {
+    const id = identifyPhantomPlans(makeState(), [
+        { messageIds: ["m1"], consumedBlockIds: [] },
+        { messageIds: ["m2"], consumedBlockIds: [] },
+    ])
+    const partition = partitionPhantomPlans(id, 2)
+    assert.deepEqual(partition, { kind: "clean" })
+})
+
+test("partitionPhantomPlans returns all-phantom when every entry is phantom", () => {
+    const state = makeState()
+    activateMessage(state, "m1", 1)
+    activateMessage(state, "m2", 1)
+    const id = identifyPhantomPlans(state, [
+        { messageIds: ["m1"], consumedBlockIds: [] },
+        { messageIds: ["m2"], consumedBlockIds: [] },
+    ])
+    assert.deepEqual(id.phantomIndices, [0, 1])
+    const partition = partitionPhantomPlans(id, 2)
+    assert.equal(partition.kind, "all-phantom")
+    if (partition.kind !== "all-phantom") return
+    assert.equal(partition.details.length, 2)
+    assert.equal(partition.details[0]!.index, 0)
+    assert.equal(partition.details[1]!.index, 1)
+})
+
+test("partitionPhantomPlans returns partial (drop + notice) when some entries are phantom", () => {
+    const state = makeState()
+    activateMessage(state, "m2", 1)
+    // 3 plans: [0] valid, [1] phantom, [2] valid
+    const id = identifyPhantomPlans(state, [
+        { messageIds: ["m1"], consumedBlockIds: [] },
+        { messageIds: ["m2"], consumedBlockIds: [] },
+        { messageIds: ["m3"], consumedBlockIds: [] },
+    ])
+    assert.deepEqual(id.phantomIndices, [1])
+    const partition = partitionPhantomPlans(id, 3)
+    assert.equal(partition.kind, "partial")
+    if (partition.kind !== "partial") return
+    assert.deepEqual(partition.dropIndices, [1])
+    assert.equal(partition.details.length, 1)
+    assert.equal(partition.details[0]!.index, 1)
+    assert.match(partition.notice, /Skipped 1 already-compressed entry \(#2\)/)
+    assert.match(partition.notice, /remaining entries were compressed/)
+})
+
+test("partitionPhantomPlans partial with multiple phantoms uses plural + lists all numbers", () => {
+    const state = makeState()
+    activateMessage(state, "m1", 1)
+    activateMessage(state, "m3", 1)
+    // 4 plans: [0] phantom, [1] valid, [2] phantom, [3] valid
+    const id = identifyPhantomPlans(state, [
+        { messageIds: ["m1"], consumedBlockIds: [] },
+        { messageIds: ["m2"], consumedBlockIds: [] },
+        { messageIds: ["m3"], consumedBlockIds: [] },
+        { messageIds: ["m4"], consumedBlockIds: [] },
+    ])
+    assert.deepEqual(id.phantomIndices, [0, 2])
+    const partition = partitionPhantomPlans(id, 4)
+    assert.equal(partition.kind, "partial")
+    if (partition.kind !== "partial") return
+    assert.deepEqual(partition.dropIndices, [0, 2])
+    assert.match(partition.notice, /Skipped 2 already-compressed entries \(#1, #3\)/)
+})
+
+test("partitionPhantomPlans partial keeps its original details even when filtered later", () => {
+    // Guards against a refactor that re-derives details from the filtered plan
+    // list (which would drop the diagnostics for the phantom entries).
+    const state = makeState()
+    activateMessage(state, "m1", 1)
+    const id = identifyPhantomPlans(state, [
+        { messageIds: ["m1"], consumedBlockIds: [] },
+        { messageIds: ["m2"], consumedBlockIds: [] },
+    ])
+    const partition = partitionPhantomPlans(id, 2)
+    if (partition.kind !== "partial") throw new Error("expected partial")
+    // details[0] must describe the DROPPED (phantom) plan, not a surviving one.
+    assert.equal(partition.details.length, 1)
+    assert.equal(partition.details[0]!.index, 0)
+    assert.deepEqual(partition.details[0]!.owningBlockIds, [1])
+})
+
+test("buildPhantomSkipNotice singular vs plural", () => {
+    assert.match(
+        buildPhantomSkipNotice({
+            phantomIndices: [3],
+            details: [{ index: 3, consumedMessageIds: [], owningBlockIds: [] }],
+        }),
+        /1 already-compressed entry/,
+    )
+    assert.match(
+        buildPhantomSkipNotice({
+            phantomIndices: [0, 2],
+            details: [
+                { index: 0, consumedMessageIds: [], owningBlockIds: [] },
+                { index: 2, consumedMessageIds: [], owningBlockIds: [] },
+            ],
+        }),
+        /2 already-compressed entries \(#1, #3\)/,
+    )
 })


### PR DESCRIPTION
## Summary

Fixes #290.

Batch `compress` calls (`content[]` with 5–6 entries) aborted **entirely** when any single entry contained only already-compressed messages. The remaining valid entries were never executed, and the error (`Compression range N contains only already-compressed messages`) named only the entry index — not the conflicting message IDs or owning blocks — forcing trial-and-error retry loops. Separately, `clampMessageRef` silently shifted beyond-last-visible refs onto possibly-compressed regions.

## Changes

**A + C — Partial-failure batches with diagnostics** (`lib/compress/pipeline.ts`, `lib/compress/range.ts`)
- New `identifyPhantomPlans()` returns per-plan diagnostics (entry index, consumed message IDs sample, owning block IDs). Preserves the multi-consumed single-tier carve-out and the `activeBlockIds`-based "new message" rule.
- `buildPhantomErrorMessage()` renders a multi-entry message (used on the all-phantom throw).
- Phantom entries are now **dropped** and the valid ones compress normally. The success return carries a one-line warn-flavored skip notice naming the dropped entry numbers; full diagnostics go to `ctx.logger.warn`.
- Hard-fails **only** when every entry is phantom — then the verbose diagnostics (entry index + consumed IDs + owning `bN` blocks) are thrown so the model can correct its boundaries.
- `checkPhantomBlock` now delegates to `identifyPhantomPlans`; its public `Error | null` contract is unchanged (existing tests pass verbatim).

**B — Clamp warning** (`lib/compress/search.ts`, `lib/compress/range-utils.ts`)
- `resolveBoundaryIds` takes an optional logger and emits a warn when `clampMessageRef` shifts a boundary, so the previously-silent clamp is observable. Threaded through `resolveRanges`; the logger is optional + structural, so existing callers (`rebuild.ts`, `decompress.ts`) and pure unit tests need no changes.

**D out of scope** — the reporter confirmed the nudge list is already correct; ghost IDs that appear there are genuinely compressible individually.

## Verification
- `npx tsc --noEmit` → 0 errors
- `node --import tsx --test tests/*.test.ts` → **968 pass / 0 fail** (+11 new in `tests/phantom-block.test.ts`)
- `npm run build` → success; bundle grep confirms all three fixes present
- `scripts/ci/check-pr.sh` → all green
- Rebased onto current master (`417f5df`, includes #288); no file overlap with #288

## Note on acp-kernel
`ranxianglei/acp-kernel` does **not** have this bug — its batch loop (`src/compress.ts:202-221`) already catches per-range errors into `errors[]` and continues, and `src/boundaries.ts` has no silent clamp. #290 is specific to opencode-acp's all-or-nothing `checkPhantomBlock` design.

Per AGENTS.md §5.1.1.2, PR merge is a human-only operation.