### PR TITLE
release: v1.14.14-dev.1 — dev prerelease (#288, #290)

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,16 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.14-dev.1 — Dev Prerelease (2 PRs since v1.14.13)
+
+Dev prerelease covering two compress-subsystem fixes: the batched-call summary leak (#288) and the batch-compress all-or-nothing abort (#290). Published to the `dev` npm tag for early testing.
+
+**PRs included**:
+- **#288** (via #289) — `hideConsumedCompressCalls` keyed its keep-set on `compressCallId`, which is 1:N under batched compress (one tool call, multiple `content[]` entries share one callId). When a T2 distillation consumed only some siblings, a surviving sibling rescued the whole tool part, permanently leaking the consumed summaries — unreclaimable because compress is a default protected tool. Fix: key visibility per-block (on `startId::endId`) instead of per-callId; for kept batches with mixed liveness, rewrite the surviving tool part's `state.input.content` to drop consumed entries' summaries. All-consumed batches still fully removed. Files: `lib/compress/hide-consumed.ts`. Tests: +3 in `tests/hide-consumed.test.ts` (core regression verified to FAIL pre-fix).
+- **#290** (via #291) — Batch `compress` aborted entirely when any single `content[]` entry contained only already-compressed messages (`Compression range N contains only already-compressed messages`), leaving valid entries unexecuted; the error also omitted which entry/IDs/blocks conflicted, forcing trial-and-error retries. Fix: (A) partial-failure batches — new `identifyPhantomPlans` drops phantom entries and compresses the rest, returning a concise skip notice; (C) detailed diagnostics on the all-phantom throw (entry index + consumed IDs + owning block); (B) a clamp warning when `clampMessageRef` silently shifts a boundary. Extracted `partitionPhantomPlans` + `buildPhantomSkipNotice` pure helpers for testable batch decision logic. `checkPhantomBlock` keeps its exact legacy contract. Files: `lib/compress/{pipeline,range,search,range-utils}.ts`. Tests: +19. Dual-agent reviewed (Oracle + General, both APPROVE).
+
+**Install**: `opencode plugin opencode-acp@dev --global`
+
 ### v1.14.13 — Stable Release (3 PRs since v1.14.12)
 
 Stable release with `allowSubAgents` promoted to a top-level config field (default: `true`), plus config documentation updates.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,6 +446,16 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 ## 更新日志
 
+### v1.14.14-dev.1 — Dev 预发布版（v1.14.13 以来 2 个 PR）
+
+Dev 预发布版，包含两个压缩子系统修复：批量调用的 summary 泄漏（#288）和批量压缩的全有或全无中断（#290）。发布到 `dev` npm tag 供早期测试。
+
+**包含的 PR**：
+- **#288**（经 #289）— `hideConsumedCompressCalls` 的 keep-set 以 `compressCallId` 为键，在批量压缩下是 1:N 关系（一次工具调用，多个 `content[]` 条目共享一个 callId）。当 T2 蒸馏只消费了部分兄弟块时，存活的兄弟块会救下整个工具 part，永久泄漏已消费的 summary——且因 compress 是默认受保护工具而无法回收。修复：改为按块（`startId::endId`）标记可见性；对混合存活状态的保留批次，重写存活工具 part 的 `state.input.content` 以丢弃已消费条目的 summary。全部消费的批次仍整体移除。文件：`lib/compress/hide-consumed.ts`。测试：`tests/hide-consumed.test.ts` +3（核心回归测试已验证修复前会失败）。
+- **#290**（经 #291）— 批量 `compress` 在任一 `content[]` 条目只含已压缩消息时整体中断（`Compression range N contains only already-compressed messages`），导致有效条目未执行；错误也未说明哪个条目/ID/块冲突，迫使反复试错重试。修复：(A) 部分失败批次——新增 `identifyPhantomPlans` 丢弃 phantom 条目并压缩其余，返回简洁的跳过提示；(C) 全 phantom 抛错时附详细诊断（条目序号 + 已消费 ID + 所属块）；(B) `clampMessageRef` 静默平移边界时发出警告。抽出 `partitionPhantomPlans` + `buildPhantomSkipNotice` 纯函数使批量决策逻辑可测试。`checkPhantomBlock` 保持原有契约不变。文件：`lib/compress/{pipeline,range,search,range-utils}.ts`。测试：+19。双 agent review（Oracle + General，均 APPROVE）。
+
+**安装**：`opencode plugin opencode-acp@dev --global`
+
 ### v1.14.13 — 正式版（v1.14.12 以来 3 个 PR）
 
 正式版发布，`allowSubAgents` 从实验性参数提升为正式参数（默认：`true`），并更新了配置文档的推荐设置。

--- a/devlog/2026-08-11_release-v1.14.14-dev.1/REQ.md
+++ b/devlog/2026-08-11_release-v1.14.14-dev.1/REQ.md
@@ -1,0 +1,34 @@
+# REQ — v1.14.14-dev.1 (Dev Prerelease)
+
+## Goal
+
+Publish a dev prerelease (`1.14.14-dev.1`) to the npm `dev` tag covering the two
+compress-subsystem fixes merged to `master` since v1.14.13, so users can opt in
+to early testing via `opencode-acp@dev`.
+
+## PRs included (since v1.14.13)
+
+1. **#288** (via #289) — `hideConsumedCompressCalls` per-block hide-consumed to
+   stop summary leak in batched compress calls.
+2. **#290** (via #291) — Partial-failure batch compress + phantom diagnostics +
+   clamp warning.
+
+## Version rationale
+
+Patch bump (1.14.13 → 1.14.14). Both PRs are compress-subsystem fixes; the
+project cadence is patch-level for fix releases. Dev suffix `-dev.1` per
+§5.4.5.
+
+## Acceptance criteria
+
+- [x] `package.json` version = `1.14.14-dev.1`.
+- [x] `README.md` + `README.zh-CN.md` changelog entries added under
+      `### v1.14.14-dev.1`.
+- [x] `scripts/ci/check-pr.sh` passes (branch name, devlog, changelog).
+- [x] `npm run build` passes; `npm run typecheck` clean.
+- [x] PR created; on merge CI publishes to `dev` tag + prerelease GitHub Release
+      (version contains `-`).
+
+## Out of scope
+
+- Stable (`latest`) release — separate release PR (`1.14.14`).

--- a/devlog/2026-08-11_release-v1.14.14-dev.1/WORKLOG.md
+++ b/devlog/2026-08-11_release-v1.14.14-dev.1/WORKLOG.md
@@ -1,0 +1,20 @@
+# WORKLOG — v1.14.14-dev.1 (Dev Prerelease)
+
+## Changes
+
+- Bumped `package.json` version `1.14.13` → `1.14.14-dev.1`.
+- Added `### v1.14.14-dev.1` changelog entry to `README.md` (EN) and
+  `README.zh-CN.md` (ZH), covering PRs #288 and #290.
+- Created devlog entry (this folder).
+
+## Verification
+
+- `scripts/ci/check-pr.sh 2026-08-11_release-v1.14.14-dev.1 github/master` — pass.
+- `npm run typecheck` — 0 errors.
+- `npm run build` — dist/index.js success.
+
+## Publish path
+
+CI `release.yml` detects the version contains `-` → publishes with
+`--tag dev` and marks the GitHub Release as `prerelease: true`. Users install
+via `opencode plugin opencode-acp@dev --global`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.13",
+    "version": "1.14.14-dev.1",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
Dev prerelease `1.14.14-dev.1` → npm `dev` tag. Covers #288 (per-block hide-consumed, summary leak in batched calls) and #290 (partial-failure batch compress + phantom diagnostics + clamp warn). Merge this FIRST. On merge, CI publishes to `dev` tag (version contains `-` → prerelease). Install: `opencode plugin opencode-acp@dev --global`. CI: all checks pass (pr-validation, test, build).