### PR TITLE
fix: invalidate stale modelContextLimit on model switch (#312)

### DIFF
--- a/devlog/2026-08-16_model-switch-stale-limit/DESIGN.md
+++ b/devlog/2026-08-16_model-switch-stale-limit/DESIGN.md
@@ -1,0 +1,75 @@
+# DESIGN - Invalidate stale modelContextLimit after a model switch
+
+- Task ID: `2026-08-16_model-switch-stale-limit`
+- Home Repo: `opencode-acp`
+- Created: 2026-08-16
+- Status: Accepted
+
+## 1. Problem Statement
+
+- **What problem are we solving?** Percentage-based context thresholds are computed against `state.modelContextLimit`, which lags the active model by one turn after a model switch (issue #312: 50% emergency fired at 26% of the new 1M window).
+- **Why now?** User-visible false emergency nudges on a common workflow (switching to a larger-window model to continue an existing session).
+
+## 2. Goals & Non-Goals
+
+- **Goals**:
+  - No threshold is ever computed from a limit whose model identity does not match the current turn.
+  - Self-correcting within one turn without extra API calls.
+  - Additive, backward-compatible persisted state.
+- **Non-Goals**:
+  - Perfect first-turn accuracy after a switch (accepted 1-turn "limit unknown" window).
+  - Upstream hook-ordering change in OpenCode.
+  - Fetching model limits via `client.app.providers()` (see §5, option B).
+
+## 3. Current Architecture (if applicable)
+
+- **How it works today**:
+  - `messages.transform` (prompt.ts:1583) runs the full ACP pipeline: filters, prune, GC, `injectCompressNudges` — all reading `state.modelContextLimit`.
+  - `system.transform` (llm.ts:118) runs LATER in the same turn and is the only writer: `state.modelContextLimit = input.model.limit.context`.
+  - Consequence: turn N+1 (first turn after a switch) evaluates the stale limit from model M(N); M(N+1)'s limit lands only after that transform.
+- **Pain points**:
+  - `emergencyThresholdPercent: "50%"` × stale 200K = 100K → 260K-token session trips the emergency at 26% of the real 1M window.
+  - Same stale value distorts percentage `min/maxContextLimit` and the adaptive `nudgeGrowthTokens` (5% of 200K = 10K instead of 50K).
+  - No record of WHICH model a limit belongs to, so staleness is undetectable.
+
+## 4. Proposed Architecture
+
+- **Overview**:
+  ```
+  messages.transform (turn N+1, model M2)
+    └─ syncModelIdentity(state, M2) ── mismatch with stored (limit ← M1)
+         └─ state.modelContextLimit = undefined   ← "limit unknown" path
+    └─ pipeline runs with unknown-limit semantics
+  system.transform (turn N+1, model M2)   ← later in the same turn
+    └─ state.modelContextLimit = M2.limit.context
+       state.modelProviderID / modelID = M2      ← provenance recorded
+  messages.transform (turn N+2, model M2)
+    └─ syncModelIdentity: identity matches → limit kept (1M)
+  ```
+- **Key components**:
+  - `SessionState.modelProviderID?` / `modelID?` — provenance of the cached limit (persisted, optional).
+  - `syncModelIdentity(state, providerID, modelID): boolean` (lib/state/utils.ts) — the single invalidation point; returns true when a switch (or unknown provenance) was detected.
+  - `createSystemPromptHandler` — stores identity alongside the limit.
+  - `createChatMessageTransformHandler` — calls `syncModelIdentity` right after state resolution, before any limit-consuming stage.
+- **Data flow**: model identity flows from the last user message (`info.model.providerID/modelID`) into `syncModelIdentity`; from the SDK `Model` (`id`/`providerID`) into the system handler. Both use the same provider/model ID namespace.
+
+## 5. Decisions
+
+| Decision | Options | Choice | Rationale |
+|---|---|---|---|
+| Stale-limit handling | (a) trust it, (b) invalidate on identity mismatch, (c) fetch fresh limit via `client.app.providers()` | (b) | (a) is the bug. (c) adds an async API call + error/caching surface to the hot path; per-session-state DESIGN already rejected `provider.list` for this reason. (b) reuses the existing, well-tested "limit unknown" semantics (unknown-limit path already guards GC, truncate, filters, adaptive growth). |
+| Where to invalidate | (a) inside each consumer, (b) one call at the transform entry | (b) | Every consumer (filters → prune → GC → nudge) runs after state resolution in `createChatMessageTransformHandler`; one call covers all. Consumers already handle `undefined` limits. |
+| Provenance storage | (a) model string `provider/model`, (b) two fields | (b) | Matches `UserMessage.info.model` shape; avoids parsing; both optional for backward compat. |
+| Legacy files (limit, no identity) | (a) trust, (b) invalidate first transform | (b) | A limit whose model cannot be verified is a stale guess; the project's own rule (README v1.13.x changelog) is to surface `undefined` rather than distorted percentages. Cost: one unknown-limit turn after upgrade — self-corrects same turn. |
+| Variant in identity | (a) include `variant`, (b) ignore | (b) | `limit.context` is per-model; variants are parameter presets on the same model. Including it would invalidate on variant flips with no limit change. |
+
+## 6. Impact Analysis
+
+- **Backward compatibility**: additive. `modelProviderID?`/`modelID?` are optional in `SessionState` and `PersistedSessionState`; old JSON loads unchanged (restore guards check `typeof === "string"`). Older plugin versions ignore the new fields. No exported API removal; `syncModelIdentity` is a new export.
+- **Performance**: one `findLast` over messages (model info, same cost as the existing `getLastUserMessage` already called in the same handler) + one identity comparison. Negligible.
+- **Behavioral**: first turn after a model switch (and first turn after an upgrade from a pre-identity version) uses unknown-limit semantics: no emergency/min/max nudges, adaptive growth falls to the 6K floor, GC/batch-cleanup/truncation skip. System prompt limit line for that turn shows the unknown-limit variant (existing behavior).
+- **Security**: N/A.
+
+## 7. Rollback
+
+Revert the branch. Persisted new fields are inert to older code.

--- a/devlog/2026-08-16_model-switch-stale-limit/REQ.md
+++ b/devlog/2026-08-16_model-switch-stale-limit/REQ.md
@@ -1,0 +1,63 @@
+# REQ - Invalidate stale modelContextLimit after a model switch
+
+- Task ID: `2026-08-16_model-switch-stale-limit`
+- Home Repo: `opencode-acp`
+- Created: 2026-08-16
+- Status: Done
+- Priority: P1
+- Owner: ranxianglei
+- References: issue #312
+
+## 1. Background & Problem Statement
+
+- **Context**: `state.modelContextLimit` drives every percentage-based threshold — `emergencyThresholdPercent`, `min/maxContextLimit`, adaptive `nudgeGrowthTokens`, GC/batch-cleanup gates. It is written only by the `experimental.chat.system.transform` handler.
+- **Current behavior (symptom)**: After switching models mid-session (issue #312: 200K → 1M), the emergency compression configured at 50% fires when the host TUI shows only 26% of the new window. The cached limit still describes the PREVIOUS model's window, so `50% × 200K = 100K` is compared against 260K real tokens.
+- **Expected behavior**: Thresholds are never computed against a window that does not belong to the current model. On the first turn after a switch, the limit is treated as unknown (the same semantics already used for providers that omit `model.limit.context`) until the system-prompt hook refreshes it within the same turn.
+- **Impact**: False "Context limit reached" emergency nudges, false min/max-limit nudges, and a mis-scaled adaptive nudge growth floor (10K instead of 50K) on the first turn after any model switch. The false emergency anchor/baseline side effects persist into later turns.
+
+## 2. Reproduction (if applicable)
+
+- **Environment**:
+  - Node: 22+
+  - OS/Arch: linux-x64
+  - OpenCode: stable v1.14.45 (hook ordering confirmed in `packages/opencode/src/session/prompt.ts:1583` → `session/llm.ts:118`)
+- **Minimal reproduction steps**:
+  1) Run a session on a model whose `limit.context` is 200K until the conversation exceeds 100K tokens (e.g. 260K on a model whose effective window exceeds its reported 200K limit).
+  2) Switch the session to a model with a 1M context window.
+  3) Send the next message. The first `messages.transform` of the new turn evaluates thresholds against the stale 200K limit → 50% emergency threshold = 100K ≤ 260K → emergency nudge injected although the TUI shows 26% of 1M.
+- **Relevant configuration**: `compress.emergencyThresholdPercent: "50%"` (any percentage threshold exhibits the bug; absolute-number thresholds are unaffected).
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+  - Backward compatibility: existing persisted state JSON files (without the new fields) must load without changes to on-disk format.
+  - Performance requirements: no new API calls per turn (explicitly NOT fetching model limits via `client.app.providers()` — see DESIGN §5).
+  - Resource limits: no new state beyond two optional string fields.
+- **Non-Goals** (explicitly out of scope):
+  - Making the first turn after a switch fully correct (1-turn "limit unknown" window is accepted — same semantics as a fresh session's first turn).
+  - Changing OpenCode's hook ordering (upstream change, out of scope).
+  - Fixing host-TUI percentage display (host-side, not ACP).
+
+## 4. Acceptance Criteria (must be testable)
+
+- **Correctness**:
+  - [x] After a model switch, the first `messages.transform` never uses the previous model's `modelContextLimit` for any threshold (emergency, min/max, adaptive growth, GC, filters).
+  - [x] The system-prompt handler records the model identity together with the limit, so subsequent transforms use the correct window.
+  - [x] Same-model transforms never invalidate the limit (no steady-state flicker).
+  - [x] Emergency threshold math is unchanged when the limit and model agree (control test: 800K/1M at 50% still fires).
+- **Performance / Stability**:
+  - [x] No new per-transform scans beyond one `findLast` (model info) — comparable to existing `getLastUserMessage` scans already in the transform.
+  - [x] Legacy state files (no identity fields) load fine; the unverifiable limit is invalidated on the first transform, then repopulated by system.transform the same turn.
+- **Regression**:
+  - [x] New test cases added to test suite and passing: `tests/model-switch-limit.test.ts` (9 tests; the e2e #312 regression was verified to FAIL when the fix is disabled).
+
+## 5. Proposed Approach (optional)
+
+- **Affected modules & entry files**:
+  - `lib/state/types.ts` — `SessionState.modelProviderID?` / `modelID?`
+  - `lib/state/utils.ts` — `syncModelIdentity()`
+  - `lib/state/state.ts` — init/reset/restore
+  - `lib/state/persistence.ts` — additive persisted fields
+  - `lib/hooks.ts` — identity store (system handler) + invalidation (message transform)
+- **Risks**: One turn of degraded (unknown-limit) behavior after a switch — the documented, safe path.
+- **Rollback strategy**: Revert the branch; persisted new fields are ignored by older code (additive).

--- a/devlog/2026-08-16_model-switch-stale-limit/WORKLOG.md
+++ b/devlog/2026-08-16_model-switch-stale-limit/WORKLOG.md
@@ -1,0 +1,76 @@
+# WORKLOG - Invalidate stale modelContextLimit after a model switch
+
+- Task ID: `2026-08-16_model-switch-stale-limit`
+- Home Repo: `opencode-acp`
+- Status: Done
+- Updated: 2026-08-16
+
+## 1. Summary
+
+- **What was done** (1–3 sentences): `modelContextLimit` is now tracked together with the model identity it was captured for. The messages transform invalidates the limit when the turn's model no longer matches, so the first turn after a model switch uses the standard "limit unknown" path; the system-prompt hook (which fires later in the same turn) repopulates the correct limit plus the new identity.
+- **Why** (1–3 sentences): `system.transform` (the only limit writer) fires AFTER `messages.transform` in every turn — confirmed in OpenCode stable v1.14.45 source (`session/prompt.ts:1583` → `session/llm.ts:118`). After a 200K→1M switch, the 50% emergency threshold was computed as 50%×200K=100K against 260K real tokens, tripping the emergency at 26% of the new window (issue #312).
+- **Behavior / compatibility changes**: Yes — first turn after a model switch (and first turn after upgrading from a pre-identity state file) uses unknown-limit semantics instead of the previous model's window. Persisted state change is additive (two optional string fields). No config-schema or exported-API removals.
+- **Risk level**: Low
+
+## 2. Change Log
+
+### Commits
+
+| Commit | Description |
+|--------|-------------|
+| `<sha>` | fix: invalidate stale modelContextLimit on model switch (#312) |
+
+### Key Files
+
+- `lib/state/types.ts` — `SessionState.modelProviderID?` / `modelID?`: provenance of the cached limit.
+- `lib/state/utils.ts` — new `syncModelIdentity(state, providerID, modelID): boolean`: invalidates `modelContextLimit` on model mismatch or unknown provenance; records the current identity; no-op on match or missing model info.
+- `lib/state/state.ts` — `createSessionState`/`resetSessionState` init the new fields; `ensureSessionInitialized` restores them with `typeof === "string"` guards (legacy files load unchanged).
+- `lib/state/persistence.ts` — `modelProviderID?`/`modelID?` added to `PersistedSessionState` and `saveSessionState` (additive).
+- `lib/hooks.ts` — `createSystemPromptHandler` stores `input.model.id`/`input.model.providerID` alongside the limit; `createChatMessageTransformHandler` calls `syncModelIdentity` after state resolution (debug log on invalidation); inline system-hook input type extended with `id`/`providerID`.
+- `tests/model-switch-limit.test.ts` — 9 new tests: 5 `syncModelIdentity` unit tests, 1 persistence round-trip, 1 e2e #312 regression (200K→1M, 260K tokens, no false emergency before or after the system-hook refresh), 2 control tests (emergency still fires with a matching 1M limit; steady-state same-model keeps the limit).
+
+## 3. Design & Implementation Notes
+
+- **Entry point / key function**: `syncModelIdentity()` (lib/state/utils.ts) — single invalidation point; called once per transform at the top of the pipeline, before every limit-consuming stage (filters, prune, GC, batch cleanup, truncation, nudge injection).
+- **Key configuration items**: none new — existing `compress.emergencyThresholdPercent`, `min/maxContextLimit` percentage thresholds now resolve against the *current* model's window (or unknown) instead of possibly the previous one.
+- **Key logic explanation** (if non-trivial):
+  - Turn N on model A: system.transform stores `(limit_A, A)`.
+  - User switches to model B. Turn N+1, messages.transform: `getModelInfo(messages)` yields B → mismatch → `modelContextLimit = undefined`, identity = B. Pipeline runs on the unknown-limit path (no emergency/min/max nudges; adaptive growth floor 6K; GC/truncation no-op).
+  - Turn N+1, system.transform: stores `(limit_B, B)`.
+  - Turn N+2+: identity matches → limit_B kept.
+  - The invalidation is idempotent: if system.transform does not fire in a turn (early returns), the next transform re-detects nothing (identity already updated) and the limit stays unknown until it does fire.
+  - `variant` is intentionally excluded from identity — the context window is per-model, not per-variant.
+
+## 4. Testing & Verification
+
+### Build & Test Commands
+
+```sh
+# Build
+cd opencode-acp && npm run build
+
+# Run full test suite
+node --import tsx --test tests/*.test.ts
+
+# Run specific test file
+node --import tsx --test tests/model-switch-limit.test.ts
+
+# Type check
+npx tsc --noEmit
+```
+
+### Results
+
+- `npm run typecheck` — pass.
+- `node --import tsx --test tests/*.test.ts` — **990 pass, 0 fail** (981 baseline + 9 new).
+- **Bug-reproduction verification** (AGENTS.md §5.2): with the invalidation call disabled (`if (false && syncModelIdentity(...))`), the e2e regression `issue #312: no false emergency on first turn after switching 200K → 1M` FAILS with `AssertionError: stale 200K limit must be invalidated` (actual 200000, expected undefined) — the test captures the root cause, not the fix's side effects. Re-enabled: all green.
+- Formatting: repo is not prettier-clean repo-wide (383 files pre-existing); new lines verified prettier-stable (diff of `prettier <file>` vs file shows only pre-existing untouched regions).
+
+## 5. Review (AGENTS.md §5.3 — dual-agent required)
+
+- [x] Agent review 1 (correctness/lifecycle): **APPROVE** (confidence 0.95) — invalidation fires at exactly the right point (before every limit consumer, every transform path checked: commands/internal-agents/ephemeral state/subagents all safe); namespace match verified against OpenCode source (step model built from `lastUser.model`, system.transform receives the same object's `.id`/`.providerID`); no scenario invalidates a correct limit; the 1-turn unknown-limit degradation equals the pre-existing first-turn state and all consumers already guard `undefined`; e2e test empirically verified to fail on a master scratch worktree and pass with the fix.
+- [x] Agent review 2 (backward compatibility/state integrity): **APPROVE** (confidence 0.85) — legacy JSON (no identity fields) loads unchanged (structural validation + `typeof` restore guards); first transform takes the safe unknown-provenance invalidation, self-heals same turn; limit+identity always written/persisted atomically as one snapshot, survive eviction+reload consistently; `dcp.schema.json` correctly untouched (user-config schema, not state format); per-transform cost = one early-exit `findLast` + 2 string comparisons, negligible vs the transform's existing full scans; no `as any`/`ts-ignore` introduced.
+- **P3 findings (both fixed before commit)**: (1) three new lines exceeded printWidth 100 → hand-wrapped to prettier-stable form (verified: `prettier <file>` diff vs file shows only pre-existing untouched regions); (2) debug log mislabeled fresh-session first-turn identity establishment as "Model switch detected (unknown → …)" → now logs `Model identity established (…) / limit awaits system.transform` when no prior identity, `Model switch detected (from → to)` only on a real switch.
+## 6. Open Items
+
+- None.

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -24,6 +24,7 @@ import {
 } from "./compress/timing"
 import { filterMessages, filterMessagesInPlace } from "./messages/shape"
 import { getLastUserMessage } from "./messages/query"
+import { getModelInfo } from "./messages/inject/utils"
 import { truncateLargeToolOutputs } from "./messages/truncate-tools"
 import {
     handleContextCommand,
@@ -36,6 +37,7 @@ import { hideFailedCompressCalls } from "./compress/hide-failed"
 import { applyMessageFilters } from "./messages/filter/apply"
 import { ensureBuiltinFiltersRegistered } from "./messages/filter/builtin"
 import { createSessionState, saveSessionState, syncToolCache, updatePerTurnState, type SessionStateRegistry } from "./state"
+import { syncModelIdentity } from "./state/utils"
 import { cacheSystemPromptTokens } from "./ui/utils"
 import { sendIgnoredMessage } from "./ui/notification"
 import { runBatchCleanup } from "./gc/merge"
@@ -75,7 +77,11 @@ export function createSystemPromptHandler(
     return async (
         input: {
             sessionID?: string
-            model: { limit: { context: number; input?: number; output?: number } }
+            model: {
+                id: string
+                providerID: string
+                limit: { context: number; input?: number; output?: number }
+            }
         },
         output: { system: string[] },
     ) => {
@@ -84,6 +90,8 @@ export function createSystemPromptHandler(
         const state = input.sessionID ? registry.get(input.sessionID) : undefined
         if (state && input.model?.limit?.context) {
             state.modelContextLimit = input.model.limit.context
+            state.modelProviderID = input.model.providerID
+            state.modelID = input.model.id
         }
 
         if (!state || (state.isSubAgent && !config.allowSubAgents)) {
@@ -159,6 +167,26 @@ export function createChatMessageTransformHandler(
                 config,
             )
             await updatePerTurnState(state, logger, messages)
+            // [FIX #312] system.transform (which refreshes modelContextLimit)
+            // fires AFTER this transform, so on the first turn after a model
+            // switch the cached limit still describes the previous model's
+            // window. Invalidate it; the "limit unknown" path applies for this
+            // transform only.
+            const { providerId, modelId } = getModelInfo(messages)
+            const prevIdentity = state.modelID
+            const prevModel = prevIdentity ? `${state.modelProviderID}/${prevIdentity}` : undefined
+            if (syncModelIdentity(state, providerId, modelId)) {
+                const target = `${providerId}/${modelId}`
+                if (prevIdentity) {
+                    logger.debug(
+                        `Model switch detected (${prevModel} → ${target}); invalidated stale modelContextLimit`,
+                    )
+                } else {
+                    logger.debug(
+                        `Model identity established (${target}); limit awaits system.transform`,
+                    )
+                }
+            }
         }
 
         syncCompressPermissionState(state, config, hostPermissions, output.messages)

--- a/lib/state/persistence.ts
+++ b/lib/state/persistence.ts
@@ -58,6 +58,8 @@ export interface PersistedSessionState {
     messageIds?: PersistedMessageIds
     lastCompaction?: number
     modelContextLimit?: number
+    modelProviderID?: string
+    modelID?: string
 }
 
 function getStorageDir(): string {
@@ -139,6 +141,8 @@ export async function saveSessionState(
         },
         lastCompaction: sessionState.lastCompaction,
         modelContextLimit: sessionState.modelContextLimit,
+        modelProviderID: sessionState.modelProviderID,
+        modelID: sessionState.modelID,
     }
 
     await writePersistedSessionState(sessionState.sessionId, state, logger)

--- a/lib/state/state.ts
+++ b/lib/state/state.ts
@@ -171,6 +171,8 @@ export function createSessionState(): SessionState {
         lastCompaction: 0,
         currentTurn: 0,
         modelContextLimit: undefined,
+        modelProviderID: undefined,
+        modelID: undefined,
         systemPromptTokens: undefined,
         qualityGateRetryPending: false,
     }
@@ -211,6 +213,8 @@ export function resetSessionState(state: SessionState): void {
     state.lastCompaction = 0
     state.currentTurn = 0
     state.modelContextLimit = undefined
+    state.modelProviderID = undefined
+    state.modelID = undefined
     state.systemPromptTokens = undefined
     state.qualityGateRetryPending = false
 }
@@ -304,6 +308,12 @@ export async function ensureSessionInitialized(
     }
     if (typeof persisted.modelContextLimit === "number" && persisted.modelContextLimit > 0) {
         state.modelContextLimit = persisted.modelContextLimit
+    }
+    if (typeof persisted.modelProviderID === "string") {
+        state.modelProviderID = persisted.modelProviderID
+    }
+    if (typeof persisted.modelID === "string") {
+        state.modelID = persisted.modelID
     }
 
     const applied = applyPendingCompressionDurations(state)

--- a/lib/state/types.ts
+++ b/lib/state/types.ts
@@ -143,6 +143,14 @@ export interface SessionState {
     lastCompaction: number
     currentTurn: number
     modelContextLimit: number | undefined
+    /**
+     * Model identity that `modelContextLimit` was captured for. Together with
+     * `modelID`, lets the messages transform detect a model switch BEFORE the
+     * system.transform hook refreshes the limit (it fires later in the same
+     * turn), so a stale limit is never used for threshold math (issue #312).
+     */
+    modelProviderID?: string
+    modelID?: string
     systemPromptTokens: number | undefined
     /**
      * Transient flag (NOT persisted): set to true when a compress call is rejected

--- a/lib/state/utils.ts
+++ b/lib/state/utils.ts
@@ -8,6 +8,44 @@ import type {
 import { isIgnoredUserMessage, messageHasCompress } from "../messages/query"
 import { isMessageWithInfo } from "../messages/shape"
 import { countTokens } from "../token-utils"
+/**
+ * Sync the cached `modelContextLimit` against the current turn's model.
+ *
+ * `modelContextLimit` is written only by the system.transform handler, which
+ * fires AFTER messages.transform within each turn (prompt.ts triggers
+ * messages.transform, then handle.process → llm.ts triggers system.transform).
+ * On the first transform after a model switch (e.g. 200K → 1M), the limit
+ * still describes the PREVIOUS model's window, so every percentage-based
+ * threshold (emergencyThresholdPercent, min/maxContextLimit, adaptive nudge
+ * growth) is computed against the stale window (issue #312: a 50% emergency
+ * fired at 26% of the new 1M window).
+ *
+ * On mismatch, invalidate the limit so the affected transform takes the
+ * standard "limit unknown" path; system.transform repopulates the correct
+ * value (plus the new identity) later in the same turn.
+ *
+ * Returns true when a model switch (or unknown provenance) was detected.
+ */
+export function syncModelIdentity(
+    state: SessionState,
+    providerID: string | undefined,
+    modelID: string | undefined,
+): boolean {
+    if (providerID === undefined || modelID === undefined) {
+        return false
+    }
+    if (state.modelProviderID === providerID && state.modelID === modelID) {
+        return false
+    }
+    // Model changed — or the limit's provenance is unknown (state file written
+    // by an older version without the identity fields). A limit that cannot be
+    // attributed to the current model is a stale guess: surface "unknown"
+    // rather than distorted percentages.
+    state.modelContextLimit = undefined
+    state.modelProviderID = providerID
+    state.modelID = modelID
+    return true
+}
 
 // [FIX Bug 3] Added summary check to match getCurrentTokenUsage exclusion logic
 export const isMessageCompacted = (state: SessionState, msg: WithParts): boolean => {

--- a/tests/model-switch-limit.test.ts
+++ b/tests/model-switch-limit.test.ts
@@ -1,0 +1,393 @@
+/**
+ * Regression tests for issue #312: switching models (200K → 1M) corrupts the
+ * context-level math — a 50% emergency compression fires at 26% of the new
+ * window.
+ *
+ * Root cause: `state.modelContextLimit` is written only by the system.transform
+ * handler, which fires AFTER messages.transform within each turn (prompt.ts
+ * triggers messages.transform, then handle.process → llm.ts triggers
+ * system.transform). On the first turn after a model switch the cached limit
+ * still describes the PREVIOUS model's window, so every percentage-based
+ * threshold (emergencyThresholdPercent, min/maxContextLimit, adaptive nudge
+ * growth) is computed against the stale window: 50% × 200K = 100K threshold
+ * vs 260K real tokens (26% of the new 1M window) → false emergency.
+ *
+ * Fix: track the model identity the limit was captured for; the messages
+ * transform invalidates the limit when the turn's model no longer matches
+ * (standard "limit unknown" path), and system.transform repopulates the
+ * correct value later in the same turn.
+ */
+import "./test-env"
+import assert from "node:assert/strict"
+import test from "node:test"
+import type { PluginConfig } from "../lib/config"
+import { createChatMessageTransformHandler, createSystemPromptHandler } from "../lib/hooks"
+import { Logger } from "../lib/logger"
+import {
+    createSessionState,
+    loadSessionState,
+    saveSessionState,
+    type SessionState,
+    type WithParts,
+} from "../lib/state"
+import { syncModelIdentity } from "../lib/state/utils"
+import { isSyntheticMessage } from "../lib/messages/query"
+import { createTestRegistry } from "./registry-stub"
+import type { Part } from "@opencode-ai/sdk/v2"
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const SID = "ses-model-switch"
+const OLD_MODEL = { providerID: "prov", modelID: "small-200k" }
+const NEW_MODEL = { providerID: "prov", modelID: "large-1m" }
+
+function buildConfig(overrides: Partial<PluginConfig> = {}): PluginConfig {
+    return {
+        enabled: true,
+        autoUpdate: true,
+        debug: false,
+        pruneNotification: "off",
+        pruneNotificationType: "chat",
+        commands: { enabled: true, protectedTools: [] },
+        experimental: { allowSubAgents: false, customPrompts: false },
+        protectedFilePatterns: [],
+        compress: {
+            mode: "message",
+            permission: "allow",
+            showCompression: false,
+            summaryBuffer: true,
+            // Percentage-based limits: resolve against the live modelContextLimit,
+            // so they go "unknown" together with it on a model switch.
+            maxContextLimit: "90%",
+            minContextLimit: "70%",
+            emergencyThresholdPercent: "50%",
+            nudgeFrequency: 5,
+            iterationNudgeThreshold: 15,
+            nudgeForce: "soft",
+            protectedTools: [],
+            protectTags: false,
+            protectUserMessages: false,
+            preserveRecentMessages: 0,
+            preserveRecentTokens: 0,
+            preserveLastUserMessage: false,
+        },
+        gc: {
+            algorithm: "truncate",
+            promotionThreshold: 5,
+            maxBlockAge: 15,
+            maxOldGenSummaryLength: 3000,
+            majorGcThresholdPercent: "100%",
+            batchCleanup: { lowThreshold: "60%", highThreshold: "75%", forceThreshold: "90%" },
+        },
+        ...overrides,
+    }
+}
+
+function makeUserMessage(
+    id: string,
+    text: string,
+    model: { providerID: string; modelID: string },
+): WithParts {
+    return {
+        info: {
+            id,
+            sessionID: SID,
+            role: "user",
+            agent: "assistant",
+            time: { created: Date.now() },
+            model,
+        } as WithParts["info"],
+        parts: [{ type: "text", text, id: `${id}-p1`, sessionID: SID, messageID: id }],
+    }
+}
+
+function makeAssistantMessage(id: string, text: string, inputTokens: number): WithParts {
+    return {
+        info: {
+            id,
+            sessionID: SID,
+            role: "assistant",
+            agent: "assistant",
+            parentID: "parent-placeholder",
+            modelID: NEW_MODEL.modelID,
+            providerID: NEW_MODEL.providerID,
+            mode: "normal",
+            path: { cwd: "/", root: "/" },
+            summary: false,
+            cost: 0,
+            tokens: { input: inputTokens, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            time: { created: Date.now() },
+        } as WithParts["info"],
+        parts: [
+            { type: "step-start", id: `${id}-ss`, sessionID: SID, messageID: id },
+            { type: "text", text, id: `${id}-p1`, sessionID: SID, messageID: id },
+        ],
+    }
+}
+
+function createMockClient() {
+    return {
+        session: {
+            get: async () => ({ data: { parentID: null } }),
+        },
+    }
+}
+
+function createMockPrompts() {
+    return {
+        reload() {},
+        getRuntimePrompts() {
+            return {
+                system: "ACP system",
+                compressRange: "compress range",
+                contextLimitNudge: "nudge",
+                turnNudge: "turn nudge",
+                iterationNudge: "iteration nudge",
+                subagentExtension: "",
+                decompressExtension: "",
+            }
+        },
+    }
+}
+
+function setupPipeline(
+    configOverrides: Partial<PluginConfig> = {},
+    stateOverrides: Partial<SessionState> = {},
+) {
+    const state = createSessionState()
+    state.sessionId = SID
+    Object.assign(state, stateOverrides)
+
+    const config = buildConfig(configOverrides)
+    const logger = new Logger(false)
+    const registry = createTestRegistry(state)
+    const prompts = createMockPrompts()
+    const messageHandler = createChatMessageTransformHandler(
+        createMockClient(),
+        registry,
+        logger,
+        config,
+        prompts,
+        { global: undefined, agents: {} },
+    )
+    const systemHandler = createSystemPromptHandler(registry, logger, config, prompts)
+
+    return { state, logger, config, messageHandler, systemHandler }
+}
+
+function partText(part: Part): string {
+    if (part.type === "text" && typeof part.text === "string") {
+        return part.text
+    }
+    return ""
+}
+
+function suffixText(messages: WithParts[]): string {
+    const suffix = messages.find((m) => isSyntheticMessage(m))
+    if (!suffix) return ""
+    return suffix.parts.map(partText).join("")
+}
+
+const EMERGENCY_MARK = "Context limit reached"
+
+// ─── Unit: syncModelIdentity ────────────────────────────────────────────────
+
+test("syncModelIdentity: same model keeps the cached limit", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 200000
+    state.modelProviderID = OLD_MODEL.providerID
+    state.modelID = OLD_MODEL.modelID
+
+    assert.equal(syncModelIdentity(state, OLD_MODEL.providerID, OLD_MODEL.modelID), false)
+    assert.equal(state.modelContextLimit, 200000)
+})
+
+test("syncModelIdentity: model switch invalidates the stale limit", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 200000
+    state.modelProviderID = OLD_MODEL.providerID
+    state.modelID = OLD_MODEL.modelID
+
+    assert.equal(syncModelIdentity(state, NEW_MODEL.providerID, NEW_MODEL.modelID), true)
+    assert.equal(state.modelContextLimit, undefined, "stale limit must be treated as unknown")
+    assert.equal(state.modelProviderID, NEW_MODEL.providerID)
+    assert.equal(state.modelID, NEW_MODEL.modelID)
+})
+
+test("syncModelIdentity: provider change invalidates even with same model id", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 200000
+    state.modelProviderID = "other"
+    state.modelID = NEW_MODEL.modelID
+
+    assert.equal(syncModelIdentity(state, NEW_MODEL.providerID, NEW_MODEL.modelID), true)
+    assert.equal(state.modelContextLimit, undefined)
+})
+
+test("syncModelIdentity: legacy state without provenance invalidates on first sync", () => {
+    // State files written before the identity fields existed carry a limit
+    // whose model cannot be verified — must not be trusted silently.
+    const state = createSessionState()
+    state.modelContextLimit = 200000
+
+    assert.equal(syncModelIdentity(state, NEW_MODEL.providerID, NEW_MODEL.modelID), true)
+    assert.equal(state.modelContextLimit, undefined)
+})
+
+test("syncModelIdentity: missing model info is a no-op", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 200000
+    state.modelProviderID = OLD_MODEL.providerID
+    state.modelID = OLD_MODEL.modelID
+
+    assert.equal(syncModelIdentity(state, undefined, NEW_MODEL.modelID), false)
+    assert.equal(syncModelIdentity(state, NEW_MODEL.providerID, undefined), false)
+    assert.equal(state.modelContextLimit, 200000, "no model info → nothing to compare against")
+})
+
+// ─── Persistence ────────────────────────────────────────────────────────────
+
+test("persistence: model identity survives save/load round-trip", async () => {
+    const state = createSessionState()
+    state.sessionId = "test-model-switch-persist"
+    state.modelContextLimit = 1000000
+    state.modelProviderID = NEW_MODEL.providerID
+    state.modelID = NEW_MODEL.modelID
+    const logger = new Logger(false)
+
+    await saveSessionState(state, logger)
+    const loaded = await loadSessionState("test-model-switch-persist", logger)
+
+    assert.ok(loaded)
+    assert.equal(loaded.modelContextLimit, 1000000)
+    assert.equal(loaded.modelProviderID, NEW_MODEL.providerID)
+    assert.equal(loaded.modelID, NEW_MODEL.modelID)
+})
+
+// ─── E2E: issue #312 scenario ───────────────────────────────────────────────
+
+test("issue #312: no false emergency on first turn after switching 200K → 1M", async () => {
+    // Session ran on the 200K model: the cached limit + identity match it.
+    // Context is at 260K tokens — 26% of the NEW 1M window, but 2.6× the stale
+    // emergency threshold (50% × 200K = 100K). The user just switched to the
+    // 1M model; this is the first messages.transform of the new turn.
+    const { state, messageHandler, systemHandler } = setupPipeline(
+        {},
+        {
+            modelContextLimit: 200000,
+            modelProviderID: OLD_MODEL.providerID,
+            modelID: OLD_MODEL.modelID,
+            nudges: createSessionState().nudges,
+        },
+    )
+    state.nudges.lastPerMessageNudgeTokens = 260000
+
+    const output = {
+        messages: [
+            makeUserMessage("u1", "Hello", OLD_MODEL),
+            makeAssistantMessage("a1", "Working on it", 260000),
+            makeUserMessage("u2", "Continue", NEW_MODEL),
+        ],
+    }
+
+    // 1. messages.transform for the new model — before system.transform fires.
+    await messageHandler({}, output)
+
+    assert.equal(state.modelContextLimit, undefined, "stale 200K limit must be invalidated")
+    assert.equal(state.modelID, NEW_MODEL.modelID, "identity must track the current turn's model")
+    assert.ok(
+        !suffixText(output.messages).includes(EMERGENCY_MARK),
+        "260K tokens is 26% of the 1M window — emergency (50%) must NOT fire on the stale threshold",
+    )
+    assert.equal(state.nudges.shouldInjectThisTurn, false)
+
+    // 2. system.transform for the new model fires later in the same turn.
+    await systemHandler(
+        {
+            sessionID: SID,
+            model: {
+                id: NEW_MODEL.modelID,
+                providerID: NEW_MODEL.providerID,
+                limit: { context: 1000000 },
+            },
+        },
+        { system: ["host system prompt"] },
+    )
+    assert.equal(state.modelContextLimit, 1000000)
+    assert.equal(state.modelID, NEW_MODEL.modelID)
+
+    // 3. Next transform: corrected 1M limit — 260K is still well below the
+    //    real 500K emergency threshold.
+    const output2 = {
+        messages: [
+            makeUserMessage("u1", "Hello", OLD_MODEL),
+            makeAssistantMessage("a1", "Working on it", 260000),
+            makeUserMessage("u3", "Keep going", NEW_MODEL),
+        ],
+    }
+    await messageHandler({}, output2)
+
+    assert.ok(
+        !suffixText(output2.messages).includes(EMERGENCY_MARK),
+        "with the correct 1M limit, 260K (26%) must not trip the 50% emergency",
+    )
+    assert.equal(state.nudges.shouldInjectThisTurn, false)
+})
+
+test("control: emergency still fires when limit and model agree", async () => {
+    // No switch — cached limit matches the turn's model. 800K tokens on a 1M
+    // model with a 50% emergency threshold (500K) MUST still trigger the
+    // strong alert, proving the threshold machinery was not neutered.
+    const { state, messageHandler } = setupPipeline(
+        {},
+        {
+            modelContextLimit: 1000000,
+            modelProviderID: NEW_MODEL.providerID,
+            modelID: NEW_MODEL.modelID,
+            nudges: createSessionState().nudges,
+        },
+    )
+    state.nudges.lastPerMessageNudgeTokens = 800000
+
+    const output = {
+        messages: [
+            makeUserMessage("u1", "Hello", NEW_MODEL),
+            makeAssistantMessage("a1", "Verbose work", 800000),
+            makeUserMessage("u2", "Continue", NEW_MODEL),
+        ],
+    }
+
+    await messageHandler({}, output)
+
+    assert.equal(state.modelContextLimit, 1000000, "matching model must not invalidate the limit")
+    assert.ok(
+        suffixText(output.messages).includes(EMERGENCY_MARK),
+        "800K >= 50% × 1M → emergency alert must fire",
+    )
+})
+
+test("control: no switch, same-model repeated transforms keep the limit", async () => {
+    const { state, messageHandler } = setupPipeline(
+        {},
+        {
+            modelContextLimit: 200000,
+            modelProviderID: OLD_MODEL.providerID,
+            modelID: OLD_MODEL.modelID,
+            nudges: createSessionState().nudges,
+        },
+    )
+    state.nudges.lastPerMessageNudgeTokens = 100000
+
+    const output = {
+        messages: [
+            makeUserMessage("u1", "Hello", OLD_MODEL),
+            makeAssistantMessage("a1", "Working", 100000),
+            makeUserMessage("u2", "More", OLD_MODEL),
+        ],
+    }
+
+    await messageHandler({}, output)
+    await messageHandler({}, output)
+
+    assert.equal(state.modelContextLimit, 200000, "steady-state model must retain its limit")
+})


### PR DESCRIPTION
## Problem (issue #312)

切换模型导致上下文水平计算错误 — 配置了 50% 紧急压缩，但在 26% 时就被告急（20w 切到 100w）。

`state.modelContextLimit` is written **only** by the `system.transform` handler, which OpenCode fires **after** `messages.transform` in every turn (verified in opencode stable v1.14.45: `session/prompt.ts:1583` → `session/llm.ts:118`). On the first turn after a model switch, every percentage-based threshold is therefore computed against the **previous** model's window:

- `emergencyThresholdPercent: "50%"` × stale 200K = 100K → a 260K-token session (26% of the new 1M window) trips the false emergency
- same staleness distorts percentage `min/maxContextLimit` and the adaptive `nudgeGrowthTokens` (10K instead of 50K)

## Fix

Track **which model** the cached limit belongs to; invalidate it when the turn's model no longer matches:

- `SessionState.modelProviderID?` / `modelID?` — provenance of the cached limit (additive, persisted, `typeof`-guarded restore; old state files load unchanged)
- `syncModelIdentity()` (`lib/state/utils.ts`) — single invalidation point: on model mismatch (or unverifiable provenance from a legacy file) sets `modelContextLimit = undefined`, so the affected transform takes the existing, well-tested **"limit unknown"** path (no false emergency/min-max nudges; GC/truncation no-op; adaptive growth floor)
- `createSystemPromptHandler` records the identity alongside the limit; `createChatMessageTransformHandler` calls `syncModelIdentity` right after state resolution — before every limit consumer
- system.transform repopulates the correct limit + identity **later in the same turn**, so the degradation is exactly one transform (same semantics as a fresh session's first turn)

Deliberately **not** fetching limits via `client.app.providers()`: an extra API call + error/caching surface in the hot path, previously rejected as a design goal (per-session-state design doc).

## Verification

- `npm run typecheck`, `npm run build`, full suite: **990 pass / 0 fail** (981 baseline + 9 new)
- New `tests/model-switch-limit.test.ts`:
  - e2e #312 regression: 200K→1M switch, 260K tokens, 50% emergency → no false emergency before **or** after the system-hook refresh; **verified to FAIL with the fix disabled** (`stale 200K limit must be invalidated`)
  - control: 800K/1M at 50% still fires the emergency (mechanism not neutered); steady-state same-model keeps the limit
  - 5 `syncModelIdentity` unit tests + persistence round-trip
- Dual-agent review (AGENTS.md §5.3): both APPROVE, no Critical/Major; 2 P3 findings (printWidth on 3 new lines; fresh-session log wording) fixed in this commit
- Backward compatible: persisted format change is additive; older plugin versions ignore the new fields

Devlog: `devlog/2026-08-16_model-switch-stale-limit/` (REQ + DESIGN + WORKLOG)
