### PR TITLE
release: v1.14.18 — fix release pipeline (supersedes unpublished v1.14.17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,16 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.18 — Supersedes unpublished v1.14.17; fix release pipeline
+
+**Problem**: v1.14.17 was merged (#305) but never published — `release.yml` failed at `npm run check:package` because the `prepare` hook added in #298 (`npm run build`) runs during `npm pack --json` inside `verify-package.mjs`, and tsup's `CLI Building entry: index.ts` stdout output breaks `JSON.parse` (`SyntaxError: Unexpected token 'C'`).
+
+**Fix**: `scripts/verify-package.mjs` now runs `npm pack --dry-run --json --ignore-scripts` — skipping the `prepare` hook, consistent with `pr-artifact.yml` which already publishes with `--ignore-scripts`. `dist/` is already built by `check:package`'s preceding build step, so packing semantics are unchanged.
+
+Files: `scripts/verify-package.mjs`. Tests: 976 pass; `check:package` green.
+
+**Install**: `opencode plugin opencode-acp@latest --global`
+
 ### v1.14.17 — Per-PR npm preview builds + release publishing feedback (#298)
 
 **Problem**: There was no way to install and test a PR's build before merging, and after a release merge nothing on the PR confirmed which version was published to npm.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,6 +446,16 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 ## 更新日志
 
+### v1.14.18 — 取代未能发布的 v1.14.17；修复发版流水线
+
+**问题**：v1.14.17 已合并（#305）但从未发布 —— \`release.yml\` 在 \`npm run check:package\` 一步失败：#298 新增的 \`prepare\` 钩子（\`npm run build\`）会在 \`verify-package.mjs\` 的 \`npm pack --json\` 期间运行，tsup 的 \`CLI Building entry: index.ts\` 输出污染 stdout，导致 \`JSON.parse\` 报错（\`SyntaxError: Unexpected token 'C'\`）。
+
+**修复**：\`scripts/verify-package.mjs\` 改为执行 \`npm pack --dry-run --json --ignore-scripts\` —— 跳过 \`prepare\` 钩子，与 \`pr-artifact.yml\` 发布时使用 \`--ignore-scripts\` 的做法一致。\`dist/\` 由 \`check:package\` 前置构建步骤产出，打包语义不变。
+
+文件：\`scripts/verify-package.mjs\`。测试：976 通过；\`check:package\` 绿。
+
+**安装**：`opencode plugin opencode-acp@latest --global`
+
 ### v1.14.17 — PR 预览构建发布 npm + 发版发布反馈（#298）
 
 **问题**：合并前无法安装测试 PR 的构建产物；发版合并后 PR 上也没有确认发布到了 npm 的哪个版本。

--- a/devlog/2026-08-14_release-v1.14.18/REQ.md
+++ b/devlog/2026-08-14_release-v1.14.18/REQ.md
@@ -1,0 +1,28 @@
+# REQ — v1.14.18: Supersedes unpublished v1.14.17 (fix release pipeline)
+
+## Background
+
+- v1.14.17 was merged to master via #305 (squash commit `2616f62`) but
+  `release.yml` FAILED and never published: `npm run check:package` crashed
+  in `scripts/verify-package.mjs` `validatePackedFiles` with
+  `SyntaxError: Unexpected token 'C', "CLI Building..." is not valid JSON`.
+- Root cause: #298 added `"prepare": "npm run build"` to package.json (so
+  GitHub-branch installs auto-build). `verify:package` shells out to
+  `npm pack --dry-run --json`; npm runs `prepare` during pack, tsup writes
+  `CLI Building entry: index.ts` to stdout, and `JSON.parse(output)` fails.
+- npm `latest` is still 1.14.16; tag/release v1.14.17 do not exist.
+
+## Requirement
+
+1. Fix `verify-package.mjs` to tolerate the `prepare` hook: use
+   `npm pack --dry-run --json --ignore-scripts` (consistent with
+   `pr-artifact.yml`, which already publishes with `--ignore-scripts`;
+   `dist/` is already built by `check:package`'s build step).
+2. Cut a stable release per AGENTS.md §5.4.2 from master with the fix:
+   version 1.14.18 supersedes never-published 1.14.17.
+
+## Acceptance criteria
+
+- `npm run check:package` green locally (previously failing).
+- `./scripts/ci/check-pr.sh 2026-08-14_release-v1.14.18 github/master` passes.
+- Merge triggers release.yml → tag v1.14.18 → npm `latest` → GitHub Release.

--- a/devlog/2026-08-14_release-v1.14.18/WORKLOG.md
+++ b/devlog/2026-08-14_release-v1.14.18/WORKLOG.md
@@ -1,0 +1,39 @@
+# WORKLOG — v1.14.18: Supersedes unpublished v1.14.17 (fix release pipeline)
+
+## Investigation
+
+- Merged #305 triggered `release.yml`; the `publish` job failed at
+  `npm run check:package`:
+  `SyntaxError: Unexpected token 'C', "CLI Building..." is not valid JSON`
+  at `validatePackedFiles` (scripts/verify-package.mjs:207), Node v22.23.2
+  on CI — reproduces locally too.
+- Chain: #298 added `"prepare": "npm run build"` to package.json →
+  `verify:package` runs `npm pack --dry-run --json` → npm executes
+  `prepare` during pack → tsup prints `CLI Building entry: index.ts` to
+  stdout → `JSON.parse(output)` fails.
+- Confirmed `pr-artifact.yml` already publishes with `--ignore-scripts`
+  for the same reason; `check:package` builds `dist/` before
+  `verify:package` runs, so skipping scripts during pack does not change
+  what is packed.
+
+## Change
+
+- `scripts/verify-package.mjs`: `npm pack --dry-run --json` →
+  `npm pack --dry-run --json --ignore-scripts` (+ comment documenting why).
+- Release files: package.json 1.14.18, bilingual changelog entries, this
+  devlog pair.
+
+## Verification
+
+- `npm run verify:package`: passed (`tarball entries: 173`).
+- `npm run check:package`: green (previously failing).
+- `npm test`: 976 pass / 0 fail.
+- `./scripts/ci/check-pr.sh 2026-08-14_release-v1.14.18 github/master`: all
+  checks passed.
+
+## Release
+
+- Commit `release: v1.14.18 — fix release pipeline (supersedes unpublished v1.14.17)`.
+- Human merges → release.yml (squash-merge Pattern 2) → tag `v1.14.18` →
+  npm `latest` → GitHub Release.
+- v1.14.17 remains a changelog entry only; it was never published to npm.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.17",
+    "version": "1.14.18",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -199,7 +199,12 @@ function validateRuntimeImportGraph() {
 }
 
 function validatePackedFiles() {
-    const output = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+    // --ignore-scripts: the `prepare` hook (added in #298) runs `npm run build`,
+    // whose tsup output ("CLI Building entry: index.ts") pollutes stdout and
+    // breaks JSON.parse. dist/ is already built by `check:package` before this
+    // runs, and pr-artifact.yml publishes with --ignore-scripts for the same
+    // reason.
+    const output = execFileSync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], {
         cwd: root,
         encoding: "utf8",
     })


### PR DESCRIPTION
Stable 发版分支（per AGENTS.md §5.4.2）。

## 背景

v1.14.17（#305）已合并但**从未发布**：release.yml 死在 `npm run check:package` —— #298 给 package.json 加的 `prepare` 钩子在 `npm pack --json` 期间运行，tsup 输出污染 stdout，`verify-package.mjs` 的 `JSON.parse` 报 `SyntaxError: Unexpected token 'C'`。npm latest 仍是 1.14.16。

## 本版内容

1. **修复发版流水线**：`scripts/verify-package.mjs` 改用 `npm pack --dry-run --json --ignore-scripts`（与 pr-artifact.yml 的发布做法一致；dist/ 由 check:package 前置构建，打包语义不变）
2. 版本 1.14.17 → **1.14.18**（1.14.17 从未上 npm，由本版取代）
3. 双语 changelog + devlog

## Checklist

- [x] 分支名 `2026-08-14_release-v1.14.18`
- [x] release commit：5 个发版文件 + 1 个流水线修复（修复是发布前置条件，否则合并后 CI 会再次死在同一处）
- [x] `check-pr.sh` all passed
- [x] tsc / 976 tests / check:package 全绿（check:package 此前必失败，现已修复）

合并后 release.yml 自动：tag `v1.14.18` → 发布 npm **latest** → GitHub Release。