### PR TITLE
release: v1.14.21 — /acp command fixes and completion (permission gate, export, help)

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,21 @@ For the complete list with root cause analysis, see the [bug tracker](https://gi
 
 ## Changelog
 
+### v1.14.21 — /acp command fixes and completion (permission gate, export, help) (#286)
+
+**Problem**: Three gaps in the `/acp` command suite: (1) when the compress permission was `deny`, ALL `/acp` subcommands were silently swallowed (the gate is a pre-#233 leftover from when `/acp` triggered compression; every current subcommand is read-only or user-initiated); (2) bare `/acp` showed behavior inconsistent with the README and diverged from pi-acp (whose bare `/acp` shows the status report, same handler as `/acp-status`); (3) the requested `/acp export` command (#265) was unimplemented.
+
+**Fix**:
+- Removed the compress-permission `deny` gate from the command handler — `/acp` subcommands (context/stats/export) work regardless of compress permission; they are all read-only or user-initiated file writes.
+- Bare `/acp` (and `/dcp`) now shows the compression status report (same as `/acp stats`), aligned with pi-acp; `/acp help` shows the command list.
+- New `/acp export`: exports active compression blocks to markdown (`--output <path>`, `--tier t1,t2,t3`, `--stdout`, `--append`).
+
+Files: `lib/hooks.ts`, `lib/commands/export.ts`, `AGENTS.md`, `README.md`, `README.zh-CN.md`. Tests: `tests/hooks-permission.test.ts` updated.
+
+Closes: #285, #265.
+
+**Install**: `opencode plugin opencode-acp@latest --global`
+
 ### v1.14.20 — Post-v1.14.19 fix batch (modelContextLimit lifecycle, inactive-block decompress, logging)
 
 **Problem**: Five clusters of post-v1.14.19 issues: (1) `modelContextLimit` stayed stale after a model switch (#312) — within one LLM request the messages hook runs before the system hook refreshes the limit, and on a catalog miss (fresh instance + failed hydration) the previous model's window survived, so every percentage threshold misfired (#315); (2) `decompress` failed on standalone inactive blocks and inactive blocks were invisible in `acp_status` (#193); (3) a preemptive `acknowledgeRisk: true` (carried over from a non-quality error) hard-failed with "no quality gate rejection is pending" (#301); (4) debug nudge notifications used `sendIgnoredMessage` causing phantom turns, the debug recommendation-filter log spammed every turn, and ERROR/WARN lines only reached the daily log when debug was on (#311, #278, #279).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -444,6 +444,21 @@ ACP 是 DCP 的直接替代品。迁移步骤：
 
 ## 更新日志
 
+### v1.14.21 — /acp 命令修复与补全（权限门、export、help）(#286)
+
+**问题**：`/acp` 命令族的三个缺口：（1）压缩权限为 `deny` 时，**所有** `/acp` 子命令被静默吞掉（该门是 #233 之前 `/acp` 会触发压缩的残留；现在的子命令全是只读或用户发起的）；（2）无参 `/acp` 行为与 README 描述不一致，且与 pi-acp 不对齐（pi-acp 无参 `/acp` 显示状态报告，与 `/acp-status` 同一 handler）；（3）需求 `/acp export` 导出命令（#265）未实现。
+
+**修复**：
+- 从命令处理器移除压缩权限 `deny` 门——`/acp` 子命令（context/stats/export）现在无论压缩权限如何都能用，它们全部只读或用户发起的文件写入。
+- 无参 `/acp`（和 `/dcp`）现在显示压缩状态报告（同 `/acp stats`），对齐 pi-acp；`/acp help` 显示命令列表。
+- 新增 `/acp export`：将 active 压缩块导出为 markdown（`--output <path>`、`--tier t1,t2,t3`、`--stdout`、`--append`）。
+
+文件：`lib/hooks.ts`、`lib/commands/export.ts`、`AGENTS.md`、`README.md`、`README.zh-CN.md`。测试：`tests/hooks-permission.test.ts` 更新。
+
+关闭：#285、#265。
+
+**安装**：`opencode plugin opencode-acp@latest --global`
+
 ### v1.14.20 — v1.14.19 之后的修复批次（modelContextLimit 生命周期、inactive block 解压缩、日志）
 
 **问题**：五类 v1.14.19 之后发现的问题：（1）`modelContextLimit` 在模型切换后失效（#312）——同一次 LLM 请求内，messages hook 先于 system hook 刷新窗口值，而目录未命中时（新实例 + 水合失败），上一个模型的窗口值会一直残留，导致所有按百分比计算的阈值误触发（#315）；（2）`decompress` 对独立的 inactive block 报 `Block not found`，且 inactive block 在 `acp_status` 里完全不可见（#193）；（3）预防式 `acknowledgeRisk: true`（从非质量门禁错误里带过来的）直接报错 `no quality gate rejection is pending`（#301）；（4）debug nudge 通知用 `sendIgnoredMessage` 触发幽灵回合（#311），debug 推荐过滤日志每回合刷屏，ERROR/WARN 在 debug 关闭时不进日常日志（#311、#278、#279）。

--- a/devlog/2026-08-17_release-v1.14.21/REQ.md
+++ b/devlog/2026-08-17_release-v1.14.21/REQ.md
@@ -1,0 +1,24 @@
+# REQ — v1.14.21: /acp command fixes and completion (permission gate, export, help)
+
+## Problem
+
+Single-PR release shipping #286 (merged as `c230d6e`), which fixed three gaps in the `/acp` command suite:
+
+1. **All `/acp` subcommands swallowed when compress permission = `deny`.** The command handler carried a pre-#233 `deny` gate from the era when `/acp` triggered compression. Every current subcommand (`context`, `stats`, `export`) is read-only or user-initiated, so the gate only broke legitimate usage (reported in #285 alongside the bare-command behavior mismatch).
+2. **Bare `/acp` diverged from pi-acp and from the README.** pi-acp's bare `/acp` shows the full compression status report (same handler as `/acp-status`); opencode-acp showed help text.
+3. **`/acp export` (#265) unimplemented** — no way to export compression blocks out of the session.
+
+## Fix (all in #286)
+
+- Removed the compress-permission `deny` gate from `createCommandExecuteHandler` (`lib/hooks.ts`).
+- Bare `/acp` / `/dcp` now dispatches to `handleStatsCommand` (same report as `acp_status` tool); `/acp help` shows the command list.
+- New `/acp export` (`lib/commands/export.ts`, ~430 lines): exports active compression blocks to markdown with `--output <path>`, `--tier t1,t2,t3`, `--stdout`, `--append`.
+
+Closes: #285, #265.
+
+## Acceptance
+
+- All existing tests pass
+- Release commit touches only `package.json` + lock; changelog + devlog on the release branch
+- `./scripts/ci/check-pr.sh` green
+- release.yml publishes v1.14.21 to npm `latest` after merge

--- a/devlog/2026-08-17_release-v1.14.21/WORKLOG.md
+++ b/devlog/2026-08-17_release-v1.14.21/WORKLOG.md
@@ -1,0 +1,20 @@
+# WORKLOG — v1.14.21
+
+## Commits on this release (1 fix commit since v1.14.20)
+
+1. `c230d6e` fix: /acp commands work regardless of compress permission + wire up export + help (#286)
+   - squash of the #286 PR (permission gate removal + `/acp export` + bare `/acp`→stats + `/acp help`)
+   - rebase follow-up: restored `sendIgnoredMessage` import after rebasing onto post-#278 master (v1.14.20)
+
+## Release steps
+
+- `npm version 1.14.21 --no-git-tag-version` (bump `package.json` + `package-lock.json`)
+- Changelog `### v1.14.21` entries added to `README.md` and `README.zh-CN.md`
+- Devlog: this folder (REQ.md + WORKLOG.md)
+- Commit `release: v1.14.21 — /acp command fixes and completion (permission gate, export, help)`
+
+## Verification
+
+- `npm test` — full suite green (see run below)
+- `./scripts/ci/check-pr.sh 2026-08-17_release-v1.14.21 origin/master` — green
+- release.yml publishes v1.14.21 to npm `latest` after merge

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-acp",
-    "version": "1.14.20",
+    "version": "1.14.21",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-acp",
-            "version": "1.14.20",
+            "version": "1.14.21",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.20",
+    "version": "1.14.21",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
Ships #286 (merged as c230d6e).

## What's in this release

- **/acp subcommands work regardless of compress permission** — the pre-#233 deny gate silently swallowed all /acp commands when compress was denied; removed (all subcommands are read-only or user-initiated).
- **Bare /acp shows compression status** (same as /acp stats), aligned with pi-acp; /acp help shows the command list.
- **New /acp export** — exports active compression blocks to markdown (--output, --tier, --stdout, --append).

Closes: #285, #265.

## Verification

- npm test: 1003/1003 pass
- ./scripts/ci/check-pr.sh: all checks passed
- Release branch: version bump + changelog (en/zh) + devlog only, per AGENTS.md §5.4.2