### PR TITLE
release: v1.14.22 — stable system prompt token estimate (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+### v1.14.22 — Stable system prompt token estimate (#255)
+
+**Problem**: After ACP compression physically removes the true first assistant message from visible history, nudge and `acp_status` each re-derived the system prompt token estimate from the _first visible assistant_ — a much later turn whose `input` includes large accumulated history. Both inflated the estimate (a real ~10K system reported as ~200K), and because each consumer saw a different message view (post-prune transform array vs. a fresh store fetch), the two numbers diverged from each other. The `state.systemPromptTokens` cache (written pre-prune every turn) existed but was never read.
+
+**Fix**: Wire both consumers to the existing cache:
+- `cacheSystemPromptTokens` (`lib/ui/utils.ts`) — write-if-undefined guard: once a stable positive estimate is cached (measured pre-prune each turn at `lib/hooks.ts:233`, before `prune()` degrades the array), later degraded post-compression arrays never overwrite it.
+- `estimateContextComposition` (`lib/messages/inject/utils.ts`, nudge path) — prefers `state.systemPromptTokens` when positive; falls back to the original `estimateSystemPromptTokens(messages)` when `undefined` (old behavior, byte-for-byte).
+- `collectVisibleMessages` (`lib/compress/status.ts`, shared by `acp_status` and `/acp stats` via `buildStatusReport`) — same cache preference and fallback.
+
+Known limitations (documented, intentional non-goals): the cache is in-session only — a restart after host compaction may re-measure from degraded history; mid-session AGENTS.md / instruction changes do not invalidate the cache.
+
+Repo (non-runtime): changelog moved from the READMEs into dedicated `CHANGELOG.md` / `CHANGELOG.zh-CN.md` (#320, closes #318); READMEs keep a one-line pointer.
+
+Files: `lib/ui/utils.ts`, `lib/messages/inject/utils.ts`, `lib/compress/status.ts`. Tests: `tests/inject-utils-pure.test.ts`, `tests/inject.test.ts`, `tests/acp-status.test.ts` (1010 pass), including the §5.7 multi-turn growth-cycle test; Docker E2E 12/12 with a new `nudgeSystemTokensStable` verifier.
+
+Closes: #255.
+
+**Install**: `opencode plugin opencode-acp@latest --global`
+
 ### v1.14.21 — /acp command fixes and completion (permission gate, export, help) (#286)
 
 **Problem**: Three gaps in the `/acp` command suite: (1) when the compress permission was `deny`, ALL `/acp` subcommands were silently swallowed (the gate is a pre-#233 leftover from when `/acp` triggered compression; every current subcommand is read-only or user-initiated); (2) bare `/acp` showed behavior inconsistent with the README and diverged from pi-acp (whose bare `/acp` shows the status report, same handler as `/acp-status`); (3) the requested `/acp export` command (#265) was unimplemented.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,24 @@
 # 更新日志
 
+### v1.14.22 — 稳定的 system prompt token 估计 (#255)
+
+**问题**：ACP 压缩把真正的首条 assistant 消息从可见历史中物理剪掉后，nudge 和 `acp_status` 各自从"第一个可见 assistant"（实际是后轮次，其 `input` 含大量累积历史）重新推导 system prompt token 估计。两者都会把估计值吹大（真实 ~10K 的 system 被报成 ~200K），且因各用各的消息视图（剪枝后的 transform 数组 vs 重新拉取的 store），两个数字还会互相不一致。`state.systemPromptTokens` 缓存（每轮在剪枝前写入）一直存在，但从未被读取。
+
+**修复**：把两个消费方接到既有缓存上：
+- `cacheSystemPromptTokens`（`lib/ui/utils.ts`）——write-if-undefined 守卫：稳定正值缓存后（每轮在剪枝前于 `lib/hooks.ts:233` 测得，早于 `prune()` 退化数组），后续压缩后的退化数组不再覆盖它。
+- `estimateContextComposition`（`lib/messages/inject/utils.ts`，nudge 路径）——`state.systemPromptTokens` 为正时优先使用；`undefined` 时 fallback 到原有 `estimateSystemPromptTokens(messages)`（旧行为，逐字节一致）。
+- `collectVisibleMessages`（`lib/compress/status.ts`，`acp_status` 与 `/acp stats` 经 `buildStatusReport` 共用）——同样的缓存优先与 fallback。
+
+已知限制（有意留的 non-goal，已文档化）：缓存仅 session 内有效——host compaction 后重启可能从退化历史重测；session 中修改 AGENTS.md / 指令不会使缓存失效。
+
+仓库（非运行时）：changelog 从 README 移到独立的 `CHANGELOG.md` / `CHANGELOG.zh-CN.md`（#320，关闭 #318）；README 只留一行指针。
+
+文件：`lib/ui/utils.ts`、`lib/messages/inject/utils.ts`、`lib/compress/status.ts`。测试：`tests/inject-utils-pure.test.ts`、`tests/inject.test.ts`、`tests/acp-status.test.ts`（1010 通过），含 §5.7 多轮增长周期测试；Docker E2E 12/12（含新增 `nudgeSystemTokensStable` 验证器）。
+
+关闭：#255。
+
+**安装**：`opencode plugin opencode-acp@latest --global`
+
 ### v1.14.21 — /acp 命令修复与补全（权限门、export、help）(#286)
 
 **问题**：`/acp` 命令族的三个缺口：（1）压缩权限为 `deny` 时，**所有** `/acp` 子命令被静默吞掉（该门是 #233 之前 `/acp` 会触发压缩的残留；现在的子命令全是只读或用户发起的）；（2）无参 `/acp` 行为与 README 描述不一致，且与 pi-acp 不对齐（pi-acp 无参 `/acp` 显示状态报告，与 `/acp-status` 同一 handler）；（3）需求 `/acp export` 导出命令（#265）未实现。

--- a/devlog/2026-08-18_release-v1.14.22/REQ.md
+++ b/devlog/2026-08-18_release-v1.14.22/REQ.md
@@ -1,0 +1,27 @@
+# REQ — v1.14.22: stable system prompt token estimate (#255)
+
+## Problem
+
+Patch release shipping the #255 fix (merged as `d24b175`, PR #322): after ACP
+compression removes the true first assistant message from visible history,
+nudge and `acp_status` each re-derived the system prompt token estimate from
+the first *visible* assistant — a late turn whose input includes large
+accumulated history. Both inflated the estimate and diverged from each other.
+
+## Content since v1.14.21
+
+- `d24b175` Merge PR #322 — `fix: stabilize system prompt token estimate (#255)`:
+  write-if-undefined guard in `cacheSystemPromptTokens` (`lib/ui/utils.ts`);
+  cache preference in `estimateContextComposition` (`lib/messages/inject/utils.ts`)
+  and `collectVisibleMessages` (`lib/compress/status.ts`). 1010 tests pass;
+  Docker E2E 12/12.
+- `0a364e1` Merge PR #320 — `feat(repo): move changelog to separate files`
+  (closes #318). Repo hygiene only; no plugin runtime changes.
+
+## Acceptance
+
+- All existing tests pass
+- Version bump on this release branch only; `CHANGELOG.md` and
+  `CHANGELOG.zh-CN.md` updated with `### v1.14.22`
+- `./scripts/ci/check-pr.sh` green
+- release.yml publishes v1.14.22 to npm `latest` after merge

--- a/devlog/2026-08-18_release-v1.14.22/WORKLOG.md
+++ b/devlog/2026-08-18_release-v1.14.22/WORKLOG.md
@@ -1,0 +1,24 @@
+# WORKLOG — v1.14.22
+
+## Commits on this release (since v1.14.21)
+
+1. `d24b175` Merge pull request #322 — `fix: stabilize system prompt token estimate (#255)`
+   - write-if-undefined guard in `cacheSystemPromptTokens` (`lib/ui/utils.ts`)
+   - `estimateContextComposition` (`lib/messages/inject/utils.ts`) prefers `state.systemPromptTokens`
+   - `collectVisibleMessages` (`lib/compress/status.ts`) prefers the same cache
+   - regression tests + §5.7 multi-turn growth-cycle test + E2E `nudgeSystemTokensStable` verifier
+2. `0a364e1` Merge pull request #320 — changelog moved to `CHANGELOG.md` / `CHANGELOG.zh-CN.md` (repo-only)
+
+## Release steps
+
+- `npm version 1.14.22 --no-git-tag-version` (bump `package.json` + `package-lock.json`)
+- `### v1.14.22` entries added to `CHANGELOG.md` and `CHANGELOG.zh-CN.md`
+- Devlog: this folder (REQ.md + WORKLOG.md)
+- Commit `release: v1.14.22 — stable system prompt token estimate (#255)`
+
+## Verification
+
+- `npm run typecheck` — green
+- `node --import tsx --test tests/*.test.ts` — 1010 pass, 0 fail
+- `./scripts/ci/check-pr.sh 2026-08-18_release-v1.14.22 origin/master` — green
+- release.yml publishes v1.14.22 to npm `latest` after merge

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-acp",
-    "version": "1.14.21",
+    "version": "1.14.22",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-acp",
-            "version": "1.14.21",
+            "version": "1.14.22",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.21",
+    "version": "1.14.22",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
Patch release for the #255 fix (merged as PR #322).

## Contents since v1.14.21

- **#322** `fix: stabilize system prompt token estimate (#255)` — nudge and `acp_status` now share the stable pre-prune `state.systemPromptTokens` cache instead of re-estimating from degraded post-compression history (which inflated the system estimate to ~200K and made the two surfaces diverge). Write-if-undefined guard in `cacheSystemPromptTokens`; cache preference + fallback in `estimateContextComposition` and `collectVisibleMessages`. 1010 tests pass; Docker E2E 12/12.
- **#320** `feat(repo): move changelog to separate files (closes #318)` — repo hygiene only, no runtime changes.

## Release checklist

- [x] Version bump `1.14.21 → 1.14.22` (`package.json` + `package-lock.json`)
- [x] `### v1.14.22` entries in `CHANGELOG.md` + `CHANGELOG.zh-CN.md`
- [x] Devlog `devlog/2026-08-18_release-v1.14.22/` (REQ + WORKLOG)
- [x] `./scripts/ci/check-pr.sh` green
- [x] `npm run typecheck` + full test suite green (1010 pass)

On merge, `release.yml` auto-creates tag `v1.14.22`, publishes to npm `latest`, and creates the GitHub Release.