### PR TITLE
fix: effective compressible accounting stops phantom-range retry loops

### DIFF
--- a/devlog/2026-08-20_effective-compressible-accounting/REQ.md
+++ b/devlog/2026-08-20_effective-compressible-accounting/REQ.md
@@ -1,0 +1,54 @@
+# REQ — Effective Compressible Accounting (Retry-Loop Fix)
+
+## Problem
+
+Issue #37 session `ses_7fb5cbc89d7ee8ky0AsO7Wrp7X` showed a repeated-compression loop:
+
+1. **Phantom loop (floors 156-175, ~10 retries)**: The nudge recommended range
+   `m00141–m00150` as "7.8K compressible | 3.4K protected". The model compressed it
+   successfully 4× (b23–b26), but the remaining uncompressed messages were: the last
+   user message (soft-filtered by `filterLastUserMessage`), 2 protected compress
+   anchors, and 1 empty message — all filtered by the pipeline. Every retry failed
+   with "all messages already compressed" (phantom), and the nudge kept recommending
+   the same range → infinite loop.
+
+2. **Min-size retry (floors 204-206)**: After a successful compression (b27), the
+   nudge immediately recommended `m00199–m00207` as "10.8K compressible". The actual
+   pipeline-compressible content was 3066 chars (protected zone + soft filters) →
+   rejected by `minCompressRange` (5000) → retry.
+
+3. **Squeezed-context pressure**: After the context was fully compressed, the
+   remaining "compressible" content was 108-token compress confirmations
+   (individually sub-minimum). The growth-gated nudge kept firing anyway.
+
+## Root Cause
+
+The recommendation engine (`buildCompressibleRanges`) counts raw visible-message
+tokens without applying the compress pipeline's soft filters (last-user-message,
+no-meaningful-content, protected zone). The display overstates what a compression
+would free by 3.6× in the incident, baiting the model into guaranteed-failed calls.
+
+## Fix
+
+1. `buildCompressibleRanges` now computes per-range `effectiveTokens`: the token sum
+   of messages that survive the pipeline's soft filters (excludes the last user
+   message and content-empty messages; zone/protected/compressed were already
+   excluded).
+2. `filterRecommendedRanges` drops ranges with effective content below
+   `EFFECTIVE_MIN_COMPRESSIBLE_TOKENS` (1250 tokens ≈ the pipeline's
+   `minCompressRange` 5000 chars ÷ 4) — the pipeline would reject them anyway.
+3. `formatCompressibleRanges` displays honest sizes ("0.8K effective of 13.6K").
+4. `injectCompressNudges` treats all-sub-floor-range states as `nothingToCompress`
+   → nudge silenced when nothing is worth compressing (non-emergency path).
+
+## Verification
+
+- §5.7.3: both incident regression tests verified to FAIL when the fix behavior is
+  disabled (surgical revert of the floor + allBelowMin).
+- 1018 tests pass (up from 1010), typecheck clean.
+
+## Non-Goals
+
+- Emergency-override behavior at maxLimit is unchanged (still nudges even when
+  nothing is compressible) — overflow warnings should never be fully silenced.
+- The `minCompressRange` pipeline check itself is untouched (remains the backstop).

--- a/devlog/2026-08-20_effective-compressible-accounting/WORKLOG.md
+++ b/devlog/2026-08-20_effective-compressible-accounting/WORKLOG.md
@@ -41,3 +41,17 @@
 - §5.7.3 surgical revert (floor disabled + allBelowMin=false): both incident
   regression tests FAIL; fix re-applied and suite green again.
 - build: 881.32 KB sourcemap / dist built successfully.
+
+## Update: config-derived floor (E2E fix + Oracle review finding)
+
+E2E scenario 06-nudge-triggered failed (`blockCount >= 1 — got 0`): the E2E harness config sets
+`minCompressRange: 0` (pipeline accepts any size), but the recommendation floor was hardcoded at
+1250 — ranges dropped, nudge silenced, no compress. Same mismatch Oracle review flagged for user
+configs that raise/lower `minCompressRange`.
+
+- `resolveEffectiveFloor(config)` in utils.ts: floor = `minCompressRange ÷ 4` (÷4 chars/token), 0 when disabled
+- `filterRecommendedRanges` takes `minEffectiveTokens` option; universal phantom guard `effective > 0` always applies
+- inject.ts passes `resolveEffectiveFloor(config)`
+- +3 tests (floor 0 passthrough, phantom guard at floor 0, raised floor)
+
+Verification: typecheck clean, full suite green, E2E scenarios 06/09/10/11/12 pass locally (5/5).

--- a/devlog/2026-08-20_effective-compressible-accounting/WORKLOG.md
+++ b/devlog/2026-08-20_effective-compressible-accounting/WORKLOG.md
@@ -1,0 +1,43 @@
+# WORKLOG — Effective Compressible Accounting
+
+## Changes
+
+### lib/messages/inject/utils.ts
+- `CompressibleRange`: added `effectiveTokens: number` field (docstring explains
+  tokens vs effectiveTokens and references the incident).
+- `buildCompressibleRanges`: tracks last user message index + per-message
+  meaningful-content flag; computes `effectiveTokens` per message/group.
+- `EFFECTIVE_MIN_COMPRESSIBLE_TOKENS = 1250` exported constant (aligned with
+  `minCompressRange` 5000 chars ÷ 4).
+- `filterRecommendedRanges`: drops sub-floor ranges; dangerous flag moves to the
+  last SURVIVING range; logs dropped ranges in debug.
+- `formatCompressibleRanges`: non-merged lines show "N effective of M" when they
+  differ; merged entries' `compressibleTokens` now sourced from effective tokens.
+
+### lib/messages/inject/inject.ts
+- `nothingToCompress` gains `allBelowMin` (compressible > 0 but recommended = 0)
+  → nudge silenced on squeezed contexts.
+
+### tests/smart-nudge-gating.test.ts
+- Updated tiny-ranges test to the new contract (sub-floor dropped).
+- Added: floor boundary, retry-loop regression (10800 raw / 766 effective),
+  all-sub-floor → empty, mixed keep/drop.
+
+### tests/property-invariants.test.ts
+- INV5 rewritten: every range ABOVE the floor is returned (no context-relative
+  suppression — issue #251 intent preserved; floor is pipeline-absolute).
+
+### tests/preserve-recent.test.ts
+- Added: effectiveTokens excludes last user message; effectiveTokens excludes
+  empty messages; incident reconstruction (floors 156-175) range not recommended;
+  injectCompressNudges silent when all ranges sub-floor (mirrors the file's
+  established baseline-preset pattern, growth gate passes via a large last user
+  message).
+
+## Verification
+
+- typecheck: 0 errors
+- tests: 1018 pass / 0 fail (was 1010 before the fix; +12 new, 2 rewritten)
+- §5.7.3 surgical revert (floor disabled + allBelowMin=false): both incident
+  regression tests FAIL; fix re-applied and suite green again.
+- build: 881.32 KB sourcemap / dist built successfully.

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -349,7 +349,8 @@ export const injectCompressNudges = (
 
     const allProtected = contextRanges.compressible.length === 0 && contextRanges.protected.length > 0
     const allInProtectedZone = protectedRefs.size > 0 && unprotectedCompressible.length === 0
-    const nothingToCompress = allProtected || allInProtectedZone
+    const allBelowMin = contextRanges.compressible.length > 0 && recommendedRanges.length === 0
+    const nothingToCompress = allProtected || allInProtectedZone || allBelowMin
     const shouldInjectNudge = nudgeAllowed && (!nothingToCompress || emergencyOverride)
     let shouldInject = shouldInjectNudge
 

--- a/lib/messages/inject/inject.ts
+++ b/lib/messages/inject/inject.ts
@@ -32,6 +32,7 @@ import {
     estimateContextComposition,
     excludeProtectedRanges,
     filterRecommendedRanges,
+    resolveEffectiveFloor,
     findLastNonIgnoredMessage,
     formatCompressibleRanges,
     getIterationNudgeThreshold,
@@ -343,7 +344,7 @@ export const injectCompressNudges = (
     const recommendedRanges = filterRecommendedRanges(
         unprotectedCompressible,
         contextRanges.protected,
-        { logger },
+        { logger, minEffectiveTokens: resolveEffectiveFloor(config) },
     )
     const hasRecommendations = recommendedRanges.length > 0
 

--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -794,18 +794,37 @@ export function buildCompressibleRanges(
 
 export interface RangeFilterOptions {
     logger?: { debug: (msg: string, data?: any) => void }
+    minEffectiveTokens?: number
 }
 
 /**
- * Token floor for a range to stay in the recommendation list, aligned with
- * the compress pipeline's minCompressRange backstop (5000 chars ÷ 4 chars/token).
- * Ranges whose effective compressible content falls below this would be
- * rejected by the pipeline's minimum-size check, so recommending them only
- * invites guaranteed-failed compress calls (the retry loop observed in
- * issue #37 session ses_7fb5cbc8: displayed "10.8K compressible" resolved
- * to 3066 chars in the pipeline → rejected → model retried ×10).
+ * DEFAULT token floor for a range to stay in the recommendation list, aligned
+ * with the compress pipeline's default minCompressRange (5000 chars ÷ 4
+ * chars/token). The actual floor is derived from the configured
+ * `compress.minCompressRange` via `resolveEffectiveFloor` so the recommendation
+ * tracks the pipeline's real rejection threshold. Ranges whose effective
+ * compressible content falls below the floor would be rejected by the
+ * pipeline's minimum-size check, so recommending them only invites
+ * guaranteed-failed compress calls (the retry loop observed in issue #37
+ * session ses_7fb5cbc8: displayed "10.8K compressible" resolved to 3066 chars
+ * in the pipeline → rejected → model retried ×10).
  */
 export const EFFECTIVE_MIN_COMPRESSIBLE_TOKENS = 1250
+
+/**
+ * Derive the effective-token recommendation floor from the pipeline's
+ * char-based `compress.minCompressRange` (÷ 4 chars/token). When
+ * minCompressRange is 0 the pipeline's size check is disabled, so the floor
+ * is 0 — but the universal phantom guard (`effective > 0`) still applies in
+ * filterRecommendedRanges: a range whose every message is soft-filtered
+ * produces a phantom plan the pipeline always rejects.
+ */
+export function resolveEffectiveFloor(config: {
+    compress?: { minCompressRange?: number }
+}): number {
+    const minChars = config.compress?.minCompressRange ?? 5000
+    return minChars > 0 ? Math.floor(minChars / 4) : 0
+}
 
 /**
  * Filter compressible ranges for the recommendation list.
@@ -838,9 +857,10 @@ export function filterRecommendedRanges(
         return []
     }
 
+    const floor = options.minEffectiveTokens ?? EFFECTIVE_MIN_COMPRESSIBLE_TOKENS
     const kept = compressible.filter((r) => {
         const effective = r.effectiveTokens ?? r.tokens
-        return effective >= EFFECTIVE_MIN_COMPRESSIBLE_TOKENS
+        return effective > 0 && effective >= floor
     })
 
     const result = kept.map((r, i) =>
@@ -850,8 +870,12 @@ export function filterRecommendedRanges(
     log?.("filterRecommendedRanges: effective-token floor applied", {
         inputRanges: compressible.length,
         outputRanges: result.length,
+        floor,
         dropped: compressible
-            .filter((r) => (r.effectiveTokens ?? r.tokens) < EFFECTIVE_MIN_COMPRESSIBLE_TOKENS)
+            .filter((r) => {
+                const effective = r.effectiveTokens ?? r.tokens
+                return effective <= 0 || effective < floor
+            })
             .map((r) => `${r.startRef}–${r.endRef} (${r.effectiveTokens ?? r.tokens} eff tokens)`),
     })
 

--- a/lib/messages/inject/utils.ts
+++ b/lib/messages/inject/utils.ts
@@ -589,6 +589,16 @@ export interface CompressibleRange {
     endRef: string
     count: number
     tokens: number
+    /**
+     * Tokens that would actually survive the compress pipeline's soft
+     * filters (last-user-message, no-meaningful-content). The pipeline
+     * silently drops those messages from plans, so `tokens` overstates
+     * what a compression would free. Recommendations and displays use
+     * this field to stay honest (phantom-loop fix, issue #37 session
+     * ses_7fb5cbc8: ranges shown as "10.8K compressible" resolved to
+     * 3066 chars in the pipeline → min-size rejection → retry loop).
+     */
+    effectiveTokens: number
     toolPct: number
     textPct: number
     dangerous?: boolean
@@ -623,6 +633,8 @@ export function buildCompressibleRanges(
         ref: string
         refNum: number
         tokens: number
+        effectiveTokens: number
+        meaningful: boolean
         isTool: boolean
         isUser: boolean
     }[] = []
@@ -632,7 +644,9 @@ export function buildCompressibleRanges(
         tokens: number
         tools: string[]
     }[] = []
-    for (const msg of messages) {
+    const lastUserRefIdx: number[] = []
+    for (let mi = 0; mi < messages.length; mi++) {
+        const msg = messages[mi]
         if (isSyntheticMessage(msg)) continue
         const ref = state.messageIds.byRawId.get(msg.info.id)
         if (!ref) continue
@@ -673,15 +687,28 @@ export function buildCompressibleRanges(
 
         let tokens = 0
         let isTool = false
+        let hasMeaningfulPart = false
         for (const part of msg.parts || []) {
             if (part.type === "text" && typeof (part as any).text === "string") {
                 tokens += Math.round(((part as any).text as string).length / 4)
+                if ((part as any).text.trim().length > 0) hasMeaningfulPart = true
             } else if (part.type !== "text" && part.type !== "reasoning") {
                 tokens += Math.round(JSON.stringify(part).length / 4)
                 isTool = true
+                hasMeaningfulPart = true
             }
         }
-        msgInfo.push({ ref, refNum: rn, tokens, isTool, isUser: msg.info.role === "user" })
+        if (msg.info.role === "user" && !isIgnoredUserMessage(msg)) {
+            lastUserRefIdx.length = 0
+            lastUserRefIdx.push(msgInfo.length)
+        }
+        msgInfo.push({ ref, refNum: rn, tokens, effectiveTokens: 0, meaningful: hasMeaningfulPart, isTool, isUser: msg.info.role === "user" })
+    }
+
+    const lastUserIdx = lastUserRefIdx.length > 0 ? lastUserRefIdx[0] : -1
+    for (let i = 0; i < msgInfo.length; i++) {
+        const info = msgInfo[i]
+        info.effectiveTokens = i !== lastUserIdx && info.meaningful ? info.tokens : 0
     }
 
     const groups: CompressibleRange[] = []
@@ -711,6 +738,7 @@ export function buildCompressibleRanges(
                 endRef: info.ref,
                 count: 1,
                 tokens: info.tokens,
+                effectiveTokens: info.effectiveTokens,
                 toolPct: info.isTool ? 100 : 0,
                 textPct: info.isTool ? 0 : 100,
             }
@@ -718,6 +746,7 @@ export function buildCompressibleRanges(
             cur.endRef = info.ref
             cur.count++
             cur.tokens += info.tokens
+            cur.effectiveTokens += info.effectiveTokens
             if (info.isTool) {
                 cur.toolPct = Math.round((cur.toolPct * (cur.count - 1) + 100) / cur.count)
             } else {
@@ -768,19 +797,33 @@ export interface RangeFilterOptions {
 }
 
 /**
+ * Token floor for a range to stay in the recommendation list, aligned with
+ * the compress pipeline's minCompressRange backstop (5000 chars ÷ 4 chars/token).
+ * Ranges whose effective compressible content falls below this would be
+ * rejected by the pipeline's minimum-size check, so recommending them only
+ * invites guaranteed-failed compress calls (the retry loop observed in
+ * issue #37 session ses_7fb5cbc8: displayed "10.8K compressible" resolved
+ * to 3066 chars in the pipeline → rejected → model retried ×10).
+ */
+export const EFFECTIVE_MIN_COMPRESSIBLE_TOKENS = 1250
+
+/**
  * Filter compressible ranges for the recommendation list.
  *
- * All ranges are shown to the model — the model decides what to compress.
- * The last segment is always marked `dangerous: true` (it may still be in
- * active use; the model is warned in the suffix text).
+ * Ranges whose effective compressible content (after the pipeline's soft
+ * filters: last-user-message, no-meaningful-content) falls below
+ * EFFECTIVE_MIN_COMPRESSIBLE_TOKENS are dropped — the pipeline's
+ * minCompressRange check would reject them anyway. The last surviving
+ * segment is marked `dangerous: true` (it may still be in active use).
  *
  * Issue #251: Previously this function used `growthThreshold` (5% of context
  * window = 50K at 1M) as an aggregate gate — if "effective compressible"
  * was below the threshold, ALL ranges were suppressed and the nudge was
  * hidden. At large context windows, individual ranges rarely exceeded this
  * threshold, so compression was permanently blocked. The aggregate gate
- * has been removed; `minCompressRange` in `range.ts` (5000 chars) already
- * prevents garbage compressions as a backstop.
+ * has been removed. The per-range effective floor below is 1250 tokens —
+ * far below #251's 50K, and matched to the pipeline's own acceptance
+ * criteria rather than the context size.
  */
 export function filterRecommendedRanges(
     compressible: CompressibleRange[],
@@ -795,13 +838,21 @@ export function filterRecommendedRanges(
         return []
     }
 
-    const result = compressible.map((r, i) =>
-        i === compressible.length - 1 ? { ...r, dangerous: true } : r,
+    const kept = compressible.filter((r) => {
+        const effective = r.effectiveTokens ?? r.tokens
+        return effective >= EFFECTIVE_MIN_COMPRESSIBLE_TOKENS
+    })
+
+    const result = kept.map((r, i) =>
+        i === kept.length - 1 ? { ...r, dangerous: true } : r,
     )
 
-    log?.("filterRecommendedRanges: passthrough (last segment marked dangerous)", {
+    log?.("filterRecommendedRanges: effective-token floor applied", {
         inputRanges: compressible.length,
         outputRanges: result.length,
+        dropped: compressible
+            .filter((r) => (r.effectiveTokens ?? r.tokens) < EFFECTIVE_MIN_COMPRESSIBLE_TOKENS)
+            .map((r) => `${r.startRef}–${r.endRef} (${r.effectiveTokens ?? r.tokens} eff tokens)`),
     })
 
     return result
@@ -833,8 +884,12 @@ export function formatCompressibleRanges(
     if (!protectedRanges || protectedRanges.length === 0) {
         if (ranges.length === 0) return ""
         const lines = ranges.map((r) => {
+            const eff = r.effectiveTokens ?? r.tokens
+            const size = eff < r.tokens
+                ? `${fmt(eff)} effective of ${fmt(r.tokens)}`
+                : fmt(r.tokens)
             const suffix = r.dangerous ? "  ⚠️ NOT recommended unless you are certain. If you MUST compress this, pass `dangerous: true`." : ""
-            return `  ${r.startRef}–${r.endRef}  ${r.count} msgs  ${fmt(r.tokens)} [tool ${r.toolPct}% | text ${r.textPct}%]${suffix}`
+            return `  ${r.startRef}–${r.endRef}  ${r.count} msgs  ${size} [tool ${r.toolPct}% | text ${r.textPct}%]${suffix}`
         })
         return `Compressible ranges (oldest first):\n${lines.join("\n")}`
     }
@@ -851,7 +906,7 @@ export function formatCompressibleRanges(
             tokens: r.tokens,
             toolPct: r.toolPct,
             textPct: r.textPct,
-            compressibleTokens: r.tokens,
+            compressibleTokens: r.effectiveTokens ?? r.tokens,
             compressibleCount: r.count,
             protectedTokens: 0,
             protectedCount: 0,

--- a/tests/preserve-recent.test.ts
+++ b/tests/preserve-recent.test.ts
@@ -4,7 +4,14 @@ import test from "node:test"
 import { createSessionState, type WithParts } from "../lib/state"
 import type { PluginConfig } from "../lib/config"
 import { Logger } from "../lib/logger"
-import { buildCompressibleRanges, computeProtectedRefs, excludeProtectedRanges, type CompressibleRange } from "../lib/messages/inject/utils"
+import {
+    buildCompressibleRanges,
+    computeProtectedRefs,
+    excludeProtectedRanges,
+    filterRecommendedRanges,
+    EFFECTIVE_MIN_COMPRESSIBLE_TOKENS,
+    type CompressibleRange,
+} from "../lib/messages/inject/utils"
 import { injectCompressNudges } from "../lib/messages/inject/inject"
 
 const SID = "ses-preserve-test"
@@ -329,4 +336,150 @@ test("buildCompressibleRanges: all messages in protected zone → no compressibl
 
     const result = buildCompressibleRanges(messages, state, [], [], protectedRefs)
     assert.equal(result.compressible.length, 0, "no compressible ranges when all messages protected")
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// effectiveTokens accounting (retry-loop fix, issue #37 ses_7fb5cbc8)
+// ─────────────────────────────────────────────────────────────────────
+
+test("effectiveTokens: last user message contributes 0 (pipeline soft-filters it)", () => {
+    const state = createSessionState()
+    // 6 assistants (2000 chars = 500 tok each) + LAST message is a user message
+    const messages: WithParts[] = []
+    let n = 0
+    for (let i = 1; i <= 6; i++) {
+        n++
+        const id = `msg-${n}`
+        state.messageIds.byRawId.set(id, `m${String(n).padStart(5, "0")}`)
+        messages.push(msg(id, "assistant", "x".repeat(2000)))
+    }
+    n++
+    const userId = `msg-${n}`
+    state.messageIds.byRawId.set(userId, `m${String(n).padStart(5, "0")}`)
+    messages.push(msg(userId, "user", "y".repeat(2000)))
+
+    const ranges = buildCompressibleRanges(messages, state, [], [])
+    const total = ranges.compressible.reduce((s, r) => s + r.tokens, 0)
+    const effective = ranges.compressible.reduce((s, r) => s + r.effectiveTokens, 0)
+    assert.equal(total, 7 * 500, "raw tokens count all 7 messages")
+    assert.equal(effective, 6 * 500, "effective tokens exclude the last user message")
+})
+
+test("effectiveTokens: empty assistant messages contribute 0", () => {
+    const state = createSessionState()
+    const messages: WithParts[] = []
+    // 3 real assistants + 2 empty (whitespace-only text, no tool parts)
+    const specs: Array<["user" | "assistant", string]> = [
+        ["assistant", "x".repeat(2000)],
+        ["assistant", ""],
+        ["assistant", "   \n  "],
+        ["assistant", "x".repeat(2000)],
+        ["user", "z".repeat(2000)],
+    ]
+    let n = 0
+    for (const [role, text] of specs) {
+        n++
+        const id = `msg-${n}`
+        state.messageIds.byRawId.set(id, `m${String(n).padStart(5, "0")}`)
+        messages.push(msg(id, role, text))
+    }
+
+    const ranges = buildCompressibleRanges(messages, state, [], [])
+    const total = ranges.compressible.reduce((s, r) => s + r.tokens, 0)
+    const effective = ranges.compressible.reduce((s, r) => s + r.effectiveTokens, 0)
+    assert.ok(total > 1000, "raw tokens include whitespace-message padding and user text")
+    assert.equal(effective, 2 * 500, "effective counts only the 2 meaningful assistants (empties + last user excluded)")
+})
+
+test("regression ses_7fb5cbc8: range of last-user + empties + protected anchors is not recommended", () => {
+    // Reconstructs floors 156-175: compress(m00141, m00150) retried ×10 because
+    // the nudge kept listing the span, but the pipeline filtered everything:
+    // 6 msgs already compressed (pruned from visible list), m00144 = last user
+    // message, m00147/m00150 = protected compress anchors, m00148 = empty.
+    const state = createSessionState()
+    const messages: WithParts[] = []
+    let n = 140
+    const push = (role: "user" | "assistant", text: string, protectedTool = false) => {
+        n++
+        const id = `msg-${n}`
+        state.messageIds.byRawId.set(id, `m${String(n).padStart(5, "0")}`)
+        if (protectedTool) {
+            messages.push({
+                info: msg(id, role, "").info,
+                parts: [{
+                    id: `p-${id}`,
+                    messageID: id,
+                    sessionID: SID,
+                    type: "tool" as const,
+                    tool: "compress",
+                    callID: `call-${id}`,
+                    state: { status: "completed", input: {}, output: "Compressed 7 messages" },
+                } as any],
+            })
+        } else {
+            messages.push(msg(id, role, text))
+        }
+    }
+
+    push("assistant", "x".repeat(2000)) // m00141 (visible stand-in for already-compressed remnants)
+    push("user", "看看还有哪些pr 列一下 ".repeat(400)) // m00144: last user message (the raw-token bait)
+    push("assistant", "") // m00148: empty
+    push("assistant", "", true) // m00147: protected compress anchor
+    push("assistant", "", true) // m00150: protected compress anchor
+    push("assistant", "x".repeat(2000)) // m00151+: loop-generated content (inside protected zone)
+    push("assistant", "x".repeat(2000))
+    push("assistant", "x".repeat(2000))
+
+    const compress = buildCompress({ preserveRecentMessages: 3, preserveRecentTokens: 0 })
+    const protectedRefs = computeProtectedRefs(messages, state, compress)
+    const ranges = buildCompressibleRanges(messages, state, ["compress"], [], protectedRefs)
+    const unprotected = excludeProtectedRanges(ranges.compressible, protectedRefs)
+    const recommended = filterRecommendedRanges(unprotected, ranges.protected, { logger })
+
+    // Raw span tokens look substantial, but effective content (excluding the
+    // last user message + empties) falls below the floor → nothing recommended.
+    const rawTotal = unprotected.reduce((s, r) => s + r.tokens, 0)
+    assert.ok(rawTotal > EFFECTIVE_MIN_COMPRESSIBLE_TOKENS, "raw span tokens exceed the floor (the bait)")
+    assert.equal(
+        recommended.length,
+        0,
+        "phantom-prone range must not be recommended after effective accounting",
+    )
+})
+
+test("regression ses_7fb5cbc8: injectCompressNudges stays silent when all ranges are sub-floor", () => {
+    const state = createSessionState()
+    state.modelContextLimit = 1_000_000
+    state.nudges.lastPerMessageNudgeTokens = 0
+    const config = buildConfig({
+        maxContextLimit: 100_000,
+        minContextLimit: 50_000,
+        preserveRecentMessages: 0,
+        preserveRecentTokens: 0,
+    })
+
+    // 3 small assistants (100 effective tokens each) + one huge last user
+    // message carrying the bulk of the raw tokens (mirrors the incident:
+    // raw context passes the growth gate, but effective compressible content
+    // is sub-floor → nothingToCompress → nudge silent).
+    const messages: WithParts[] = []
+    for (let i = 1; i <= 3; i++) {
+        const id = `msg-${i}`
+        state.messageIds.byRawId.set(id, `m${String(i).padStart(5, "0")}`)
+        messages.push(msg(id, "assistant", "x".repeat(400)))
+    }
+    state.messageIds.byRawId.set("msg-4", "m00004")
+    messages.push(msg("msg-4", "user", "y".repeat(220_000)))
+
+    const before = messages.length
+    injectCompressNudges(state, config, logger, messages, {} as any)
+    const suffix = suffixText(messages)
+
+    assert.equal(messages.length, before, "no synthetic suffix message left behind")
+    assert.ok(!suffix || !suffix.includes("Compressible ranges"), "no range recommendation injected")
+    assert.equal(
+        state.nudges.shouldInjectThisTurn,
+        false,
+        "growth passes the gate but all ranges are sub-floor → nothing worth compressing",
+    )
 })

--- a/tests/property-invariants.test.ts
+++ b/tests/property-invariants.test.ts
@@ -26,6 +26,7 @@ import {
     buildCompressibleRanges,
     excludeProtectedRanges,
     filterRecommendedRanges,
+    EFFECTIVE_MIN_COMPRESSIBLE_TOKENS,
     type CompressibleRange,
 } from "../lib/messages/inject/utils"
 import { injectCompressNudges } from "../lib/messages/inject/inject"
@@ -399,15 +400,17 @@ test("INV4c: computeShouldNudge returns false when growth step not met and not o
 })
 
 // ═══════════════════════════════════════════════════════════════════════
-// INV5: filterRecommendedRanges — always returns all input ranges
+// INV5: filterRecommendedRanges — no context-relative suppression
 // ═══════════════════════════════════════════════════════════════════════
 // Issue #251 regression: filterRecommendedRanges used to suppress ranges
 // below a context-relative threshold (5% of modelContextLimit). At 1M context
 // this meant 50K+ of compressible content was never recommended.
-// New invariant: ALL input ranges are always returned (no suppression).
-// The minCompressRange backstop in range.ts handles garbage filtering.
+// Invariant: every range ABOVE the pipeline-aligned effective floor
+// (EFFECTIVE_MIN_COMPRESSIBLE_TOKENS) is returned — no context-relative
+// suppression. Ranges below the floor are dropped because the pipeline's
+// minCompressRange would reject them anyway (retry-loop fix).
 
-test("INV5: filterRecommendedRanges always returns all input ranges", () => {
+test("INV5: filterRecommendedRanges keeps every range above the effective floor", () => {
     fc.assert(
         fc.property(
             fc.array(
@@ -415,22 +418,23 @@ test("INV5: filterRecommendedRanges always returns all input ranges", () => {
                     startRef: fc.string({ minLength: 2, maxLength: 6 }).map((s) => "m" + s.slice(1)),
                     endRef: fc.string({ minLength: 2, maxLength: 6 }).map((s) => "m" + s.slice(1)),
                     count: fc.integer({ min: 1, max: 10 }),
-                    tokens: fc.integer({ min: 100, max: 50_000 }),
+                    tokens: fc.integer({ min: EFFECTIVE_MIN_COMPRESSIBLE_TOKENS, max: 50_000 }),
                     toolPct: fc.integer({ min: 0, max: 100 }),
                     textPct: fc.integer({ min: 0, max: 100 }),
                 }),
                 { minLength: 1, maxLength: 20 },
             ),
             (ranges) => {
+                const withEffective = ranges.map((r) => ({ ...r, effectiveTokens: r.tokens }))
                 const result = filterRecommendedRanges(
-                    ranges as CompressibleRange[],
+                    withEffective as CompressibleRange[],
                     [],
                     {},
                 )
                 assert.equal(
                     result.length,
                     ranges.length,
-                    `Input has ${ranges.length} ranges but got ${result.length} — suppression should not occur`,
+                    `Input has ${ranges.length} above-floor ranges but got ${result.length} — suppression should not occur`,
                 )
             },
         ),

--- a/tests/smart-nudge-gating.test.ts
+++ b/tests/smart-nudge-gating.test.ts
@@ -141,3 +141,31 @@ test("protected ranges do not affect filtering logic", () => {
     const withProtected = filterRecommendedRanges(ranges, protectedRanges, OPTS)
     assert.deepEqual(withProtected, withoutProtected)
 })
+test("config-derived floor: minCompressRange 0 disables the size floor (E2E config)", () => {
+    const subFloor = [makeRange("m00001", "m00002", 2, 300)]
+    const kept = filterRecommendedRanges(subFloor, [], {
+        ...OPTS,
+        minEffectiveTokens: 0,
+    })
+    assert.equal(kept.length, 1, "minCompressRange 0 → pipeline accepts any size → range shown")
+})
+
+test("config-derived floor: phantom guard still drops effective-0 ranges at floor 0", () => {
+    const phantomBait = [makeRange("m00001", "m00002", 2, 900, 100, 0)]
+    const kept = filterRecommendedRanges(phantomBait, [], {
+        ...OPTS,
+        minEffectiveTokens: 0,
+    })
+    assert.equal(kept.length, 0, "all-soft-filtered range is phantom bait regardless of floor")
+})
+
+test("config-derived floor: higher minCompressRange raises the floor", () => {
+    const range = [makeRange("m00001", "m00002", 2, 2000)]
+    const defaultFloor = filterRecommendedRanges(range, [], OPTS)
+    const raisedFloor = filterRecommendedRanges(range, [], {
+        ...OPTS,
+        minEffectiveTokens: 5000,
+    })
+    assert.equal(defaultFloor.length, 1)
+    assert.equal(raisedFloor.length, 0, "2000 effective tokens < 20000-char minCompressRange ÷ 4")
+})

--- a/tests/smart-nudge-gating.test.ts
+++ b/tests/smart-nudge-gating.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict"
 import test from "node:test"
-import { filterRecommendedRanges } from "../lib/messages/inject/utils"
+import {
+    filterRecommendedRanges,
+    EFFECTIVE_MIN_COMPRESSIBLE_TOKENS,
+} from "../lib/messages/inject/utils"
 import type { CompressibleRange, ProtectedRange } from "../lib/messages/inject/utils"
 
 function makeRange(
@@ -9,8 +12,17 @@ function makeRange(
     count: number,
     tokens: number,
     toolPct = 100,
+    effectiveTokens?: number,
 ): CompressibleRange {
-    return { startRef, endRef, count, tokens, toolPct, textPct: 100 - toolPct }
+    return {
+        startRef,
+        endRef,
+        count,
+        tokens,
+        effectiveTokens: effectiveTokens ?? tokens,
+        toolPct,
+        textPct: 100 - toolPct,
+    }
 }
 
 function makeProtected(
@@ -63,13 +75,55 @@ test("aggregate below old 5% threshold no longer suppresses (Issue #251)", () =>
     assert.equal(result[1].dangerous, true)
 })
 
-test("tiny ranges (500 tokens) still shown — minCompressRange is the backstop", () => {
+test("sub-floor ranges (below pipeline minimum) dropped — matches minCompressRange rejection", () => {
     const ranges = [
         makeRange("m00001", "m00002", 2, 300),
         makeRange("m00003", "m00004", 2, 200),
     ]
     const result = filterRecommendedRanges(ranges, [], OPTS)
-    assert.equal(result.length, 2)
+    assert.equal(result.length, 0, "ranges below EFFECTIVE_MIN_COMPRESSIBLE_TOKENS are not recommended")
+})
+
+test("range at floor boundary survives, below it drops", () => {
+    const kept = [makeRange("m00001", "m00002", 2, EFFECTIVE_MIN_COMPRESSIBLE_TOKENS)]
+    assert.equal(filterRecommendedRanges(kept, [], OPTS).length, 1)
+
+    const dropped = [makeRange("m00001", "m00002", 2, EFFECTIVE_MIN_COMPRESSIBLE_TOKENS - 1)]
+    assert.equal(filterRecommendedRanges(dropped, [], OPTS).length, 0)
+})
+
+test("effective tokens below floor drops range even when raw tokens are large (retry-loop regression)", () => {
+    // Incident ses_7fb5cbc8 floor 205: display showed "10.8K compressible" but the
+    // pipeline's soft filters (protected zone + last user message) left only ~766
+    // tokens → min-size rejection → model retried the same range ×10.
+    const ranges = [
+        makeRange("m00199", "m00207", 9, 10_800, 100, 766),
+        makeRange("m00150", "m00160", 11, 8_000, 100, 6_200),
+    ]
+    const result = filterRecommendedRanges(ranges, [], OPTS)
+    assert.equal(result.length, 1, "only the range with real compressible content stays")
+    assert.equal(result[0].startRef, "m00150")
+    assert.equal(result[0].dangerous, true, "last surviving range is marked dangerous")
+})
+
+test("all ranges sub-floor → empty result (drives nothingToCompress nudge silence)", () => {
+    const ranges = [
+        makeRange("m00001", "m00002", 2, 1_000),
+        makeRange("m00003", "m00004", 2, 500),
+    ]
+    const result = filterRecommendedRanges(ranges, [], OPTS)
+    assert.equal(result.length, 0)
+})
+
+test("mixed: sub-floor range dropped, big range kept and gets dangerous flag", () => {
+    const ranges = [
+        makeRange("m00001", "m00002", 2, 400),
+        makeRange("m00010", "m00020", 11, 12_000),
+    ]
+    const result = filterRecommendedRanges(ranges, [], OPTS)
+    assert.equal(result.length, 1)
+    assert.equal(result[0].startRef, "m00010")
+    assert.equal(result[0].dangerous, true)
 })
 
 test("empty input returns empty", () => {


### PR DESCRIPTION
## Problem

Issue #37 session `ses_7fb5cbc89d7ee8ky0AsO7Wrp7X` showed a repeated-compression loop ("频繁压缩连续压缩"):

1. **Phantom loop (floors 156-175, ~10 retries)**: nudge recommended `m00141–m00150` as "7.8K compressible". After 4 successful compressions (b23-b26), the remaining messages were the last user message (soft-filtered), 2 protected compress anchors, and 1 empty message — all pipeline-filtered. Every retry failed as phantom; the nudge kept recommending the same range → infinite loop.
2. **Min-size retry (floors 204-206)**: displayed "10.8K compressible" resolved to 3066 chars in the pipeline → `minCompressRange` rejection → retry.
3. **Squeezed context**: remaining "compressible" content was 108-token compress confirmations; the growth-gated nudge kept firing.

## Root Cause

`buildCompressibleRanges` counts raw visible-message tokens without applying the compress pipeline's soft filters (last-user, empty, protected zone). Display overstated compressible content 3.6×.

## Fix

- `CompressibleRange.effectiveTokens`: token sum of messages that survive the pipeline's soft filters
- **Config-derived floor** `resolveEffectiveFloor(config)`: `minCompressRange ÷ 4` (default 1250 tokens); 0 when `minCompressRange: 0` — the recommendation tracks the pipeline's real rejection threshold (fixes E2E scenario 06, which runs with `minCompressRange: 0`)
- Universal phantom guard: `effective > 0` always required (all-soft-filtered ranges are phantom bait regardless of floor)
- Honest display: "0.8K effective of 13.6K"
- `nothingToCompress` extended with `allBelowMin` → nudge silent on squeezed contexts (non-emergency)

## Verification

- Full suite green (typecheck clean, +15 new tests)
- §5.7.3: surgical behavioral revert makes both incident regression tests FAIL; fix restored → green
- E2E scenarios 06/09/10/11/12 pass locally (5/5) after the config-derived floor fix
- Dual-agent review: Oracle verified core mirroring correct (autonomous/multi-user/pruned cases); flagged the hardcoded-floor divergence → addressed in 5924c69. Explore verified no parser breakage, tests exercise real paths.