### PR TITLE
fix(#312): invalidate stale modelContextLimit on catalog miss (#313 + #314 combined)

### DIFF
--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -98,6 +98,10 @@ export function createSystemPromptHandler(
         const state = input.sessionID ? registry.get(input.sessionID) : undefined
         if (state && input.model?.limit?.context) {
             state.modelContextLimit = input.model.limit.context
+            // [FIX #312 follow-up] Record WHICH model the limit belongs to so
+            // the messages hook can detect staleness on a catalog miss.
+            state.modelProviderID = input.model?.providerID
+            state.modelID = input.model?.id
         }
 
         if (!state || (state.isSubAgent && !config.allowSubAgents)) {
@@ -179,8 +183,6 @@ export function createChatMessageTransformHandler(
             // value still reflects the previous model. Reconcile it from the
             // catalog entry for the model named on this request's user message
             // before any consumer (filters, GC, nudge thresholds) reads it.
-            // Unknown model → keep the previous value; the system hook
-            // refreshes it later in this same request anyway.
             const requestModel = (
                 lastUserMessage.info as { model?: { providerID?: string; modelID?: string } }
             ).model
@@ -190,6 +192,26 @@ export function createChatMessageTransformHandler(
             )
             if (requestModelLimit !== undefined) {
                 state.modelContextLimit = requestModelLimit
+                state.modelProviderID = requestModel?.providerID
+                state.modelID = requestModel?.modelID
+            } else if (
+                // [FIX #312 fallback] Catalog miss: we cannot CORRECT the
+                // limit, but we can tell when it belongs to a DIFFERENT model.
+                // Invalidate instead of letting every percentage threshold
+                // below run against the wrong window (#312's false positive).
+                // States persisted before this identity pair existed carry no
+                // identity and are treated as stale for the same reason.
+                // Consumers already tolerate undefined — fresh sessions run
+                // with it until the first system.transform sets the pair.
+                requestModel?.providerID &&
+                requestModel?.modelID &&
+                state.modelContextLimit !== undefined &&
+                (state.modelProviderID !== requestModel.providerID ||
+                    state.modelID !== requestModel.modelID)
+            ) {
+                state.modelContextLimit = undefined
+                state.modelProviderID = requestModel.providerID
+                state.modelID = requestModel.modelID
             }
             await updatePerTurnState(state, logger, messages)
         }

--- a/lib/state/persistence.ts
+++ b/lib/state/persistence.ts
@@ -58,6 +58,8 @@ export interface PersistedSessionState {
     messageIds?: PersistedMessageIds
     lastCompaction?: number
     modelContextLimit?: number
+    modelProviderID?: string
+    modelID?: string
 }
 
 function getStorageDir(): string {
@@ -139,6 +141,8 @@ export async function saveSessionState(
         },
         lastCompaction: sessionState.lastCompaction,
         modelContextLimit: sessionState.modelContextLimit,
+        modelProviderID: sessionState.modelProviderID,
+        modelID: sessionState.modelID,
     }
 
     await writePersistedSessionState(sessionState.sessionId, state, logger)

--- a/lib/state/state.ts
+++ b/lib/state/state.ts
@@ -203,6 +203,8 @@ export function createSessionState(): SessionState {
         lastCompaction: 0,
         currentTurn: 0,
         modelContextLimit: undefined,
+        modelProviderID: undefined,
+        modelID: undefined,
         systemPromptTokens: undefined,
         qualityGateRetryPending: false,
     }
@@ -243,6 +245,8 @@ export function resetSessionState(state: SessionState): void {
     state.lastCompaction = 0
     state.currentTurn = 0
     state.modelContextLimit = undefined
+    state.modelProviderID = undefined
+    state.modelID = undefined
     state.systemPromptTokens = undefined
     state.qualityGateRetryPending = false
 }
@@ -336,6 +340,11 @@ export async function ensureSessionInitialized(
     }
     if (typeof persisted.modelContextLimit === "number" && persisted.modelContextLimit > 0) {
         state.modelContextLimit = persisted.modelContextLimit
+        // Restore the identity pair together with the limit (persisted as a
+        // pair in saveSessionState) so the messages-hook staleness check
+        // survives restarts. Invalid/absent limit → fresh undefined pair.
+        state.modelProviderID = persisted.modelProviderID
+        state.modelID = persisted.modelID
     }
 
     const applied = applyPendingCompressionDurations(state)

--- a/lib/state/types.ts
+++ b/lib/state/types.ts
@@ -143,6 +143,9 @@ export interface SessionState {
     lastCompaction: number
     currentTurn: number
     modelContextLimit: number | undefined
+    /** [FIX #312 follow-up] Identity of the model `modelContextLimit` was recorded for. Written together with the limit by the system hook; lets the messages hook detect a stale limit when the catalog misses. */
+    modelProviderID: string | undefined
+    modelID: string | undefined
     systemPromptTokens: number | undefined
     /**
      * Transient flag (NOT persisted): set to true when a compress call is rejected

--- a/tests/model-switch-limits.test.ts
+++ b/tests/model-switch-limits.test.ts
@@ -130,6 +130,7 @@ function createMockPrompts() {
                 iterationNudge: "iteration nudge",
                 manualExtension: "",
                 subagentExtension: "",
+                decompressExtension: "",
             }
         },
     }
@@ -154,6 +155,7 @@ async function runTransform(opts: {
     currentTokens: number
     modelId: string
     initialLimit: number
+    initialModel?: { providerID: string; modelID: string }
     catalog?: Array<[providerId: string, modelId: string, limit: number]>
 }): Promise<{ text: string; state: SessionState }> {
     const tempDir = mkdtempSync(join(tmpdir(), "acp-model-switch-"))
@@ -164,6 +166,13 @@ async function runTransform(opts: {
         const state = createSessionState()
         state.sessionId = SID
         state.modelContextLimit = opts.initialLimit
+        // Simulates the identity pair the system hook would have recorded
+        // alongside the limit; omitting it simulates a legacy persisted state
+        // (saved before the pair existed).
+        if (opts.initialModel) {
+            state.modelProviderID = opts.initialModel.providerID
+            state.modelID = opts.initialModel.modelID
+        }
 
         const registry = createTestRegistry(state)
         for (const [providerId, modelId, limit] of opts.catalog ?? []) {
@@ -213,18 +222,54 @@ test("model switch to larger window: 26% usage must NOT fire a 50% emergency nud
     assert.equal(state.nudges.lastNudgeShownTokens, undefined, "no nudge baseline recorded")
 })
 
-test("unknown model in catalog keeps previous limit (documents pre-fix path)", async () => {
-    // No catalog entry for the new model: reconciliation cannot run and the
-    // stale 200K limit computes a 100K threshold → 260K fires. This is exactly
-    // the issue #312 symptom and the fallback behavior when the catalog misses.
+test("catalog miss + model switch invalidates the stale limit (legacy state)", async () => {
+    // No catalog entry for the new model AND the state carries no identity
+    // pair (legacy persisted state): the messages hook cannot CORRECT the
+    // limit, so it invalidates it instead of computing a 100K threshold from
+    // the stale 200K window. The #312 false positive is eliminated even when
+    // the catalog misses; system.transform refreshes the pair later in this
+    // same request.
     const { text, state } = await runTransform({
         currentTokens: 260_000,
         modelId: NEW_MODEL,
         initialLimit: OLD_LIMIT,
     })
 
-    assert.equal(state.modelContextLimit, OLD_LIMIT)
-    assert.ok(text.includes("Context limit reached"), "stale-limit path still fires (bug symptom)")
+    assert.equal(state.modelContextLimit, undefined, "stale limit must be invalidated")
+    assert.equal(state.modelProviderID, PROVIDER)
+    assert.equal(state.modelID, NEW_MODEL)
+    assert.ok(!text.includes("Context limit reached"), "no emergency math against unknown window")
+})
+
+test("catalog miss + identity mismatch invalidates the stale limit", async () => {
+    // Same as above, but the state KNOWS its limit belongs to OLD_MODEL — the
+    // recorded-identity check (not the legacy heuristic) drives the fix.
+    const { text, state } = await runTransform({
+        currentTokens: 260_000,
+        modelId: NEW_MODEL,
+        initialLimit: OLD_LIMIT,
+        initialModel: { providerID: PROVIDER, modelID: OLD_MODEL },
+    })
+
+    assert.equal(state.modelContextLimit, undefined)
+    assert.equal(state.modelID, NEW_MODEL)
+    assert.ok(!text.includes("Context limit reached"))
+})
+
+test("catalog miss + same identity keeps the limit (no needless blindness)", async () => {
+    // Catalog misses but the request names the SAME model the limit was
+    // recorded for (e.g. fresh instance after failed hydration): the limit is
+    // still trusted — percentage math stays enabled instead of blinding
+    // every such turn. 260K on 200K = 130% ≥ 50% → emergency still fires.
+    const { text, state } = await runTransform({
+        currentTokens: 260_000,
+        modelId: OLD_MODEL,
+        initialLimit: OLD_LIMIT,
+        initialModel: { providerID: PROVIDER, modelID: OLD_MODEL },
+    })
+
+    assert.equal(state.modelContextLimit, OLD_LIMIT, "same-identity limit must be kept")
+    assert.ok(text.includes("Context limit reached"), "130% of 200K still fires the emergency")
 })
 
 test("model switch to smaller window: emergency fires when actually over threshold", async () => {
@@ -266,6 +311,30 @@ test("system.transform records model limit even when session state is absent", a
 
     assert.equal(registry.resolveModelLimit(PROVIDER, NEW_MODEL), NEW_LIMIT)
     assert.equal(registry.resolveModelLimit(PROVIDER, "other"), undefined)
+})
+
+test("system.transform records the model identity alongside the limit", async () => {
+    const state = createSessionState()
+    state.sessionId = SID
+    const registry = createTestRegistry(state)
+    const handler = createSystemPromptHandler(
+        registry,
+        new Logger(false),
+        buildConfig(),
+        createMockPrompts(),
+    )
+
+    await handler(
+        {
+            sessionID: SID,
+            model: { id: NEW_MODEL, providerID: PROVIDER, limit: { context: NEW_LIMIT } },
+        },
+        { system: ["base system prompt"] },
+    )
+
+    assert.equal(state.modelContextLimit, NEW_LIMIT)
+    assert.equal(state.modelProviderID, PROVIDER)
+    assert.equal(state.modelID, NEW_MODEL)
 })
 
 test("registry catalog ignores invalid entries and unknown lookups", () => {

--- a/tests/persistence.test.ts
+++ b/tests/persistence.test.ts
@@ -60,12 +60,18 @@ test("loadSessionState round-trips saved state", async () => {
     state.stats.totalPruneTokens = 999
     state.nudges.contextLimitAnchors.add("anchor-1")
     state.nudges.contextLimitAnchors.add("anchor-2")
+    state.modelContextLimit = 200_000
+    state.modelProviderID = "prov"
+    state.modelID = "model-1m"
 
     await saveSessionState(state, logger)
     const loaded = await loadSessionState(TEST_SESSION, logger)
 
     assert.ok(loaded, "loaded state should not be null")
     assert.equal(loaded!.stats.totalPruneTokens, 999)
+    assert.equal(loaded!.modelContextLimit, 200_000)
+    assert.equal(loaded!.modelProviderID, "prov")
+    assert.equal(loaded!.modelID, "model-1m")
     assert.ok(loaded!.nudges.contextLimitAnchors.includes("anchor-1"))
     assert.ok(loaded!.nudges.contextLimitAnchors.includes("anchor-2"))
     await cleanup()


### PR DESCRIPTION
## What

Completes the #314 fix (merged) with #313's fail-safe as the fallback path — the "ideal combined fix" from the review of both PRs.

## Background

Issue #312: after switching models (e.g. 200K → 1M), a 50% emergency-compression threshold fired at ~26% real usage, because `experimental.chat.messages.transform` fires **before** `system.transform` in one request, and only the system hook writes `state.modelContextLimit` — so the first request after a switch computes every percentage against the **previous** model's window.

- **#314 (merged)** fixes this by reconciling the limit from a `${providerID}/${modelID}` → limit catalog (seeded at init from `/config/providers`, recorded live by the system hook).
- **Remaining gap:** on a catalog **miss** (fresh instance + failed hydration + never-used model), the stale limit survived and the #312 false positive still reproduced.

## This PR

Records the identity pair (`modelProviderID` / `modelID`) alongside the limit whenever the system hook writes it, persisted and restored together. On a catalog miss the messages hook now compares the request's model against that identity:

| catalog miss + | behavior |
|---|---|
| identity **match** | keep the limit — no needless blindness when the catalog simply lacks an entry for the *current* model |
| identity **mismatch** | invalidate (`limit = undefined`) — #313's fail-safe: never run percentage math against the wrong window |
| legacy state (no identity persisted) | treated as stale — one blind turn per upgraded session, same trade-off #313 accepted |

`undefined` is already the natural fresh-session state (before the first `system.transform`), so all consumers (nudges, GC, batch-cleanup, adaptive growth) tolerate it by construction. The same request's `system.transform` refreshes the pair right after, so the blind window is a single turn at most.

## Supersedes

- Closes #313 (its unconditional-invalidation approach is fully covered by the fallback path here; its tests are re-expressed in `tests/model-switch-limits.test.ts`).

## Changes

- `lib/state/types.ts` — `SessionState.modelProviderID/modelID` (optional, persisted)
- `lib/state/state.ts` — init/reset/load keep the pair atomic with the limit
- `lib/state/persistence.ts` — serialize/restore the pair
- `lib/hooks.ts` — system hook records identity; messages hook: catalog hit → correct + record identity; miss + mismatch → invalidate
- tests — legacy-state invalidation, identity-mismatch invalidation, same-identity keep (emergency still fires at 130% of the real window), system-hook identity recording, persistence round-trip

## Verification

- `tsc --noEmit` clean
- **991/991** tests pass (was 988; net +3)
- prettier-clean on all touched hunks (pre-existing format dirt elsewhere left untouched)