### PR TITLE
release: v1.14.19 — fix release pipeline for real (npm 10 --ignore-scripts bug)

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,16 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.19 — Fix release pipeline for real (npm 10 `--ignore-scripts` bug)
+
+**Problem**: v1.14.18 (#306) was merged but still never published — `release.yml` failed at the exact same step. Root cause of the failed fix: the CI runner uses Node 22 (npm 10.9.x), and **npm 10 runs the `prepare` lifecycle hook during `npm pack` even when `--ignore-scripts` is passed**. v1.14.18's fix (`npm pack --ignore-scripts`) works on npm 11 but is a no-op on npm 10. When prepare runs, tsup writes `CLI Building entry: index.ts` to **stdout**, breaking `JSON.parse` in `verify-package.mjs` (`SyntaxError: Unexpected token`).
+
+**Fix**: Redirect the `prepare` build's stdout to stderr: `"prepare": "npm run build 1>&2"` in `package.json`. Build output (informational) goes to stderr; stdout stays pure JSON regardless of npm version or whether `--ignore-scripts` works. Verified empirically with npm 10.9.9 locally: `npm pack --dry-run --json` now returns valid JSON (173 tarball entries) both with and without `--ignore-scripts`. The `--ignore-scripts` flag added in v1.14.18 is kept (harmless on npm 10, skips the redundant rebuild on npm 11). The `npm install github:...#branch` path still works — prepare still runs and still builds `dist/`.
+
+Files: `package.json`. Tests: 976 pass; `check:package` green on npm 10.9.9 and npm 11.12.1.
+
+**Install**: `opencode plugin opencode-acp@latest --global`
+
 ### v1.14.18 — Supersedes unpublished v1.14.17; fix release pipeline
 
 **Problem**: v1.14.17 was merged (#305) but never published — `release.yml` failed at `npm run check:package` because the `prepare` hook added in #298 (`npm run build`) runs during `npm pack --json` inside `verify-package.mjs`, and tsup's `CLI Building entry: index.ts` stdout output breaks `JSON.parse` (`SyntaxError: Unexpected token 'C'`).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,6 +446,16 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 ## 更新日志
 
+### v1.14.19 — 彻底修复发版流水线（npm 10 `--ignore-scripts` 失效）
+
+**问题**：v1.14.18（#306）已合并但依然没有发布 —— `release.yml` 又在同一步骤失败。v1.14.18 修复失败的根本原因：CI 运行器是 Node 22（npm 10.9.x），而 **npm 10 在 `npm pack` 时即使传了 `--ignore-scripts` 也照样执行 `prepare` 生命周期钩子**。v1.14.18 的修复（`npm pack --ignore-scripts`）在 npm 11 上有效，在 npm 10 上是空操作。prepare 一旦执行，tsup 会把 `CLI Building entry: index.ts` 写到 **stdout**，破坏 `verify-package.mjs` 里的 `JSON.parse`（`SyntaxError: Unexpected token`）。
+
+**修复**：把 `prepare` 构建的 stdout 重定向到 stderr：`package.json` 中改为 `"prepare": "npm run build 1>&2"`。构建输出（信息性）走 stderr，stdout 无论 npm 版本、无论 `--ignore-scripts` 是否生效都保持纯 JSON。已在本地用 npm 10.9.9 实证验证：`npm pack --dry-run --json` 现在返回合法 JSON（173 个 tarball 条目），带与不带 `--ignore-scripts` 均通过。v1.14.18 加的 `--ignore-scripts` 标志保留（npm 10 上无害，npm 11 上跳过多余重建）。`npm install github:...#branch` 路径不受影响 —— prepare 照常执行并构建 `dist/`。
+
+文件：`package.json`。测试：976 通过；`check:package` 在 npm 10.9.9 和 npm 11.12.1 上均绿。
+
+**安装**：`opencode plugin opencode-acp@latest --global`
+
 ### v1.14.18 — 取代未能发布的 v1.14.17；修复发版流水线
 
 **问题**：v1.14.17 已合并（#305）但从未发布 —— \`release.yml\` 在 \`npm run check:package\` 一步失败：#298 新增的 \`prepare\` 钩子（\`npm run build\`）会在 \`verify-package.mjs\` 的 \`npm pack --json\` 期间运行，tsup 的 \`CLI Building entry: index.ts\` 输出污染 stdout，导致 \`JSON.parse\` 报错（\`SyntaxError: Unexpected token 'C'\`）。

--- a/devlog/2026-08-15_release-v1.14.19/REQ.md
+++ b/devlog/2026-08-15_release-v1.14.19/REQ.md
@@ -1,0 +1,22 @@
+# REQ — v1.14.19: Fix release pipeline for real (npm 10 `--ignore-scripts` bug)
+
+## Problem
+
+v1.14.18 (PR #306) was merged but never published — `release.yml` failed at the exact same `verify-package.mjs` step as v1.14.17. The v1.14.18 fix (`npm pack --ignore-scripts`) turned out to be insufficient: the CI runner uses Node 22 (npm 10.9.x), and **npm 10 runs the `prepare` lifecycle hook during `npm pack` even when `--ignore-scripts` is passed**. The flag works on npm 11 (local Node 25), which is why local verification passed but CI failed. When prepare runs, tsup writes `CLI Building entry: index.ts` to **stdout**, breaking `JSON.parse` in `verify-package.mjs`.
+
+Two consecutive versions (1.14.17, 1.14.18) failed to publish because of this.
+
+## Fix
+
+Redirect the `prepare` build's stdout to stderr: `"prepare": "npm run build 1>&2"` in `package.json`.
+
+- Build output (informational) goes to stderr
+- stdout stays pure JSON regardless of npm version or whether `--ignore-scripts` works
+- Verified empirically with npm 10.9.9 locally: `npm pack --dry-run --json` returns valid JSON (173 tarball entries) both with and without `--ignore-scripts`
+- The `--ignore-scripts` flag added in v1.14.18 is kept (harmless on npm 10, skips redundant rebuild on npm 11)
+- The `npm install github:...#branch` path still works — prepare still runs and still builds `dist/`
+
+## Acceptance
+
+- `npm run check:package` green on both npm 10.9.9 and npm 11.12.1
+- release.yml publishes v1.14.19 to npm `latest` after merge

--- a/devlog/2026-08-15_release-v1.14.19/WORKLOG.md
+++ b/devlog/2026-08-15_release-v1.14.19/WORKLOG.md
@@ -1,0 +1,24 @@
+# WORKLOG — v1.14.19
+
+## Investigation
+
+1. PR #306 (v1.14.18) merged → release.yml failed at same `verify-package.mjs` step: `SyntaxError: Unexpected token '', "[34mCLI["... is not valid JSON`
+2. Initial assumption: same root cause as v1.14.17. But v1.14.18 already added `--ignore-scripts`...
+3. Key insight: CI runner = Node 22 → npm 10.9.x. Local = Node 25 → npm 11.12.1.
+4. Empirical test with `npx -y npm@10 pack --dry-run --json --ignore-scripts`:
+   - npm 10.9.9: prepare STILL RUNS despite `--ignore-scripts` → stdout polluted ❌
+   - npm 11.12.1: flag works → clean stdout ✓
+   - This explains why v1.14.18 passed local verification but failed CI.
+
+## Fix
+
+- `package.json`: `"prepare": "npm run build 1>&2"` — redirect build stdout to stderr
+- Verified: npm 10.9.9 `npm pack --dry-run --json` returns valid JSON (173 entries), with and without `--ignore-scripts`
+- Version bumped to 1.14.19
+- Changelog entries added to README.md + README.zh-CN.md
+
+## Verification
+
+- `npm run build`: 391.59 KB ✓
+- `node scripts/verify-package.mjs`: "package verification passed for opencode-acp@1.14.19, tarball entries: 173" ✓
+- Full check:package path green

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.18",
+    "version": "1.14.19",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",
@@ -19,7 +19,7 @@
     "scripts": {
         "clean": "rm -rf dist",
         "build": "npm run clean && tsup && tsc --emitDeclarationOnly",
-        "prepare": "npm run build",
+        "prepare": "npm run build 1>&2",
         "verify:package": "node scripts/verify-package.mjs",
         "check:package": "npm run build && npm run verify:package",
         "prepublishOnly": "npm run check:package",


### PR DESCRIPTION
## Problem

v1.14.18 (#306) was merged but never published — `release.yml` failed at the exact same `verify-package.mjs` step as v1.14.17. The v1.14.18 fix (`npm pack --ignore-scripts`) turned out to be insufficient: the CI runner uses **Node 22 (npm 10.9.x)**, and **npm 10 runs the `prepare` lifecycle hook during `npm pack` even when `--ignore-scripts` is passed**. The flag works on npm 11 (local Node 25), which is why local verification passed but CI failed.

When prepare runs, tsup writes `CLI Building entry: index.ts` to **stdout**, breaking `JSON.parse` in `verify-package.mjs`.

Two consecutive versions (1.14.17, 1.14.18) failed to publish because of this.

## Fix

Redirect the `prepare` build's stdout to stderr: `"prepare": "npm run build 1>&2"` in `package.json`.

- Build output (informational) goes to stderr
- stdout stays pure JSON regardless of npm version or whether `--ignore-scripts` works
- **Verified empirically with npm 10.9.9 locally**: `npm pack --dry-run --json` returns valid JSON (173 tarball entries) both with and without `--ignore-scripts`
- The `--ignore-scripts` flag from v1.14.18 is kept (harmless on npm 10, skips redundant rebuild on npm 11)
- `npm install github:...#branch` path unaffected — prepare still runs and still builds `dist/`

## Verification

- `npm run build`: 391.59 KB ✓
- `node scripts/verify-package.mjs`: passed, 173 tarball entries ✓ (npm 10.9.9 + npm 11.12.1)
- `./scripts/ci/check-pr.sh`: all checks passed ✓
- 976 tests pass, typecheck clean

## After merge

CI will auto-publish v1.14.19 to npm `latest` (this also finally ships everything from the unpublished 1.14.17 + 1.14.18). Then PR #307 (promote stable) needs retargeting from v1.14.18 → v1.14.19.