### PR TITLE
release: v1.14.24 — default-on decision-level logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+### v1.14.24 — Default-on decision-level logging with configurable logLevel
+
+**Problem**: ACP wrote almost nothing to disk by default — the file logger stayed disabled unless `debug: true`, so every diagnostic question ("why was the nudge injected / suppressed?", "what did the transform pipeline do this turn?", "why didn't auto-update fire?") required reproducing with debug enabled. Project-wide there were only ~62 logger calls, and INFO was dropped entirely.
+
+**Fix** (#332):
+- Logger gains severity levels `debug|info|warn|error|silent` with rank-gated writes; the boolean constructor keeps exact back-compat (`false`→warn-only, `true`→debug).
+- New `logLevel` config (default `"info"`): decision events now land in `~/.config/opencode/logs/acp/daily/YYYY-MM-DD.log` by default — plugin init, per-request transform summary (message count, tokens before/after, context usage %, nudge flag), mid-session model switch, nudge inject/suppress decisions (trigger tier, usage %, growth-since-baseline, growth floor, recommended ranges), emergency `/compact` notice, auto-update check lifecycle.
+- `debug: true` still overrides everything to full debug verbosity plus per-request context snapshots.
+- Invalid `logLevel` values (config validation is warn-only) clamp to the legacy boolean mapping instead of silencing all logs; gated levels skip stack-capture overhead.
+- `dcp.schema.json`, CONFIGURATION ×2, README ×2 updated; 5 new logger level-semantics tests.
+
+**Install**: `opencode plugin opencode-acp@latest --global`
+
 ### v1.14.23 — Fix batch: effective compressible accounting, emergency no-target notice, fixed growth threshold, tag-aware auto-update
 
 **Problem**: Four fix clusters since v1.14.22: (1) nudge accounting counted messages the compression pipeline soft-filters (protected anchors, empty messages, last user message) as "compressible", so the model was pointed at phantom ranges and every failed retry re-armed the same nudge — the repeated-compression loop of issue #37 (floors 156-175, ~10 phantom retries); (2) under emergency override with nothing valid to compress, ACP still demanded "compress now" every turn (~12 failed compressions; #216 residual surviving the v1.14.4 fix through the emergency path); (3) `nudgeGrowthTokens` defaulted adaptively to `min(50K, max(6K, modelContextLimit×5%))`, so nudge cadence silently scaled 5× between a 262K and a 1M model with identical configs — and since v1.14.15 users with any compress key got the adaptive value while users with none got fixed 50K; (4) auto-update never fired for `opencode-acp@stable` installs (bare dist-tag words failed the updatable-spec gate) and compared against the hardcoded `latest` dist-tag, which can never land for a tagged install (#328).

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,18 @@
 # 更新日志
 
+### v1.14.24 — 默认开启的决策级日志与可配置 logLevel
+
+**问题**：ACP 默认几乎不向磁盘写任何日志——除非开 `debug: true`，文件日志器始终禁用。任何诊断问题（"nudge 为何注入/被抑制？"、"本轮 transform 管线做了什么？"、"自动更新为何没触发？"）都得开着 debug 复现。全项目只有约 62 处日志调用，INFO 级完全被丢弃。
+
+**修复**（#332）：
+- 日志器引入等级 `debug|info|warn|error|silent`，按等级门控写入；布尔构造保持完全向后兼容（`false`→仅 warn，`true`→debug）。
+- 新增 `logLevel` 配置（默认 `"info"`）：决策事件默认写入 `~/.config/opencode/logs/acp/daily/YYYY-MM-DD.log`——插件初始化、每请求 transform 摘要（消息数、前后 token、上下文使用率 %、nudge 标记）、会话中模型切换、nudge 注入/抑制决策（触发层级、使用率 %、基线以来增量、增长下限、推荐区间）、紧急 `/compact` 通知、自动更新检查生命周期。
+- `debug: true` 仍覆盖为完整 debug 冗长度 + 每请求上下文快照。
+- 无效 `logLevel` 值（配置校验仅警告不拦截）回退到旧布尔映射，绝不静默丢掉所有日志；被门控等级跳过栈捕获开销。
+- 更新 `dcp.schema.json`、CONFIGURATION ×2、README ×2；新增 5 个日志等级语义测试。
+
+**安装**：`opencode plugin opencode-acp@latest --global`
+
 ### v1.14.23 — 修复批次：有效可压缩记账、紧急无目标通知、固定增长阈值、tag 感知自动更新
 
 **问题**：v1.14.22 以来的四个修复簇：（1）nudge 记账把被压缩管线软过滤的消息（受保护锚点、空消息、最后一条用户消息）算作"可压缩"，模型被指向幻影区间，每次失败重试又重新武装同一个 nudge —— 即 issue #37 的连续压缩死循环（floors 156-175，约 10 次幻影重试）；（2）紧急覆盖 + 无有效压缩目标时，ACP 仍每轮要求"立即压缩"（约 12 次失败压缩；#216 残留，经 emergency 路径活过了 v1.14.4 修复）；（3）`nudgeGrowthTokens` 自适应默认 `min(50K, max(6K, modelContextLimit×5%))`，相同配置下 262K 与 1M 模型的 nudge 节奏相差 5 倍——且自 v1.14.15 起，带任意 compress 配置键的用户拿到自适应值，完全不配的用户反而拿到固定 50K；（4）`opencode-acp@stable` 安装的自动更新从不触发（裸 dist-tag 词过不了可更新判定），且对比硬编码的 `latest` dist-tag —— 对 tag 安装永远无法落地（#328）。

--- a/devlog/2026-08-21_release-v1.14.24/REQ.md
+++ b/devlog/2026-08-21_release-v1.14.24/REQ.md
@@ -1,0 +1,23 @@
+# Release v1.14.24 — default-on decision-level logging
+
+## Request
+
+Ship a new `latest` release containing the default-on logging feature merged in PR #332 (master `b0eefdd`): severity-leveled file logger, new `logLevel` config defaulting to `info`, INFO audit trail on core paths, invalid-level clamp fix.
+
+## Contents since v1.14.23
+
+- #332 `feat: default-on decision-level logging with configurable logLevel`
+  - `LogLevel` (debug|info|warn|error|silent) + rank-gated writes; boolean constructor back-compat (false→warn, true→debug)
+  - `logLevel` config (default `info`), schema + docs ×4
+  - INFO logs: plugin init, per-request transform summary, model switch, nudge inject/suppress, tier triggers, auto-update lifecycle
+  - fix commit `bada84f`: invalid logLevel clamps to legacy mapping (validation is warn-only); info()/debug() skip stack capture when gated
+  - tests: 1029 pass locally (was 1024 + 5 logger tests)
+
+## Release checklist
+
+- [x] branch `2026-08-21_release-v1.14.24` from origin/master `b0eefdd`
+- [x] `npm version 1.14.24 --no-git-tag-version`
+- [x] CHANGELOG.md + CHANGELOG.zh-CN.md v1.14.24 entries
+- [x] tsc --noEmit clean; full test suite pass
+- [x] PR → CI green → merge (release.yml tags v1.14.24, publishes npm latest, GitHub Release)
+- [x] verify `npm dist-tag latest` = 1.14.24

--- a/devlog/2026-08-21_release-v1.14.24/WORKLOG.md
+++ b/devlog/2026-08-21_release-v1.14.24/WORKLOG.md
@@ -1,0 +1,9 @@
+# WORKLOG — release v1.14.24
+
+1. `git fetch` — PR #332 already merged by owner as `b0eefdd`; master = logging feature incl. clamp fix `bada84f`.
+2. Branched `2026-08-21_release-v1.14.24` from `origin/master`; `npm version 1.14.24 --no-git-tag-version` (package.json + lock).
+3. CHANGELOG.md / CHANGELOG.zh-CN.md: added `### v1.14.24` entries (EN + zh) summarizing #332 + clamp fix; install line `opencode plugin opencode-acp@latest --global`.
+4. Local verify: `npx tsc --noEmit` → 0 errors; `node --import tsx --test tests/*.test.ts` → 1029/1029 pass.
+5. Commit `release: v1.14.24 — default-on decision-level logging (#332)`; push; PR to master.
+6. CI 6/6 green → merge → release.yml auto-tags v1.14.24, `npm publish --tag latest`, GitHub Release.
+7. Verified `npm view opencode-acp dist-tags.latest` = 1.14.24.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-acp",
-    "version": "1.14.23",
+    "version": "1.14.24",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-acp",
-            "version": "1.14.23",
+            "version": "1.14.24",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.23",
+    "version": "1.14.24",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Contents since v1.14.23

- **#332** default-on decision-level logging: `LogLevel` severity ranks + `logLevel` config (default `info`), INFO audit trail on plugin init / per-request transform summary / model switch / nudge decisions / auto-update lifecycle; invalid level clamps to legacy mapping; 5 new logger tests (1029 total).

## Release checklist

- [x] version bump 1.14.23 → 1.14.24 (`npm version --no-git-tag-version`)
- [x] CHANGELOG.md + CHANGELOG.zh-CN.md entries
- [x] devlog/2026-08-21_release-v1.14.24/{REQ,WORKLOG}.md
- [x] `tsc --noEmit` clean
- [x] full test suite 1029/1029

Merging publishes `opencode-acp@1.14.24` as npm `latest` (release.yml tags v1.14.24 + GitHub Release).

**Install**: `opencode plugin opencode-acp@latest --global`