### PR TITLE
fix: show published npm version in PR artifact comment

### DIFF
--- a/devlog/2026-08-13_pr-artifact-version-display/REQ.md
+++ b/devlog/2026-08-13_pr-artifact-version-display/REQ.md
@@ -1,0 +1,11 @@
+# REQ — PR Artifact Version Display
+
+## Problem
+PR #298's bot comment showed the npm tag (`pr-298`) but not the actual published version number. Users couldn't verify which version corresponds to the current PR state on npm.
+
+## Fix
+Pass the published version from the npm publish step to the PR comment step via GITHUB_OUTPUT. The comment now shows:
+```
+**Published:** `opencode-acp@1.14.16-pr.298.5`
+Current version: `1.14.16-pr.298.5` (npm tag `pr-298`)
+```

--- a/devlog/2026-08-13_pr-artifact-version-display/WORKLOG.md
+++ b/devlog/2026-08-13_pr-artifact-version-display/WORKLOG.md
@@ -1,0 +1,4 @@
+# WORKLOG — PR Artifact Version Display
+
+## Changes
+- `.github/workflows/pr-artifact.yml`: Added `id: npm-publish` + `GITHUB_OUTPUT` outputs (`version`, `npm_tag`). Comment step reads `${{ steps.npm-publish.outputs.version }}` and displays it.


### PR DESCRIPTION
## Problem

PR #298's bot comment showed the npm tag (`pr-298`) but not the actual published version number. Users couldn't verify which version corresponds to the current PR state on npm.

## Fix

Pass the published version from the npm publish step to the PR comment step via `GITHUB_OUTPUT`. The comment now shows:

```
**Published:** `opencode-acp@1.14.16-pr.298.5`
Current version: `1.14.16-pr.298.5` (npm tag `pr-298`)
```

## Files Changed

- `.github/workflows/pr-artifact.yml` — added `id: npm-publish` + outputs, comment reads version