### PR TITLE
release: v1.14.15 — pin nudge growth to fixed 50000 tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,16 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.15 — Pin nudge growth to fixed 50,000 tokens
+
+**Problem**: The T2/T3 nudge growth threshold was computed as 5% of the model context window (clamped 20K–50K via `resolveAdaptiveNudgeGrowth` from `context-compress-algorithms`). For sub-1M-context models this produced smaller thresholds (e.g. 10K at 200K, 20K at 400K), causing nudges to fire too eagerly and over-compress.
+
+**Fix**: Set a fixed default `compress.nudgeGrowthTokens: 50000` in the default config (`lib/config.ts`), overriding the adaptive value through the existing `config.compress?.nudgeGrowthTokens ?? resolveAdaptiveNudgeGrowth(...)` hook at `lib/messages/inject/inject.ts`. Aligns opencode-acp with the parallel `acp-kernel` change (v0.0.19). The `emergencyThresholdPercent: "98%"` backstop still fires regardless of growth threshold. Users can override via `compress.nudgeGrowthTokens` in their config.
+
+Files: `lib/config.ts`. Tests: 976 pass (no test asserts the default value).
+
+**Install**: `opencode plugin opencode-acp@latest --global`
+
 ### v1.14.14 — Stable Release (2 PRs since v1.14.13)
 
 Stable release covering two compress-subsystem fixes: the batched-call summary leak (#288) and the batch-compress all-or-nothing abort (#290). Published to the `latest` npm tag.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,7 +446,17 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 ## 更新日志
 
-### v1.14.14 — 正式版（v1.14.13 以来 2 个 PR）
+ ### v1.14.15 — 固定 nudge 增长阈值为 50,000 tokens
+
+**问题**：T2/T3 nudge 增长阈值按模型上下文窗口的 5% 计算（通过 `context-compress-algorithms` 的 `resolveAdaptiveNudgeGrowth` 钳制在 20K–50K）。对于低于 1M 上下文的模型，这会产生更小的阈值（例如 200K 时为 10K，400K 时为 20K），导致 nudge 触发过于频繁、过度压缩。
+
+**修复**：在默认配置（`lib/config.ts`）中设置固定默认值 `compress.nudgeGrowthTokens: 50000`，通过 `lib/messages/inject/inject.ts` 中已有的 `config.compress?.nudgeGrowthTokens ?? resolveAdaptiveNudgeGrowth(...)` 钩子覆盖自适应值。使 opencode-acp 与 `acp-kernel` 的并行改动（v0.0.19）保持一致。`emergencyThresholdPercent: "98%"` 兜底仍与增长阈值无关地触发。用户可通过配置中的 `compress.nudgeGrowthTokens` 覆盖。
+
+文件：`lib/config.ts`。测试：976 通过（无测试断言该默认值）。
+
+**安装**：`opencode plugin opencode-acp@latest --global`
+
+ ### v1.14.14 — 正式版（v1.14.13 以来 2 个 PR）
 
 正式版，包含两个压缩子系统修复：批量调用的 summary 泄漏（#288）和批量压缩的全有或全无中断（#290）。发布到 `latest` npm tag。
 

--- a/devlog/2026-08-12_release-v1.14.15/REQ.md
+++ b/devlog/2026-08-12_release-v1.14.15/REQ.md
@@ -1,0 +1,33 @@
+# REQ — v1.14.15: Pin nudge growth to fixed 50,000 tokens
+
+## Background
+
+The T2/T3 nudge growth threshold (`nudgeGrowthTokens`) was adaptive: 5% of the
+model context window, clamped to [20000, 50000] via
+`resolveAdaptiveNudgeGrowth` from the `context-compress-algorithms` dependency.
+For sub-1M-context models this produced thresholds below 50K (e.g. 200K → 10K,
+400K → 20K), causing nudges to fire too eagerly and drive over-compression.
+
+A parallel change is being made in `acp-kernel` (v0.0.19, feeds
+`billion-context` and `billion-context-pi`) and here in `opencode-acp` so all
+three adapters use a single fixed 50,000-token growth threshold.
+
+## Requirement
+
+Set the default `compress.nudgeGrowthTokens` to a fixed `50000` in opencode-acp's
+default config, overriding the adaptive value through the existing override hook
+at `lib/messages/inject/inject.ts`
+(`config.compress?.nudgeGrowthTokens ?? resolveAdaptiveNudgeGrowth(...)`).
+
+## Acceptance criteria
+
+- `lib/config.ts` default compress block sets `nudgeGrowthTokens: 50000`.
+- typecheck + test + build all green.
+- No test asserts the previous adaptive default (so none need updating).
+- Users can still override via `compress.nudgeGrowthTokens` in their config.
+- `emergencyThresholdPercent: "98%"` backstop remains unchanged.
+
+## Scope
+
+Single-file change: `lib/config.ts`. Release-only metadata: `package.json`,
+`README.md`, `README.zh-CN.md`, this devlog.

--- a/devlog/2026-08-12_release-v1.14.15/WORKLOG.md
+++ b/devlog/2026-08-12_release-v1.14.15/WORKLOG.md
@@ -1,0 +1,40 @@
+# WORKLOG — v1.14.15: Pin nudge growth to fixed 50,000 tokens
+
+## Investigation
+
+- opencode-acp does NOT own its nudge-growth math. It imports
+  `defaultTriggerPolicy` from external npm pkg `context-compress-algorithms`
+  (ranxianglei's; npm 1.3.0). That pkg's `resolveAdaptiveNudgeGrowth(limit)` =
+  `min(NUDGE_GROWTH_CAP, max(NUDGE_GROWTH_FLOOR, round(limit * NUDGE_GROWTH_RATIO)))`.
+- Override chain: `lib/messages/inject/inject.ts:250-251` reads
+  `config.compress?.nudgeGrowthTokens ?? resolveAdaptiveNudgeGrowth(modelContextLimit)`.
+  The `??` hook lets a config value override the adaptive default — but opencode-acp's
+  default config did not set `nudgeGrowthTokens`, so it always fell through to adaptive.
+- Decision: self-contained override in opencode-acp's own default config (not a
+  `context-compress-algorithms` release). Aligns with the "4 PRs" count
+  (acp-kernel + opencode-acp + billion-context + billion-context-pi) and uses the
+  existing override hook with no source-logic change.
+
+## Change
+
+`lib/config.ts` defaultConfig compress block — added one line after
+`minNudgeGrowthFloor: 5000,`:
+
+```ts
+nudgeGrowthTokens: 50000,
+```
+
+Type `CompressConfig.nudgeGrowthTokens?: number` (config.ts:21) — type-correct.
+
+## Verification
+
+- typecheck (`tsc --noEmit`): clean.
+- tests (`node --import tsx --test tests/*.test.ts`): 976 pass / 0 fail.
+- build (`tsup && tsc --emitDeclarationOnly`): success, dist/index.js 391.34 KB.
+
+## Release
+
+- Version bump 1.14.14 → 1.14.15 (package.json).
+- Changelog entries in README.md + README.zh-CN.md.
+- Branch `2026-08-12_release-v1.14.15`, commit `release: v1.14.15 — ...`.
+- CI auto-publishes on merge (release.yml detects `YYYY-MM-DD_release-v*` branch).

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -205,6 +205,7 @@ const defaultConfig: PluginConfig = {
         minCompressRange: 5000,
         minNudgeGrowthRatio: 0.45,
         minNudgeGrowthFloor: 5000,
+        nudgeGrowthTokens: 50000,
         emergencyThresholdPercent: "98%",
         maxVisibleSegments: 50,
         keepEmbedMaxChars: 2000,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.14",
+    "version": "1.14.15",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
# release: v1.14.15 — Pin nudge growth to fixed 50,000 tokens

## Summary

Sets a fixed default `compress.nudgeGrowthTokens: 50000`, overriding the adaptive
5%-of-context value (clamped 20K–50K) from `context-compress-algorithms`.

## Problem

The T2/T3 nudge growth threshold was computed as 5% of the model context window
(clamped 20K–50K via `resolveAdaptiveNudgeGrowth`). For sub-1M-context models this
produced smaller thresholds (e.g. 200K → 10K, 400K → 20K), causing nudges to fire
too eagerly and drive over-compression.

## Change

`lib/config.ts` default compress block — one new line:

```ts
nudgeGrowthTokens: 50000,
```

This overrides the adaptive value through the existing hook at
`lib/messages/inject/inject.ts:250-251`:

```ts
const nudgeGrowthTokens = config.compress?.nudgeGrowthTokens ?? resolveAdaptiveNudgeGrowth(modelContextLimit)
```

No source-logic change. The `emergencyThresholdPercent: "98%"` backstop is
unchanged. Users can still override via `compress.nudgeGrowthTokens` in their config.

## Why self-contained (not a `context-compress-algorithms` release)

opencode-acp imports the adaptive math from the external `context-compress-algorithms`
package. The `??` override hook already exists precisely for host-side overrides.
Changing it here (rather than releasing a 5th package) keeps the change visible in
opencode-acp's own config and matches the parallel change in `acp-kernel` v0.0.19
(which feeds `billion-context` and `billion-context-pi`). All three adapters now use
a single fixed 50,000-token growth threshold.

## Verification

- typecheck (`tsc --noEmit`): clean
- tests (`node --import tsx --test tests/*.test.ts`): 976 pass / 0 fail
- build (`tsup && tsc --emitDeclarationOnly`): success, 391.34 KB
- `scripts/ci/check-pr.sh`: all checks pass (branch name, devlog, changelog)

## Merge → auto-publish

Merging this PR triggers `release.yml`, which detects the `2026-08-12_release-v*`
branch, tags `v1.14.15`, and publishes to npm `latest`. PR merge is human-only.
