### PR TITLE
release: v1.14.17 — eliminate compress retry dead-ends (#301)

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,16 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.17 — Eliminate compress retry dead-ends (#301)
+
+**Problem**: Two compress arguments hard-failed on first use and produced confusing error loops instead of actionable feedback. (1) The model learned "add `acknowledgeRisk: true` to retry" from quality-gate rejection templates, then carried the flag into *every* retry — including retries after non-quality errors (e.g. a missing topic), where no quality-gate rejection was pending, hitting `Parameter "acknowledgeRisk": true was provided, but no quality gate rejection is pending` (issue #301). (2) `content[0] needs a topic — provide content[0].topic or the top-level topic` hard-failed compress calls whose entries had no topic and no top-level fallback.
+
+**Fix**: Both parameters are now tolerant. `acknowledgeRisk` without a pending rejection is a no-op — quality checks still run (the gate's protection is unchanged: bypass is only armed by a real quality-gate rejection), and a successful result carries an `⚠️ acknowledgeRisk was ignored: ...` note teaching correct usage. Topics are fully optional: an entry without its own topic falls back to the top-level topic, then to one derived from the summary's first line (markdown headings stripped, capped at 80 chars), so `search_context` always has something searchable.
+
+Files: `lib/compress/range.ts`, `lib/compress/range-utils.ts` (new `deriveFallbackTopic`), `lib/compress/quality-gate/rejection.ts` (removed `buildPreemptiveAcknowledgeError`), `lib/compress/types.ts`, `lib/prompts/compress-range.ts`, `lib/prompts/extensions/tool.ts`, `lib/state/types.ts`. Tests: 976 pass.
+
+**Install**: `opencode plugin opencode-acp@latest --global`
+
 ### v1.14.16 — Raise context limits to 80%
 
 **Problem**: The compression thresholds were `maxContextLimit: 55%` / `minContextLimit: 45%`. The strong "over-limit" nudge fired as soon as context exceeded 55% of the model window. Combined with the fixed 50K growth threshold (v1.14.15), this still engaged compression relatively early, leaving usable context unused.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,6 +446,16 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 ## 更新日志
 
+### v1.14.17 — 消除 compress 重试死循环（#301）
+
+**问题**：两个 compress 参数在首次使用时硬报错，产生令人困惑的错误循环而非可执行的反馈。(1) 模型从质量门拒绝模板学到「重试要加 `acknowledgeRisk: true`」，于是把它带进了所有重试——包括非质量错误（如缺 topic）之后的重试，此时没有 pending 的质量门拒绝，撞上 `Parameter "acknowledgeRisk": true was provided, but no quality gate rejection is pending`（issue #301）。(2) `content[0] needs a topic — provide content[0].topic or the top-level topic` 在 entry 无 topic 且无顶层 fallback 时硬报错。
+
+**修复**：两个参数均改为宽容处理。无 pending 拒绝时的 `acknowledgeRisk` 为 no-op——质量检查照常运行（质量门保护不变：bypass 只由真实的质量门拒绝解锁），成功结果附带 `⚠️ acknowledgeRisk was ignored: ...` 提示教模型正确用法。topic 完全可选：entry 无自有 topic 时依次回退到顶层 topic、再到从 summary 首行派生的 topic（去 markdown 标题符、截断 80 字符），保证 `search_context` 始终有可检索内容。
+
+文件：`lib/compress/range.ts`、`lib/compress/range-utils.ts`（新增 `deriveFallbackTopic`）、`lib/compress/quality-gate/rejection.ts`（移除 `buildPreemptiveAcknowledgeError`）、`lib/compress/types.ts`、`lib/prompts/compress-range.ts`、`lib/prompts/extensions/tool.ts`、`lib/state/types.ts`。测试：976 通过。
+
+**安装**：`opencode plugin opencode-acp@latest --global`
+
  ### v1.14.16 — 将上下文 limit 提升至 80%
 
 **问题**：压缩阈值原为 `maxContextLimit: 55%` / `minContextLimit: 45%`。上下文一旦超过模型窗口的 55% 就会触发强「超限」nudge。配合 v1.14.15 固定的 50K 增长阈值，压缩仍较早介入，可用上下文未被充分利用。

--- a/devlog/2026-08-14_release-v1.14.17/REQ.md
+++ b/devlog/2026-08-14_release-v1.14.17/REQ.md
@@ -1,0 +1,46 @@
+# REQ — v1.14.17: Eliminate compress retry dead-ends (#301)
+
+## Background
+
+Issue #301 reported a compress error loop with two hard errors that hit the
+model on first use:
+
+```
+⚙ compress [acknowledgeRisk=true, dangerous=true]
+content[0] needs a topic — provide content[0].topic or the top-level topic
+⚙ compress [acknowledgeRisk=true, dangerous=true, topic=xxx]
+Parameter "acknowledgeRisk": true was provided, but no quality gate rejection is pending.
+```
+
+Root causes:
+
+1. The quality-gate rejection template teaches "add `acknowledgeRisk: true`
+   to retry". Models generalize this into carrying the flag on EVERY retry —
+   including retries after non-quality errors (e.g. argument validation
+   failures like a missing topic). Validation errors never set
+   `qualityGateRetryPending`, so the preemptive guard hard-failed the retry
+   with "no rejection pending", producing a confusing dead-end loop.
+2. `validateArgs` required every content entry to have its own `topic` or a
+   top-level fallback, hard-failing otherwise.
+
+## Requirement
+
+Neither parameter may hard-fail on ordinary model usage:
+
+- `acknowledgeRisk` without a pending quality-gate rejection becomes a no-op:
+  quality checks still run; a successful result carries an
+  `⚠️ acknowledgeRisk was ignored` note teaching correct usage. The gate's
+  protection is unchanged — bypass is only armed by a real quality-gate
+  rejection.
+- Topics become fully optional: entry.topic → top-level topic → automatic
+  fallback derived from the summary's first line (markdown headings stripped,
+  capped at 80 chars), keeping `search_context` functional.
+
+## Acceptance criteria
+
+- Compress calls with missing topics succeed (topic auto-derived).
+- Compress calls with preemptive `acknowledgeRisk` + good summary succeed with
+  ignore note; with bad summary they are rejected by the QUALITY gate (not a
+  parameter error) and the flag is armed for the retry.
+- `buildPreemptiveAcknowledgeError` removed from `lib/compress/quality-gate`.
+- typecheck + tests + build green.

--- a/devlog/2026-08-14_release-v1.14.17/WORKLOG.md
+++ b/devlog/2026-08-14_release-v1.14.17/WORKLOG.md
@@ -1,0 +1,45 @@
+# WORKLOG — v1.14.17: Eliminate compress retry dead-ends (#301)
+
+## Investigation
+
+- Issue #301 trace: `compress [acknowledgeRisk=true]` → `content[0] needs a topic` → retry with `topic` → `Parameter "acknowledgeRisk": true was provided, but no quality gate rejection is pending`.
+- `qualityGateRetryPending` (lib/state/types.ts) is only set by a quality-gate
+  rejection in `lib/compress/range.ts`. Argument-validation errors thrown in
+  `validateArgs` (lib/compress/range-utils.ts) never arm it.
+- The quality-gate rejection template (lib/compress/quality-gate/rejection.ts)
+  teaches `add "acknowledgeRisk": true to retry`; models generalize this to
+  every retry, so any validation error followed by a compliant retry hit the
+  preemptive guard — a dead-end loop.
+- `validateArgs` also required every content entry to carry a topic (own or
+  top-level fallback), a second hard failure of the same class.
+
+## Change
+
+Cherry-picked from PR #303 (ca19139) and PR #302 (053987c) onto master:
+
+1. **Preemptive acknowledgeRisk → no-op** (`lib/compress/range.ts`):
+   `bypassQuality = acknowledgeRisk && qualityGateRetryPending`;
+   when no rejection is pending the flag is ignored with a warn log and an
+   `⚠️ acknowledgeRisk was ignored` note in the result. Quality checks always
+   run unless a real rejection armed the bypass. Removed
+   `buildPreemptiveAcknowledgeError` (quality-gate/rejection.ts, index.ts).
+2. **Optional topics** (`lib/compress/range-utils.ts`): dropped the topic
+   throw; added `deriveFallbackTopic(summary)` (first non-empty line, markdown
+   heading stripped, capped at 80 chars) filled by `resolveRanges` when both
+   entry.topic and top-level topic are absent. Prompt files + types updated.
+
+## Verification
+
+- typecheck (`tsc --noEmit`): clean.
+- tests: 976 pass / 0 fail (includes 3 reworked batch-compress cases + new
+  deriveFallbackTopic unit test + reworked no-op integration tests).
+- Quality-gate protection verified unchanged: bad summary + preemptive
+  acknowledgeRisk is still rejected by the QUALITY gate (not a parameter
+  error) and arms the flag for retry.
+
+## Release
+
+- Version bump 1.14.16 → 1.14.17 (package.json).
+- Changelog entries in README.md + README.zh-CN.md.
+- Branch `2026-08-14_release-v1.14.17`, commit `release: v1.14.17 — ...`.
+- Supersedes PR #302 + PR #303 (this release branch contains both commits).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.16",
+    "version": "1.14.17",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
Fixes #301

## 本版内容（基于最新 master 8a2bee3 + 两个 fix commit）

1. **acknowledgeRisk no-op**（原 PR #303）：无 pending 质量门拒绝时 `acknowledgeRisk` 不再硬报错——质量检查照常运行（保护不变），结果附带使用提示；移除 `buildPreemptiveAcknowledgeError`
2. **topic 自动派生**（原 PR #302）：topic 完全可选，缺失时依次回退 顶层 topic → summary 首行派生（去标题符、80 字符截断），`search_context` 始终可检索

## Checklist（per AGENTS.md §5.4.2）

- [x] 分支名 `2026-08-14_release-v1.14.17`（auto-tag 约定）
- [x] package.json 1.14.16 → 1.14.17
- [x] README.md + README.zh-CN.md 双语 changelog
- [x] devlog/{REQ,WORKLOG}.md
- [x] `./scripts/ci/check-pr.sh` all passed
- [x] tsc clean / 976 tests pass / build success

> 注：`npm run verify:package` 在本地 Node v25 因 npm pack --json 输出被 prepare 钩子污染而失败——master 上同样失败，系本地环境问题，非本 PR 引入（GitHub CI 使用 Actions node 环境不受影响）。

## 说明

本 PR 包含 #302 + #303 的全部两个 commit，合并后那两个 PR 可直接关闭（superseded）。合并即触发 release.yml 自动打 tag `v1.14.17`、构建、发布 npm latest、创建 GitHub Release。