### PR TITLE
fix(compress): make preemptive acknowledgeRisk a no-op instead of an error [stable]

### DIFF
--- a/lib/compress/quality-gate/index.ts
+++ b/lib/compress/quality-gate/index.ts
@@ -14,6 +14,6 @@ export {
 } from "./registry"
 
 export { evaluateBlockQuality, evaluateBatchQuality, evaluatePreCommitQuality } from "./evaluate"
-export { buildQualityRejectionError, buildPreemptiveAcknowledgeError } from "./rejection"
+export { buildQualityRejectionError } from "./rejection"
 export type { RejectionPlanInfo } from "./rejection"
 export { ensureBuiltinGatesRegistered } from "./algorithms"

--- a/lib/compress/quality-gate/rejection.ts
+++ b/lib/compress/quality-gate/rejection.ts
@@ -73,11 +73,3 @@ Without acknowledgeRisk: true, the compression will be rejected again.`
 
     return new Error(message)
 }
-
-export function buildPreemptiveAcknowledgeError(): Error {
-    return new Error(
-        'Parameter "acknowledgeRisk": true was provided, but no quality gate rejection is pending. ' +
-            "This parameter is only valid immediately after a compression was rejected by the quality gate. " +
-            "Remove it and try again.",
-    )
-}

--- a/lib/compress/range.ts
+++ b/lib/compress/range.ts
@@ -39,7 +39,6 @@ import {
 import type { CompressRangeToolArgs } from "./types"
 import { resolveKeepMarkers } from "./keep-markers"
 import {
-    buildPreemptiveAcknowledgeError,
     buildQualityRejectionError,
     evaluatePreCommitQuality,
 } from "./quality-gate"
@@ -315,13 +314,18 @@ export function createCompressRangeTool(factoryCtx: ToolFactoryContext): ReturnT
 
             const qualityGateRetryPendingBefore = ctx.state.qualityGateRetryPending
 
-            if (acknowledgeRisk && !ctx.state.qualityGateRetryPending) {
-                throw buildPreemptiveAcknowledgeError()
+            // #301: the model routinely carries acknowledgeRisk over from
+            // non-quality errors (e.g. argument validation failures), which
+            // used to hard-fail with "no rejection pending". Without a pending
+            // quality-gate rejection the flag is a no-op instead — quality
+            // still runs. Only a real rejection arms the bypass.
+            const bypassQuality = acknowledgeRisk && ctx.state.qualityGateRetryPending
+            const ignoredAcknowledgeRisk = acknowledgeRisk && !ctx.state.qualityGateRetryPending
+            if (ignoredAcknowledgeRisk) {
+                ctx.logger.warn("compress: acknowledgeRisk ignored — no quality gate rejection pending")
             }
-            if (acknowledgeRisk) {
-                ctx.state.qualityGateRetryPending = false
-            } else {
-                ctx.state.qualityGateRetryPending = false
+            ctx.state.qualityGateRetryPending = false
+            if (!bypassQuality) {
                 for (const plan of preparedPlans) {
                     const result = evaluatePreCommitQuality(
                         rawMessages,
@@ -402,7 +406,10 @@ export function createCompressRangeTool(factoryCtx: ToolFactoryContext): ReturnT
             }
 
             const skippedNote = phantomSkipNotice !== null ? `\n⚠️ ${phantomSkipNotice}\n` : ""
-            return `Compressed ${totalCompressedMessages} messages into ${COMPRESSED_BLOCK_HEADER}.${skippedNote}\nIMPORTANT: This was an automatic context compression. You MUST continue your previous task exactly where you left off. Do NOT ask the user what to do next.\n💡 Tip: Use search_context('keyword') to find compressed content when you need it later.`
+            const ackNote = ignoredAcknowledgeRisk
+                ? `\n⚠️ acknowledgeRisk was ignored: no quality gate rejection was pending, so quality checks ran normally. Only pass it when retrying immediately after a quality gate rejection.\n`
+                : ""
+            return `Compressed ${totalCompressedMessages} messages into ${COMPRESSED_BLOCK_HEADER}.${skippedNote}${ackNote}\nIMPORTANT: This was an automatic context compression. You MUST continue your previous task exactly where you left off. Do NOT ask the user what to do next.\n💡 Tip: Use search_context('keyword') to find compressed content when you need it later.`
         },
     })
 }

--- a/lib/state/types.ts
+++ b/lib/state/types.ts
@@ -152,7 +152,8 @@ export interface SessionState {
      * Lifecycle:
      * - Quality fails → flag = true → rejection error returned
      * - Retry with acknowledgeRisk:true + flag=true → accepted, flag = false
-     * - acknowledgeRisk:true + flag=false → error "no rejection pending, remove parameter"
+     * - acknowledgeRisk:true + flag=false → IGNORED (no-op): quality runs
+     *   normally, result carries an "acknowledgeRisk was ignored" note (#301)
      * - Normal call (no acknowledgeRisk) → quality runs normally
      */
     qualityGateRetryPending: boolean

--- a/tests/quality-gate-enforcement.test.ts
+++ b/tests/quality-gate-enforcement.test.ts
@@ -6,7 +6,6 @@ import { mkdirSync } from "node:fs"
 import {
     evaluatePreCommitQuality,
     buildQualityRejectionError,
-    buildPreemptiveAcknowledgeError,
 } from "../lib/compress/quality-gate"
 import { createCompressRangeTool } from "../lib/compress/range"
 import { createSessionState, resetSessionState, type WithParts } from "../lib/state"
@@ -259,16 +258,6 @@ test("buildQualityRejectionError computes ratio and retention from plan data", (
     assert.ok(error.message.includes("100 chars"), "should show summary chars")
 })
 
-test("buildPreemptiveAcknowledgeError explains the parameter is invalid without pending rejection", () => {
-    const error = buildPreemptiveAcknowledgeError()
-    assert.ok(error.message.includes("acknowledgeRisk"), "should mention the parameter name")
-    assert.ok(
-        error.message.includes("no quality gate rejection is pending"),
-        "should explain why it's invalid",
-    )
-    assert.ok(error.message.includes("Remove it"), "should tell model to remove it")
-})
-
 test("qualityGateRetryPending defaults to false", () => {
     const state = createSessionState()
     assert.equal(state.qualityGateRetryPending, false)
@@ -395,29 +384,47 @@ test("integration: acknowledgeRisk bypasses quality after rejection", async () =
     assert.equal(state.prune.messages.blocksById.size, 1, "one block should be committed")
 })
 
-test("integration: preemptive acknowledgeRisk without prior rejection is rejected", async () => {
+test("integration: preemptive acknowledgeRisk is a no-op — quality still runs (#301)", async () => {
     const sessionID = `ses-int-preempt-${Date.now()}`
     const rawMessages = buildIntegrationMessages(sessionID)
     const state = createSessionState()
     const config = buildConfig(true)
     const tool = buildToolContext(state, config, rawMessages)
 
+    // Bad summary + preemptive acknowledgeRisk: quality must still reject.
     await assert.rejects(
         tool.execute(
             {
                 topic: "Auth analysis",
-                content: [{ startId: "m00001", endId: "m00004", summary: "Good enough summary with keywords." }],
+                content: [{ startId: "m00001", endId: "m00004", summary: "Bad." }],
                 acknowledgeRisk: true,
-            } as any,
+            },
             { ...toolCtx, sessionID },
         ),
         (err: Error) => {
-            assert.ok(err.message.includes("no quality gate rejection is pending"), `should be preemptive error, got: ${err.message}`)
+            assert.ok(err.message.includes("QUALITY GATE FAILURE"), `should be quality rejection, got: ${err.message}`)
             return true
         },
     )
-    assert.equal(state.qualityGateRetryPending, false, "flag should stay false")
-    assert.equal(state.prune.messages.blocksById.size, 0, "no blocks committed")
+    assert.equal(state.qualityGateRetryPending, true, "rejection arms the flag even when acknowledgeRisk was passed")
+
+    // Fresh session: good summary + preemptive acknowledgeRisk (flag=false)
+    // succeeds, with an ignore note in the result.
+    const sessionID2 = `ses-int-preempt2-${Date.now()}`
+    const state2 = createSessionState()
+    const tool2 = buildToolContext(state2, config, buildIntegrationMessages(sessionID2))
+    const result = await tool2.execute(
+        {
+            topic: "Auth analysis",
+            content: [{ startId: "m00001", endId: "m00004", summary: "Authentication system design analysis. File: lib/auth.ts:142 holds the token refresh logic. Critical bug: retry lacked exponential backoff; fixed with base=1000ms, max=30000ms. Decision: JWT over session cookies for stateless architecture. lib/auth.test.ts now covers refresh edge cases. Performance overhead 3ms per refresh attempt, acceptable." }],
+            acknowledgeRisk: true,
+        },
+        { ...toolCtx, sessionID: sessionID2 },
+    )
+    assert.ok(result.includes("Compressed"), "good summary succeeds despite preemptive acknowledgeRisk")
+    assert.ok(result.includes("acknowledgeRisk was ignored"), "result notes the ignored flag")
+    assert.equal(state2.qualityGateRetryPending, false, "flag stays false")
+    assert.equal(state2.prune.messages.blocksById.size, 1, "one block committed")
 })
 
 test("integration: flag cleared on successful non-acknowledgeRisk compression", async () => {


### PR DESCRIPTION
Stable/minimal split of PR #302 — contains only the core #301 fix (acknowledgeRisk). Merge this first; the topic-fallback commit stays in #302 for a follow-up merge.

## 问题

```
⚙ compress [acknowledgeRisk=true, dangerous=true]
content[0] needs a topic — provide content[0].topic or the top-level topic
⚙ compress [acknowledgeRisk=true, dangerous=true, topic=xxx]
Parameter "acknowledgeRisk": true was provided, but no quality gate rejection is pending.
```

模型从质量门拒绝模板学到"重试要加 acknowledgeRisk: true"，于是把它带进了所有重试——包括参数校验失败这类与质量门无关的错误。校验错误不会置位 `qualityGateRetryPending`，重试即撞上 preemptive 错误，形成错误循环。

## 修复

无 pending 拒绝时的 `acknowledgeRisk` 改为 no-op：质量检查照常运行（质量门保护不变），成功结果附带提示教模型正确用法。删除 `buildPreemptiveAcknowledgeError`。

## 验证

- `tsc --noEmit` 通过
- `tests/quality-gate-enforcement.test.ts` 13/13
- 全量 975/975 通过（基于最新 master 8a2bee3）