### PR TITLE
promote: stable v1.14.19 — pipeline-fixed release incl. 14.14/14.16 content

### DIFF
--- a/devlog/2026-08-15_promote-stable-v1.14.19/REQ.md
+++ b/devlog/2026-08-15_promote-stable-v1.14.19/REQ.md
@@ -1,0 +1,21 @@
+# REQ — Promote v1.14.19 to npm stable tag
+
+## Goal
+
+Point the npm `stable` dist-tag at `opencode-acp@1.14.19` (currently at 1.14.13). Users installing via `opencode plugin opencode-acp@stable --global` receive the latest stable release.
+
+## Context
+
+- v1.14.19 published to npm `latest` (PR #308 merged; release.yml succeeded — pipeline finally fixed after 1.14.17/1.14.18 both failed to publish)
+- v1.14.13 was the last version on `stable` — 6 versions behind (14.14, 14.16, 17†, 18†, 19; † never published)
+- This PR supersedes #307 which promoted v1.14.18 — that version was never published to npm (release pipeline was broken at the time), so its `npm dist-tag add opencode-acp@1.14.18 stable` would fail
+
+## Mechanism
+
+No code changes. Branch name `2026-08-15_promote-stable-v1.14.19` + squash-merge title `promote: stable v1.14.19 — ...` triggers release.yml Pattern 3, which runs `npm dist-tag add opencode-acp@1.14.19 stable`.
+
+## Content shipped in stable 1.14.13 → 1.14.19
+
+- v1.14.14: batched-call summary leak fix (#288), batch-compress all-or-nothing abort fix (#290)
+- v1.14.16: context limits raised to 80% (max/min)
+- v1.14.19: per-PR npm preview builds + release publishing feedback (#298, from unpublished 1.14.17), release pipeline fix (from unpublished 1.14.18), npm 10 prepare-hook stdout redirect fix

--- a/devlog/2026-08-15_promote-stable-v1.14.19/WORKLOG.md
+++ b/devlog/2026-08-15_promote-stable-v1.14.19/WORKLOG.md
@@ -1,0 +1,12 @@
+# WORKLOG — Promote v1.14.19 to stable
+
+## Steps
+
+1. Verified v1.14.19 published to npm `latest` (release.yml run 31823530381 completed success; `npm view opencode-acp dist-tags.latest` = 1.14.19)
+2. Created branch `2026-08-15_promote-stable-v1.14.19` from master `d6b540e` (post-merge)
+3. No code/config changes — promote-only release
+4. Supersedes PR #307 (promoted unpublished v1.14.18; would fail at `npm dist-tag add opencode-acp@1.14.18 stable`)
+
+## After merge
+
+release.yml Pattern 3 (squash title `promote: stable v1.14.19 — ...`) runs `npm dist-tag add opencode-acp@1.14.19 stable`. Verify with `npm view opencode-acp dist-tags`.


### PR DESCRIPTION
## Goal

Point the npm `stable` dist-tag at `opencode-acp@1.14.19` (currently 1.14.13 — 6 versions behind). No code changes.

## Mechanism

Squash-merge title matches release.yml Pattern 3 → runs `npm dist-tag add opencode-acp@1.14.19 stable`.

## Supersedes PR #307

#307 promoted v1.14.18 — a version that was **never published** (release pipeline was broken). Its `npm dist-tag add opencode-acp@1.14.18 stable` would fail with version-not-found. This PR promotes v1.14.19, which **is** published (`latest` = 1.14.19, release run 31823530381 ✓).

## Content shipped stable 1.14.13 → 1.14.19

- **v1.14.14**: batched-call summary leak fix (#288), batch-compress all-or-nothing abort fix (#290)
- **v1.14.16**: context limits raised to 80%
- **v1.14.19** (from unpublished 1.14.17 + 1.14.18): per-PR npm preview builds + release publishing feedback (#298), release pipeline fixes (verify-package `--ignore-scripts` + npm 10 `prepare` stdout redirect)