### PR TITLE
fix: stabilize system prompt token estimate (#255)

### DIFF
--- a/devlog/2026-08-18_fix-system-prompt-tokens/DESIGN.md
+++ b/devlog/2026-08-18_fix-system-prompt-tokens/DESIGN.md
@@ -1,0 +1,114 @@
+# DESIGN - Stabilize system prompt token estimate (#255)
+
+- Task ID: `2026-08-18_fix-system-prompt-tokens`
+- Home Repo: `opencode-acp`
+- Created: 2026-08-18
+- Status: Accepted
+
+## 1. Problem Statement
+
+- **What problem are we solving?** After ACP compression removes the true first
+  assistant message from visible history, nudge and `acp_status` re-derive the
+  system prompt token estimate from the _first visible assistant_ — a much later
+  turn whose `input` includes large accumulated history. Both inflate the
+  estimate, and because each consumer sees a different message view (post-prune
+  transform array vs. fresh store fetch), the two numbers diverge.
+- **Why now?** Issue #255. The `SessionState.systemPromptTokens` field and its
+  writer (`cacheSystemPromptTokens`) already exist but have no readers — the
+  missing link is wiring consumers to the cache.
+
+## 2. Goals & Non-Goals
+
+- **Goals**:
+    - nudge and `acp_status` use the same stable system prompt token estimate
+      after compression changes visible messages.
+    - Preserve existing behavior exactly when no cache exists (`undefined`).
+- **Non-Goals** (per human review of the investigation phase):
+    - No persistence of `systemPromptTokens` (survives only in-session).
+    - No model/provider identity invalidation.
+    - No `/acp context` changes.
+    - No refactor of `lib/token-utils.ts`; `estimateSystemPromptTokens()` public
+      semantics unchanged.
+
+## 3. Current Architecture
+
+**How it works today:**
+
+```
+estimateSystemPromptTokens(messages)   # token-utils.ts
+  ↑ 现算 ×4（互不共享）
+nudge:    injectCompressNudges → estimateContextComposition → estimateSystemPromptTokens(messages)
+acp_status: collectVisibleMessages → estimateSystemPromptTokens(rawMessages)
+/acp stats: buildStatusReport（同 acp_status）
+/acp context: analyzeTokens（内联实现）
+
+cacheSystemPromptTokens(state, output.messages)  # hooks.ts:233，prune 前，每轮写入
+  → state.systemPromptTokens（存在，但无人读取）
+```
+
+**Pain points:**
+
+- nudge runs after `prune` (hooks.ts:253 > 247); `filterCompressedRanges`
+  physically removes compressed messages from the array → first visible
+  assistant is a late turn → inflated estimate.
+- `acp_status` fetches fresh from the store → different view → inconsistent
+  numbers.
+
+## 4. Proposed Architecture
+
+**Overview (text diagram):**
+
+```
+pre-prune transform  (hooks.ts:233)
+  → cacheSystemPromptTokens(state, output.messages)
+      → state.systemPromptTokens  ← write-if-undefined（首测后不再覆盖）
+        ↓
+nudge  estimateContextComposition → state?.systemPromptTokens ?? 现算
+acp_status  collectVisibleMessages → ctx.state.systemPromptTokens ?? 现算
+undefined 时：fallback 到 estimateSystemPromptTokens(messages)（旧行为）
+```
+
+**Key components:**
+
+- `lib/ui/utils.ts` — `cacheSystemPromptTokens`: write-if-undefined guard.
+- `lib/messages/inject/utils.ts` — `estimateContextComposition`: prefer cache.
+- `lib/compress/status.ts` — `collectVisibleMessages`: prefer cache.
+
+**Data flow:** pre-prune cache → `SessionState.systemPromptTokens` → both
+consumers → `undefined` fallback to old estimate.
+
+**API / interface changes:** none (fields/functions already exist).
+
+## 5. Design Decisions & Rationale
+
+| Decision                    | Options Considered                                               | Chosen             | Why                                                                                                                                         |
+| --------------------------- | ---------------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cache source                | first measurement wins (write-if-undefined) vs. always overwrite | write-if-undefined | After compression the array is degraded; overwriting would corrupt the stable value. `undefined` stays `undefined` (never cache undefined). |
+| Reader fallback             | hard-require cache vs. `?? estimateSystemPromptTokens`           | `??` fallback      | Backward compat: old/restart states lack the field; behavior identical to pre-fix master when `undefined`.                                  |
+| Persistence                 | persist vs. in-session only                                      | in-session only    | Per human scope decision; a restart re-measures on first pre-prune transform. Known limitation (see §8).                                    |
+| Model identity invalidation | add vs. skip                                                     | skip               | Per human scope decision; no evidence of mid-session model-switch churn; would expand blast radius.                                         |
+| `/acp context`              | unify vs. leave                                                  | leave              | Separate surface; not required to satisfy #255. Would be scope expansion.                                                                   |
+
+## 6. Impact Analysis
+
+- **Backward compatibility:** full — optional field, `undefined` fallback keeps
+  old behavior byte-for-byte.
+- **Performance:** cache read is O(1); saves the existing per-consumer estimate
+  work in the common (cached) path.
+- **Security:** none.
+- **Dependencies:** none.
+
+## 7. Migration Plan
+
+- **Steps:** not applicable — no persisted state changes, no config changes.
+- **Feature flags:** none.
+
+## 8. Open Questions / Known Limitations
+
+- Plugin restart: cache is re-measured on the first pre-prune transform. If
+  OpenCode compaction has already dropped the true first assistant from the
+  store, the re-measured value is degraded — out of scope for #255 (would need
+  persistence).
+- AGENTS.md / project instruction changes mid-session do not actively invalidate
+  the cache — out of scope for #255 (would need model-identity or file-watch
+  invalidation).

--- a/devlog/2026-08-18_fix-system-prompt-tokens/REQ.md
+++ b/devlog/2026-08-18_fix-system-prompt-tokens/REQ.md
@@ -3,7 +3,7 @@
 - Task ID: `2026-08-18_fix-system-prompt-tokens`
 - Home Repo: `opencode-acp`
 - Created: 2026-08-18
-- Status: InProgress
+- Status: Done
 - Priority: P1
 - Owner: beatrice
 - References: Issue #255

--- a/devlog/2026-08-18_fix-system-prompt-tokens/REQ.md
+++ b/devlog/2026-08-18_fix-system-prompt-tokens/REQ.md
@@ -1,0 +1,91 @@
+# REQ - Stabilize system prompt token estimate (#255)
+
+- Task ID: `2026-08-18_fix-system-prompt-tokens`
+- Home Repo: `opencode-acp`
+- Created: 2026-08-18
+- Status: InProgress
+- Priority: P1
+- Owner: beatrice
+- References: Issue #255
+
+## 1. Background & Problem Statement
+
+- **Context**: `estimateSystemPromptTokens()` (`lib/token-utils.ts`) derives the
+  system prompt token estimate from the _first visible assistant message_ with
+  token data (`tokens.input + cache.read + cache.write` minus first user text).
+  After ACP compression, `prune()` (`lib/messages/prune.ts:52-90`,
+  `filterCompressedRanges`) physically removes compressed messages from the
+  transform array. The first visible assistant then belongs to a much later
+  turn, whose `input` includes a large accumulated history — inflating the
+  system prompt estimate to roughly the size of the whole context.
+- **Current behavior (symptom)**: nudge (`estimateContextComposition` in
+  `lib/messages/inject/utils.ts:565`) and `acp_status`
+  (`lib/compress/status.ts:175`) each re-derive the system estimate from their
+  own message views (post-prune transform array vs. fresh store fetch), so the
+  two numbers diverge and both can be wildly overestimated.
+- **Expected behavior**: once a reliable positive `state.systemPromptTokens` has
+  been measured (before compression removed the true first assistant), nudge and
+  `acp_status` both use that stable cached value; later compression/compaction
+  of visible messages must not overwrite or invalidate it.
+- **Impact**: wrong system prompt numbers mislead both the model (nudge
+  breakdown, compressibleTokens = total − systemTokens − ...) and the user
+  (`acp_status` breakdown).
+
+## 2. Reproduction (if applicable)
+
+- **Environment**:
+    - Node: 22+
+    - OS/Arch: linux-x64
+- **Minimal reproduction steps**:
+    1. Session with first assistant input ≈ `system + first user` (system ≈ 10_000).
+    2. ACP compression removes the first assistant from visible messages.
+    3. First _visible_ assistant input ≈ `system + large history` (≈ 200_000).
+    4. nudge `estimateContextComposition` reports system ≈ 200_000 while the
+       cached `state.systemPromptTokens` is 10_000.
+- **Relevant configuration**: default ACP config.
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+    - Backward compatibility: `state.systemPromptTokens` may be `undefined`;
+      all readers must fall back to the existing
+      `estimateSystemPromptTokens(messages)` behavior unchanged.
+    - Performance requirements: no new per-turn computation; reuse the cache.
+    - Resource limits: none.
+- **Non-Goals** (explicitly out of scope, per human review of prior
+  investigation):
+    - No persistence changes (`PersistedSessionState` / save/load stay untouched).
+    - No model/provider identity invalidation.
+    - No `/acp context` changes (separate surface; not required to satisfy #255).
+    - No `lib/token-utils.ts` refactor; `estimateSystemPromptTokens()` public
+      semantics unchanged.
+    - No `package.json` version change.
+
+## 4. Acceptance Criteria (must be testable)
+
+- **Correctness**:
+    - [x] `cacheSystemPromptTokens()`: once `state.systemPromptTokens` holds a
+          positive value, subsequent calls with a degraded messages array (first
+          visible assistant input ≈ 200_000) must NOT overwrite it (stays 10_000).
+    - [x] `estimateContextComposition()`: with `state.systemPromptTokens = 10_000`
+          and a degraded messages array, `composition.systemTokens === 10_000`
+          (not ≈ 200_000).
+    - [x] `acp_status` uses the same cached value (if test structure allows).
+- **Performance / Stability**: no new per-turn work; cache read is O(1).
+- **Regression**:
+    - [x] New/modified test cases added to test suite and passing
+          (`tests/inject-utils-pure.test.ts` + cache overwrite regression).
+
+## 5. Proposed Approach (optional)
+
+- **Affected modules & entry files**:
+    - `lib/ui/utils.ts` — `cacheSystemPromptTokens`: write-if-undefined guard.
+    - `lib/messages/inject/utils.ts` — `estimateContextComposition`: prefer
+      `state?.systemPromptTokens` over fresh estimate.
+    - `lib/compress/status.ts` — `collectVisibleMessages`: prefer
+      `ctx.state.systemPromptTokens` over fresh estimate.
+    - `tests/inject-utils-pure.test.ts` — regression tests.
+- **Risks**: low — readers only prefer the cache when it is a positive number;
+  `undefined` preserves current behavior exactly.
+- **Rollback strategy**: revert the three file changes; tests would then fail
+  (proving they target the fix).

--- a/devlog/2026-08-18_fix-system-prompt-tokens/WORKLOG.md
+++ b/devlog/2026-08-18_fix-system-prompt-tokens/WORKLOG.md
@@ -1,0 +1,50 @@
+# WORKLOG - Stabilize system prompt token estimate (#255)
+
+## Changes
+
+1. `lib/ui/utils.ts` — `cacheSystemPromptTokens`: added write-if-undefined
+   guard. Once `state.systemPromptTokens` holds a stable positive value, later
+   transforms never overwrite it — after compression/compaction the first
+   visible assistant's input includes large history, which would inflate the
+   estimate. `undefined` stays `undefined` when no reliable assistant token data
+   is present.
+
+2. `lib/messages/inject/utils.ts` — `estimateContextComposition`: `systemTokens`
+   now prefers `state?.systemPromptTokens` (when positive); falls back to
+   `estimateSystemPromptTokens(messages)` when undefined — old behavior
+   preserved.
+
+3. `lib/compress/status.ts` — `collectVisibleMessages`: `systemTokens` now
+   prefers `ctx.state.systemPromptTokens` (when positive); falls back to
+   `estimateSystemPromptTokens(rawMessages)` when undefined.
+
+4. Tests:
+    - `tests/inject-utils-pure.test.ts` — 5 new tests: cached-value preference,
+      undefined-cache fallback, cache-overwrite protection, initial write,
+      keep-undefined-when-no-data.
+    - `tests/acp-status.test.ts` — 1 new test: overview breakdown uses cached
+      value instead of re-estimating from degraded visible messages.
+
+## Test Results (pre-fix verification)
+
+The 3 bug-targeting tests were confirmed FAILING on unmodified master before
+the fix (e.g. `199996 !== 10000`), proving they capture the #255 regression.
+
+- 44 tests in inject-utils-pure.test.ts (2 new failing pre-fix)
+- 24 tests in acp-status.test.ts (1 new failing pre-fix)
+
+## Test Results (post-fix)
+
+- typecheck: pass (`tsc --noEmit`, exit 0)
+- build: pass (tsup success)
+- test: 1009 pass / 0 fail (full suite, `npm run test`)
+
+## Scope Notes
+
+Per human review of the investigation phase, this PR is intentionally minimal:
+
+- No persistence changes (`PersistedSessionState` / save / load untouched).
+- No model/provider identity invalidation.
+- No `/acp context` changes.
+- `estimateSystemPromptTokens()` public semantics unchanged.
+- `package.json` version unchanged.

--- a/devlog/2026-08-18_fix-system-prompt-tokens/WORKLOG.md
+++ b/devlog/2026-08-18_fix-system-prompt-tokens/WORKLOG.md
@@ -18,26 +18,55 @@
    prefers `ctx.state.systemPromptTokens` (when positive); falls back to
    `estimateSystemPromptTokens(rawMessages)` when undefined.
 
-4. Tests:
+4. Tests (unit):
     - `tests/inject-utils-pure.test.ts` — 5 new tests: cached-value preference,
       undefined-cache fallback, cache-overwrite protection, initial write,
       keep-undefined-when-no-data.
     - `tests/acp-status.test.ts` — 1 new test: overview breakdown uses cached
       value instead of re-estimating from degraded visible messages.
+    - `tests/inject.test.ts` — 1 new §5.7-compliant multi-turn growth-cycle test
+      (4 turns: baseline → growth → nudge → compress → new baseline → growth →
+      nudge) with `preserveRecentMessages = 20` (production default),
+      side-effect assertions (`shouldInjectThisTurn` + `lastPerMessageNudgeTokens`
+      after every turn), and #255 assertions (cached system value survives
+      degraded post-compression arrays).
+
+5. E2E infrastructure (`scripts/e2e/`, test-only — not production):
+    - `fake-llm-server.ts` — observation now records `nudgeSystemTokens` parsed
+      from the nudge breakdown text (`Breakdown: N system`).
+    - `verify.ts` — new `nudgeSystemTokensStable` assertion: all nudge
+      observations must report the same system estimate (requires ≥2 nudge
+      observations).
+    - `scenarios/10-autonomous-nudge-refire.json` — added
+      `nudgeSystemTokensStable: true` (extended existing scenario; scenario 10
+      already exercises multi-turn nudge→compress→growth→re-nudge with ≥2 nudge
+      observations).
 
 ## Test Results (pre-fix verification)
 
-The 3 bug-targeting tests were confirmed FAILING on unmodified master before
-the fix (e.g. `199996 !== 10000`), proving they capture the #255 regression.
+The bug-targeting tests were confirmed FAILING on unmodified production code
+before the fix:
 
-- 44 tests in inject-utils-pure.test.ts (2 new failing pre-fix)
-- 24 tests in acp-status.test.ts (1 new failing pre-fix)
+- `estimateContextComposition: prefers cached...` — FAIL (199996 !== 10000)
+- `cacheSystemPromptTokens: does not overwrite...` — FAIL (199996 !== 10000)
+- `acp_status: overview prefers cached...` — FAIL
+- §5.7 multi-turn cycle test — FAIL under reverted production fix
+- E2E scenario 10 with `nudgeSystemTokensStable` — FAIL under reverted fix
+  (observed system values `[18200, 18700]` diverged after compression)
+
+All confirmed via `git show 09bf2b8 -- lib/ | git apply -R` + test run + `git
+apply` restore. No temporary reverts committed.
 
 ## Test Results (post-fix)
 
 - typecheck: pass (`tsc --noEmit`, exit 0)
 - build: pass (tsup success)
-- test: 1009 pass / 0 fail (full suite, `npm run test`)
+- test: 1009 + 1 new = 1010 pass / 0 fail (full suite, `npm run test`)
+- Docker E2E: all 12 scenarios pass (`SKIP_BUILD=1 ./scripts/e2e/run-e2e.sh`),
+  including scenario 10 with the new `nudgeSystemTokensStable` assertion
+- Live OpenCode smoke test: plugin loads, ACP state file written, no
+  ACP-related errors (the only observed errors were opencode→model-gateway TLS
+  certificate failures, unrelated to ACP)
 
 ## Scope Notes
 
@@ -48,3 +77,5 @@ Per human review of the investigation phase, this PR is intentionally minimal:
 - No `/acp context` changes.
 - `estimateSystemPromptTokens()` public semantics unchanged.
 - `package.json` version unchanged.
+- Production changes are 3 small source edits; test/E2E additions are scoped to
+  verification of the fix.

--- a/lib/compress/status.ts
+++ b/lib/compress/status.ts
@@ -172,7 +172,14 @@ function collectVisibleMessages(
         }
     })
 
-    return { messages: result, summaryTokens, systemTokens: estimateSystemPromptTokens(rawMessages) }
+    return {
+        messages: result,
+        summaryTokens,
+        systemTokens:
+            ctx.state.systemPromptTokens !== undefined && ctx.state.systemPromptTokens > 0
+                ? ctx.state.systemPromptTokens
+                : estimateSystemPromptTokens(rawMessages),
+    }
 }
 
 function renderOverview(

--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -562,7 +562,10 @@ export function estimateContextComposition(
         .map(([tool, tokens]) => ({ tool, tokens }))
         .sort((a, b) => b.tokens - a.tokens)
 
-    const systemTokens = estimateSystemPromptTokens(messages)
+    const systemTokens =
+        state?.systemPromptTokens !== undefined && state.systemPromptTokens > 0
+            ? state.systemPromptTokens
+            : estimateSystemPromptTokens(messages)
 
     return {
         toolTokens,

--- a/lib/ui/utils.ts
+++ b/lib/ui/utils.ts
@@ -54,6 +54,13 @@ export function formatProgressBar(
 }
 
 export function cacheSystemPromptTokens(state: SessionState, messages: WithParts[]): void {
+    // [FIX #255] Never overwrite a stable positive cache - after compression
+    // the first visible assistant's input includes large history, inflating
+    // the estimate.
+    if (state.systemPromptTokens !== undefined && state.systemPromptTokens > 0) {
+        return
+    }
+
     let firstInputTokens = 0
     for (const msg of messages) {
         if (msg.info.role !== "assistant") {

--- a/scripts/e2e/fake-llm-server.ts
+++ b/scripts/e2e/fake-llm-server.ts
@@ -82,6 +82,7 @@ export interface RequestObservation {
     /** Count of `compress` tool_use calls visible to the LLM in this request */
     compressCallCount: number
     nudgeDetected: boolean
+    nudgeSystemTokens?: number
     isChild: boolean
     isAuxiliary: boolean
 }
@@ -100,10 +101,11 @@ function recordObservation(
     messageCount: number,
     compressCallCount: number,
     nudgeDetected: boolean,
+    nudgeSystemTokens: number | undefined,
     isChild: boolean,
     isAuxiliary: boolean,
 ): void {
-    observations.requests.push({ turn, inputTokens, messageCount, compressCallCount, nudgeDetected, isChild, isAuxiliary })
+    observations.requests.push({ turn, inputTokens, messageCount, compressCallCount, nudgeDetected, nudgeSystemTokens, isChild, isAuxiliary })
     try {
         writeFileSync(OBSERVATIONS_FILE, JSON.stringify(observations, null, 2))
     } catch {
@@ -199,7 +201,7 @@ async function handleChatCompletion(req: Request): Promise<Response> {
 
     const isAuxiliary = tools.length === 0
 
-    recordObservation(readTurnCounter(), inputTokens, messages.length, compressCallCount, nudgeDetected, isChild, isAuxiliary)
+    recordObservation(readTurnCounter(), inputTokens, messages.length, compressCallCount, nudgeDetected, extractNudgeSystemTokens(messages), isChild, isAuxiliary)
 
     log(
         `  body: stream=${isStream} msgs=${messages.length} ` +
@@ -377,6 +379,22 @@ function detectNudge(messages: any[]): boolean {
         }
     }
     return false
+}
+
+function extractNudgeSystemTokens(messages: any[]): number | undefined {
+    const breakdownRe = /Breakdown: ([0-9.]+)K? system/
+    for (const msg of messages) {
+        if (msg?.role === "user") {
+            const text = extractMessageText(msg)
+            const match = text.match(breakdownRe)
+            if (match) {
+                const value = parseFloat(match[1])
+                const kilo = text.includes(`${match[1]}K system`)
+                return kilo ? Math.round(value * 1000) : Math.round(value)
+            }
+        }
+    }
+    return undefined
 }
 
 function handleNudgeCompressStep(

--- a/scripts/e2e/scenarios/10-autonomous-nudge-refire.json
+++ b/scripts/e2e/scenarios/10-autonomous-nudge-refire.json
@@ -1,6 +1,6 @@
 {
     "name": "autonomous-nudge-refire",
-    "description": "Issue #176 regression: Autonomous session (single user message, bash tool calls grow context). Tests that after first nudge\u2192compress, continued growth triggers a SECOND nudge\u2192compress. Before fix: nudge permanently stuck after first compress. After fix: second nudge fires and second compress succeeds.",
+    "description": "Issue #176 regression: Autonomous session (single user message, bash tool calls grow context). Tests that after first nudge→compress, continued growth triggers a SECOND nudge→compress. Before fix: nudge permanently stuck after first compress. After fix: second nudge fires and second compress succeeds.",
     "acpConfig": {
         "compress": {
             "minCompressRange": 0,

--- a/scripts/e2e/scenarios/10-autonomous-nudge-refire.json
+++ b/scripts/e2e/scenarios/10-autonomous-nudge-refire.json
@@ -1,6 +1,6 @@
 {
     "name": "autonomous-nudge-refire",
-    "description": "Issue #176 regression: Autonomous session (single user message, bash tool calls grow context). Tests that after first nudge→compress, continued growth triggers a SECOND nudge→compress. Before fix: nudge permanently stuck after first compress. After fix: second nudge fires and second compress succeeds.",
+    "description": "Issue #176 regression: Autonomous session (single user message, bash tool calls grow context). Tests that after first nudge\u2192compress, continued growth triggers a SECOND nudge\u2192compress. Before fix: nudge permanently stuck after first compress. After fix: second nudge fires and second compress succeeds.",
     "acpConfig": {
         "compress": {
             "minCompressRange": 0,
@@ -28,6 +28,7 @@
         "maxBlockCount": 5,
         "nudgeBaselineSet": true,
         "maxCompressCallsVisible": 2,
-        "maxNudgeCount": 10
+        "maxNudgeCount": 10,
+        "nudgeSystemTokensStable": true
     }
 }

--- a/scripts/e2e/verify.ts
+++ b/scripts/e2e/verify.ts
@@ -18,6 +18,7 @@ interface VerifyExpectations {
     maxCompressCallsVisible?: number
     lastRequestCompressCalls?: number
     maxNudgeCount?: number
+    nudgeSystemTokensStable?: boolean
 }
 
 interface VerifyScenario {
@@ -32,6 +33,7 @@ interface RequestObservation {
     nudgeDetected: boolean
     isChild: boolean
     isAuxiliary: boolean
+    nudgeSystemTokens?: number
 }
 
 const statePath = process.argv[2]

--- a/scripts/e2e/verify.ts
+++ b/scripts/e2e/verify.ts
@@ -288,6 +288,17 @@ if (expect.maxNudgeCount !== undefined) {
     )
 }
 
+if (expect.nudgeSystemTokensStable) {
+    const systemValues = parentObs
+        .filter((o) => o.nudgeDetected && o.nudgeSystemTokens !== undefined)
+        .map((o) => o.nudgeSystemTokens)
+    assert(
+        `nudgeSystemTokensStable: all ${systemValues.length} nudge observations report the same system prompt estimate`,
+        systemValues.length >= 2 && new Set(systemValues).size === 1,
+        `got ${JSON.stringify(systemValues)} — compression changed visible history, so system was re-estimated from a later assistant`,
+    )
+}
+
 console.log()
 if (failed > 0) {
     console.error(`FAIL: ${failed} assertion(s) failed, ${passed} passed`)

--- a/tests/acp-status.test.ts
+++ b/tests/acp-status.test.ts
@@ -409,3 +409,33 @@ test("acp_status: overview (no scope) excludes inactive blocks from count and to
     assert.doesNotMatch(result, /2 active/)
     assert.doesNotMatch(result, /"dead"/)
 })
+
+test("acp_status: overview prefers cached systemPromptTokens over degraded visible messages (#255)", async () => {
+    const mockMsgs = [
+        {
+            info: {
+                id: "raw-later",
+                role: "assistant",
+                tokens: { input: 200_000, output: 100, cache: { read: 0, write: 0 } },
+            },
+            parts: [{ type: "text", text: "ok" }],
+        },
+    ]
+    const mockClient = makeMockClient(mockMsgs)
+    const state = makeState([], new Map())
+    state.systemPromptTokens = 10_000
+    const ctx: ToolFactoryContext = {
+        client: mockClient,
+        registry: singletonRegistry(state),
+        logger: { enabled: false } as any,
+        config: {} as any,
+        prompts: { reload: () => {} } as any,
+    }
+    const statusTool = createAcpStatusTool(ctx)
+    const result = await statusTool.execute({} as any, { sessionID: SID } as any)
+
+    assert.match(result, /CONTEXT BREAKDOWN/)
+    assert.match(result, /10\.0K system/)
+    assert.doesNotMatch(result, /200\.0K system/)
+})
+

--- a/tests/acp-status.test.ts
+++ b/tests/acp-status.test.ts
@@ -438,4 +438,3 @@ test("acp_status: overview prefers cached systemPromptTokens over degraded visib
     assert.match(result, /10\.0K system/)
     assert.doesNotMatch(result, /200\.0K system/)
 })
-

--- a/tests/inject-utils-pure.test.ts
+++ b/tests/inject-utils-pure.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 import { computeShouldNudge, resolveAdaptiveNudgeGrowth, estimateContextComposition } from "../lib/messages/inject/utils"
+import { cacheSystemPromptTokens } from "../lib/ui/utils"
 import { estimateSystemPromptTokens } from "../lib/token-utils"
 import { countTokens } from "../lib/token-utils"
 import type { WithParts } from "../lib/state"
@@ -447,3 +448,71 @@ test("estimateContextComposition: non-compress tools unaffected by summary class
     assert.ok(c.toolTokens > 0)
     assert.equal(c.total, c.toolTokens)
 })
+
+test("estimateContextComposition: prefers cached state.systemPromptTokens over degraded estimate (#255)", () => {
+    const userText = "later turn user message"
+    const messages = [
+        {
+            info: { id: "u2", role: "user" } as any,
+            parts: [{ type: "text", text: userText }] as any,
+        },
+        mkAssistantWithTokens(200_000),
+    ]
+    const state = {
+        systemPromptTokens: 10_000,
+        messageIds: { byRawId: new Map(), byRef: new Map(), nextRef: 2 },
+    } as any
+    const c = estimateContextComposition(messages, state)
+    assert.equal(c.systemTokens, 10_000, "systemTokens must come from cached state, not the degraded estimate")
+    assert.equal(c.total, 10_000 + c.toolTokens + c.summaryTokens + c.messageTokens)
+})
+
+test("estimateContextComposition: falls back to fresh estimate when cache is undefined (#255)", () => {
+    const userText = "later turn user message"
+    const messages = [
+        {
+            info: { id: "u2", role: "user" } as any,
+            parts: [{ type: "text", text: userText }] as any,
+        },
+        mkAssistantWithTokens(200_000),
+    ]
+    const state = {
+        systemPromptTokens: undefined,
+        messageIds: { byRawId: new Map(), byRef: new Map(), nextRef: 2 },
+    } as any
+    const c = estimateContextComposition(messages, state)
+    assert.equal(c.systemTokens, 200_000 - countTokens(userText))
+})
+
+test("cacheSystemPromptTokens: does not overwrite stable positive cache with degraded estimate (#255)", () => {
+    const state = { systemPromptTokens: 10_000 } as any
+    const degraded = [
+        {
+            info: { id: "u2", role: "user" } as any,
+            parts: [{ type: "text", text: "later turn user message" }] as any,
+        },
+        mkAssistantWithTokens(200_000),
+    ]
+    cacheSystemPromptTokens(state, degraded)
+    assert.equal(state.systemPromptTokens, 10_000, "stable cache must survive degraded message arrays")
+})
+
+test("cacheSystemPromptTokens: writes initial estimate when cache is undefined (#255)", () => {
+    const state = { systemPromptTokens: undefined } as any
+    const firstTurn = [
+        {
+            info: { id: "u1", role: "user" } as any,
+            parts: [{ type: "text", text: "first task" }] as any,
+        },
+        mkAssistantWithTokens(10_000),
+    ]
+    cacheSystemPromptTokens(state, firstTurn)
+    assert.equal(state.systemPromptTokens, 10_000 - countTokens("first task"))
+})
+
+test("cacheSystemPromptTokens: keeps undefined when no reliable assistant token data (#255)", () => {
+    const state = { systemPromptTokens: undefined } as any
+    cacheSystemPromptTokens(state, [mkText("u1", "no assistant yet")])
+    assert.equal(state.systemPromptTokens, undefined)
+})
+

--- a/tests/inject-utils-pure.test.ts
+++ b/tests/inject-utils-pure.test.ts
@@ -515,4 +515,3 @@ test("cacheSystemPromptTokens: keeps undefined when no reliable assistant token 
     cacheSystemPromptTokens(state, [mkText("u1", "no assistant yet")])
     assert.equal(state.systemPromptTokens, undefined)
 })
-

--- a/tests/inject.test.ts
+++ b/tests/inject.test.ts
@@ -8,6 +8,9 @@ import { homedir } from "os"
 import type { PluginConfig } from "../lib/config"
 import { Logger } from "../lib/logger"
 import { injectMessageIds, injectCompressNudges } from "../lib/messages/inject/inject"
+import { cacheSystemPromptTokens } from "../lib/ui/utils"
+import { estimateContextComposition } from "../lib/messages/inject/utils"
+import { countTokens } from "../lib/token-utils"
 import { createSyntheticUserMessage } from "../lib/messages/utils"
 import { createSessionState, ensureSessionInitialized, type WithParts } from "../lib/state"
 import { saveSessionState, loadSessionState } from "../lib/state/persistence"
@@ -1658,5 +1661,78 @@ test("T2 cadence: does NOT immediately re-fire after compress attempt (T2 loop b
         false,
         "phase 3: T2 should NOT re-fire with growth < growthFloor (the T2 loop bug)",
     )
+})
+
+function buildMultiTurn(n: number, input: number, toolOutputChars: number): WithParts[] {
+    const msgs: WithParts[] = []
+    for (let i = 1; i <= n; i++) {
+        msgs.push(userMsg(`u${i}`, `task ${i}`))
+        msgs.push(
+            assistantMsgWithTokens(`a${i}`, `result ${i}`, { input, output: 20_000 }, [
+                toolPart(`t${i}`, "x".repeat(toolOutputChars)),
+            ]),
+        )
+    }
+    return msgs
+}
+
+test("Issue #255: stable system prompt cache survives compression in multi-turn nudge cycle (§5.7)", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    const config = buildConfig()
+    config.compress.maxContextLimit = 800_000
+    config.compress.minContextLimit = 200_000
+    config.compress.preserveRecentMessages = 20
+
+    // Turn 1: full history — first assistant input ≈ system + first user
+    const turn1: WithParts[] = [
+        userMsg("u1", "hello"),
+        assistantMsgWithTokens("a1", "done", { input: 10_000, output: 5_000 }),
+    ]
+    cacheSystemPromptTokens(state, turn1)
+    const stableSystem = state.systemPromptTokens
+    assert.ok(stableSystem !== undefined && stableSystem > 0, "first measurement caches a stable system estimate")
+    assert.equal(stableSystem, 10_000 - countTokens("hello"))
+
+    injectCompressNudges(state, config, logger, turn1, {} as any)
+    assert.equal(state.nudges.shouldInjectThisTurn, false, "turn 1: baseline only")
+    assert.equal(state.nudges.lastPerMessageNudgeTokens, 15_000, "turn 1: baseline = first assistant input+output")
+
+    // Turn 2: 25 rounds of growth → nudge fires. 50 messages exceed the 20-msg
+    // protection window so compressible ranges exist. First assistant in this
+    // array is a later turn (input 300K) — composition must still use the cache.
+    const turn2 = buildMultiTurn(25, 300_000, 40_000)
+    cacheSystemPromptTokens(state, turn2)
+    assert.equal(state.systemPromptTokens, stableSystem, "turn 2: degraded array must not overwrite the cache")
+    injectCompressNudges(state, config, logger, turn2, {} as any)
+    assert.equal(state.nudges.shouldInjectThisTurn, true, "turn 2: 335K growth ≥ 50K threshold → nudge")
+    assert.equal(state.nudges.lastNudgeShownTokens, 320_000, "turn 2: nudge shown tokens recorded")
+
+    const comp2 = estimateContextComposition(turn2, state)
+    assert.equal(comp2.systemTokens, stableSystem, "turn 2: composition uses cached system, not inflated 300K-4 estimate")
+
+    // Turn 3: compress → new baseline
+    const turn3: WithParts[] = [
+        userMsg("u3", "compress now"),
+        assistantMsgWithTokens("a3", "done", { input: 350_000, output: 10_000 }, [
+            compressToolPart("c1", "compressed"),
+        ]),
+    ]
+    injectCompressNudges(state, config, logger, turn3, {} as any)
+    assert.equal(state.nudges.lastPerMessageNudgeTokens, 360_000, "turn 3: compress sets new baseline to post-compression tokens")
+    assert.equal(state.nudges.compressBaselineSet, true, "turn 3: baseline locked after compress")
+
+    // Turn 4: post-compression growth → nudge again. Visible history no longer
+    // contains the true first assistant; first visible assistant input ≈ 460K.
+    const turn4 = buildMultiTurn(25, 460_000, 40_000)
+    cacheSystemPromptTokens(state, turn4)
+    assert.equal(state.systemPromptTokens, stableSystem, "turn 4: cache must NOT be overwritten by degraded array")
+    injectCompressNudges(state, config, logger, turn4, {} as any)
+    assert.equal(state.nudges.shouldInjectThisTurn, true, "turn 4: 110K growth from post-compress baseline → nudge again")
+    assert.equal(state.nudges.lastPerMessageNudgeTokens, 360_000, "turn 4: baseline preserved (only compress resets)")
+
+    const comp4 = estimateContextComposition(turn4, state)
+    assert.equal(comp4.systemTokens, stableSystem, "turn 4: composition still uses stable cached system, not inflated 460K estimate")
+    assert.ok(comp4.systemTokens < 200_000, "turn 4: system estimate must not inflate to later assistant input")
 })
 


### PR DESCRIPTION
## Summary

ACP already populated `state.systemPromptTokens` before pruning, but nudge and
`acp_status` ignored that cache — each re-estimated the system prompt tokens
from a different message view. After compression, the first visible assistant
can belong to a much later turn whose input includes large accumulated history,
inflating the estimate and causing the two numbers to diverge.

## Root Cause

- The stable pre-prune cache (`state.systemPromptTokens`) existed but was never
  consumed.
- nudge re-estimated from the post-prune transform array, where compressed
  messages are removed and the first visible assistant is a late turn.
- `acp_status` re-estimated from its own fetched message view.
- After compression those views can select different late assistant messages,
  producing inflated and divergent estimates.

## Fix

Three minimal production changes:

1. `cacheSystemPromptTokens` preserves the first stable positive estimate —
   later transforms no longer overwrite it with a degraded post-compression
   estimate (write-if-undefined guard).
2. `estimateContextComposition` prefers `state.systemPromptTokens` when it is a
   positive value; falls back to the existing
   `estimateSystemPromptTokens(messages)` unchanged when undefined.
3. `acp_status` (`collectVisibleMessages`) prefers the same cached value; falls
   back to the existing estimate when undefined.

## Scope

- No persistence change.
- No model/provider identity invalidation.
- No `/acp context` change.
- No public API change.
- No version bump.

## Tests

- Pure regression tests: degraded post-compression visible history must not
  inflate the system estimate (cached 10K survives first-visible-assistant
  input of ~200K), and undefined cache falls back to the original estimate.
- `acp_status` overview regression asserting the cached value appears in the
  breakdown.
- §5.7 multi-turn growth-cycle test (`preserveRecentMessages: 20`): baseline →
  growth → nudge → compress → new baseline → growth → nudge again, asserting the
  stable system estimate survives compression.
- Docker E2E: autonomous nudge → compress → growth → re-nudge with a verifier
  that ≥2 nudge observations report the same system prompt estimate.
- Bug-targeting tests verified to FAIL with the fix reverted and PASS with it
  applied.
- Verified: `npm run typecheck`, `npm run build`, `npm run test` (1010 pass),
  Docker E2E (12/12 scenarios), `check-pr.sh`.
- Live OpenCode smoke: plugin loads, ACP state initializes, `acp_status`
  executes without ACP errors. This verifies the runtime path only — the precise
  #255 regression is covered by the automated tests; the live environment was
  not used to reconstruct a 200K post-compression session.

## Known limitations

- The cache is in-session only; a restart after host compaction may re-estimate
  from degraded history.
- Mid-session instruction/AGENTS.md changes do not invalidate the cache.

Both are intentionally out of scope for this fix.

Fixes #255