### PR TITLE
release: v1.14.14 — stable release (#288, #290)

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,16 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.14 — Stable Release (2 PRs since v1.14.13)
+
+Stable release covering two compress-subsystem fixes: the batched-call summary leak (#288) and the batch-compress all-or-nothing abort (#290). Published to the `latest` npm tag.
+
+**PRs included**:
+- **#288** (via #289) — `hideConsumedCompressCalls` keyed its keep-set on `compressCallId`, which is 1:N under batched compress (one tool call, multiple `content[]` entries share one callId). When a T2 distillation consumed only some siblings, a surviving sibling rescued the whole tool part, permanently leaking the consumed summaries — unreclaimable because compress is a default protected tool. Fix: key visibility per-block (on `startId::endId`) instead of per-callId; for kept batches with mixed liveness, rewrite the surviving tool part's `state.input.content` to drop consumed entries' summaries. All-consumed batches still fully removed. Files: `lib/compress/hide-consumed.ts`. Tests: +3 in `tests/hide-consumed.test.ts` (core regression verified to FAIL pre-fix).
+- **#290** (via #291) — Batch `compress` aborted entirely when any single `content[]` entry contained only already-compressed messages (`Compression range N contains only already-compressed messages`), leaving valid entries unexecuted; the error also omitted which entry/IDs/blocks conflicted, forcing trial-and-error retries. Fix: (A) partial-failure batches — new `identifyPhantomPlans` drops phantom entries and compresses the rest, returning a concise skip notice; (C) detailed diagnostics on the all-phantom throw (entry index + consumed IDs + owning block); (B) a clamp warning when `clampMessageRef` silently shifts a boundary. Extracted `partitionPhantomPlans` + `buildPhantomSkipNotice` pure helpers for testable batch decision logic. `checkPhantomBlock` keeps its exact legacy contract. Files: `lib/compress/{pipeline,range,search,range-utils}.ts`. Tests: +19. Dual-agent reviewed (Oracle + General, both APPROVE).
+
+**Install**: `opencode plugin opencode-acp@latest --global`
+
 ### v1.14.14-dev.1 — Dev Prerelease (2 PRs since v1.14.13)
 
 Dev prerelease covering two compress-subsystem fixes: the batched-call summary leak (#288) and the batch-compress all-or-nothing abort (#290). Published to the `dev` npm tag for early testing.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,6 +446,16 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 ## 更新日志
 
+### v1.14.14 — 正式版（v1.14.13 以来 2 个 PR）
+
+正式版，包含两个压缩子系统修复：批量调用的 summary 泄漏（#288）和批量压缩的全有或全无中断（#290）。发布到 `latest` npm tag。
+
+**包含的 PR**：
+- **#288**（经 #289）— `hideConsumedCompressCalls` 的 keep-set 以 `compressCallId` 为键，在批量压缩下是 1:N 关系（一次工具调用，多个 `content[]` 条目共享一个 callId）。当 T2 蒸馏只消费了部分兄弟块时，存活的兄弟块会救下整个工具 part，永久泄漏已消费的 summary——且因 compress 是默认受保护工具而无法回收。修复：改为按块（`startId::endId`）标记可见性；对混合存活状态的保留批次，重写存活工具 part 的 `state.input.content` 以丢弃已消费条目的 summary。全部消费的批次仍整体移除。文件：`lib/compress/hide-consumed.ts`。测试：`tests/hide-consumed.test.ts` +3（核心回归测试已验证修复前会失败）。
+- **#290**（经 #291）— 批量 `compress` 在任一 `content[]` 条目只含已压缩消息时整体中断（`Compression range N contains only already-compressed messages`），导致有效条目未执行；错误也未说明哪个条目/ID/块冲突，迫使反复试错重试。修复：(A) 部分失败批次——新增 `identifyPhantomPlans` 丢弃 phantom 条目并压缩其余，返回简洁的跳过提示；(C) 全 phantom 抛错时附详细诊断（条目序号 + 已消费 ID + 所属块）；(B) `clampMessageRef` 静默平移边界时发出警告。抽出 `partitionPhantomPlans` + `buildPhantomSkipNotice` 纯函数使批量决策逻辑可测试。`checkPhantomBlock` 保持原有契约不变。文件：`lib/compress/{pipeline,range,search,range-utils}.ts`。测试：+19。双 agent review（Oracle + General，均 APPROVE）。
+
+**安装**：`opencode plugin opencode-acp@latest --global`
+
 ### v1.14.14-dev.1 — Dev 预发布版（v1.14.13 以来 2 个 PR）
 
 Dev 预发布版，包含两个压缩子系统修复：批量调用的 summary 泄漏（#288）和批量压缩的全有或全无中断（#290）。发布到 `dev` npm tag 供早期测试。

--- a/devlog/2026-08-11_release-v1.14.14/REQ.md
+++ b/devlog/2026-08-11_release-v1.14.14/REQ.md
@@ -1,0 +1,32 @@
+# REQ — v1.14.14 (Stable Release)
+
+## Goal
+
+Publish the stable release `1.14.14` to the npm `latest` tag covering the two
+compress-subsystem fixes merged to `master` since v1.14.13.
+
+## PRs included (since v1.14.13)
+
+1. **#288** (via #289) — `hideConsumedCompressCalls` per-block hide-consumed to
+   stop summary leak in batched compress calls.
+2. **#290** (via #291) — Partial-failure batch compress + phantom diagnostics +
+   clamp warning.
+
+## Version rationale
+
+Patch bump (1.14.13 → 1.14.14). Both PRs are compress-subsystem fixes; the
+project cadence is patch-level for fix releases.
+
+## Note on branch base
+
+This branch is rebased onto the post-dev-merge `master` (e6fbdf2, which contains
+the squashed v1.14.14-dev.1). It adds only the stable-specific delta: version
+bump to `1.14.14`, the `### v1.14.14` changelog entries, and this devlog.
+
+## Acceptance criteria
+
+- [x] `package.json` version = `1.14.14`.
+- [x] `README.md` + `README.zh-CN.md` changelog entries under `### v1.14.14`.
+- [x] `scripts/ci/check-pr.sh` passes.
+- [x] `npm run build` + `npm run typecheck` pass.
+- [x] PR mergeable (no conflicts); on merge CI publishes to `latest` tag.

--- a/devlog/2026-08-11_release-v1.14.14/WORKLOG.md
+++ b/devlog/2026-08-11_release-v1.14.14/WORKLOG.md
@@ -1,0 +1,26 @@
+# WORKLOG — v1.14.14 (Stable Release)
+
+## Changes
+
+- Rebased stable branch onto post-dev-merge master (e6fbdf2) to clear the
+  conflict caused by #292 being squash-merged (the original stable branch was
+  based on the pre-squash dev commit d46c541, which is not in master history,
+  so both branches appeared to add the same changelog lines).
+- Bumped `package.json` version `1.14.14-dev.1` → `1.14.14`.
+- Added `### v1.14.14 — Stable Release (2 PRs since v1.14.13)` changelog entry
+  to `README.md` (EN) and `### v1.14.14 — 正式版` to `README.zh-CN.md` (ZH),
+  above the dev entry. Install via `opencode-acp@latest`.
+- Recreated devlog entry.
+
+## Verification
+
+- `scripts/ci/check-pr.sh` — pass.
+- `npm run typecheck` — 0 errors.
+- `npm run build` — success.
+- GitHub `mergeable_state` clean after force-push.
+
+## Publish path
+
+CI `release.yml` detects the version does NOT contain `-` → publishes with
+`--tag latest` and creates a stable GitHub Release. Users install via
+`opencode plugin opencode-acp@latest --global`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.14-dev.1",
+    "version": "1.14.14",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
Stable release `1.14.14` → npm `latest` tag. Covers #288 (per-block hide-consumed, summary leak in batched compress calls) and #290 (partial-failure batch compress + phantom diagnostics + clamp warn). Merge the DEV prerelease PR #292 (v1.14.14-dev.1) FIRST, then this one — this branch is based off the dev branch, so the merge order is conflict-free. On merge, CI publishes to `latest` tag + creates a stable GitHub Release. Install: `opencode plugin opencode-acp@latest --global`. CI: all checks pass (pr-validation, test, build).