### PR TITLE
fix: self-disable when running under billion-context proxy

### DIFF
--- a/devlog/2026-08-23_self-disable-proxy/REQ.md
+++ b/devlog/2026-08-23_self-disable-proxy/REQ.md
@@ -1,0 +1,50 @@
+# REQ - Self-disable when billion-context proxy is active
+
+- Task ID: `2026-08-23_self-disable-proxy`
+- Home Repo: `opencode-acp`
+- Created: 2026-08-23
+- Status: Done
+- Priority: P1
+- Owner: bili-agent (qwen3.8-27b)
+- References: companion PRs ranxianglei/billion-context-pi#211 (same guard for pi), ranxianglei/billion-context#211 (opencode launcher + thin /acp plugin)
+
+## 1. Background & Problem Statement
+
+- **Context**: `billion-context` (the `bili` proxy) ships a launcher (`bili opencode`) that transparently injects the four ACP tools (compress / decompress / search_context / acp_status) at the wire level and adds its own `/acp` status command via a thin plugin. Users who ALSO have `opencode-acp` installed get both registered at once.
+- **Current behavior (symptom)**: duplicate tool registrations (same tool names from two sources) and two competing `/acp` commands; the client-side plugin's panel shadows the proxy's real compression state (0% vs 51k blocks).
+- **Expected behavior**: when the bili proxy is driving the session, `opencode-acp` should stand down so a single ACP authority remains.
+- **Impact**: any user running `bili opencode` with `opencode-acp` in `~/.config/opencode/opencode.json` `plugin` list.
+
+## 2. Reproduction (if applicable)
+
+- **Environment**:
+  - Node: 25.9.0
+  - OS/Arch: linux-x64
+- **Minimal reproduction steps**:
+  1. Install `opencode-acp` (e.g. `"plugin": ["opencode-acp@latest"]`).
+  2. Launch `bili opencode`.
+  3. Both stacks register ACP tools; `/acp` shows the client plugin's local state instead of the proxy's.
+- **Relevant configuration**: `BILLION_CONTEXT_PROXY` env var is always set by the bili launcher (points at the local proxy origin).
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+  - Backward compatibility: zero behavior change when `BILLION_CONTEXT_PROXY` is absent (standalone opencode-acp unaffected).
+  - No new dependencies.
+- **Non-Goals** (explicitly out of scope): any coordination protocol, config flag, or UI affordance — env-var detection only.
+
+## 4. Acceptance Criteria (must be testable)
+
+- **Correctness**:
+  - [x] With `BILLION_CONTEXT_PROXY` set, the plugin logs `[opencode-acp] disabled: BILLION_CONTEXT_PROXY detected` and returns an empty object (no tools, no commands).
+  - [x] Without the env var, startup is byte-for-byte identical to before.
+- **Performance / Stability**: one `process.env` read at startup; no runtime cost after.
+
+## 5. Alternatives Considered
+
+- **Config flag (`disableWhenBili`)**: requires user action; env detection is zero-config and the launcher already guarantees the var.
+- **Name-spacing the tools**: rejected upstream — tool names are shared vocabulary with acp-kernel.
+
+## 6. Milestones & Estimates
+
+- Single-commit change; implemented + verified in one pass on 2026-08-23.

--- a/devlog/2026-08-23_self-disable-proxy/WORKLOG.md
+++ b/devlog/2026-08-23_self-disable-proxy/WORKLOG.md
@@ -1,0 +1,56 @@
+# WORKLOG - Self-disable when billion-context proxy is active
+
+- Task ID: `2026-08-23_self-disable-proxy`
+- Home Repo: `opencode-acp`
+- Status: Done
+- Updated: 2026-08-23 23:59
+
+## 1. Summary
+
+- **What was done**: added an early-return guard at the plugin entry point that detects `BILLION_CONTEXT_PROXY` in the environment and disables the whole extension (logs one line, returns an empty plugin object).
+- **Why**: `bili opencode` injects ACP tooling at the wire level; running both stacks duplicates the four tools and the `/acp` command, and the client-side panel shadows the proxy's real state.
+- **Behavior / compatibility changes**: No — zero behavior change without the env var.
+- **Risk level**: Low
+
+## 2. Change Log
+
+### Commits
+
+| Commit | Description |
+|--------|-------------|
+| `51fd677` | feat: self-disable when BILLION_CONTEXT_PROXY is set |
+
+### Key Files
+
+- `src/index.ts` — 4 lines at the top of the `Plugin` initializer: env check + log + `return {}`.
+
+## 3. Design & Implementation Notes
+
+- **Entry point / key function**: the default `Plugin` export (`src/index.ts`), before any hook registration.
+- **Key configuration items**: `process.env.BILLION_CONTEXT_PROXY` (set exclusively by the `bili` launcher / `bili start`).
+- **Key logic explanation**: the bili launcher always exports this var into the child client process, so its presence is a reliable "the proxy owns ACP for this session" signal. Returning an empty object makes opencode treat the plugin as a no-op (same shape as `enabled: false` in plugin config).
+
+## 4. Testing & Verification
+
+### Build & Test Commands
+
+```sh
+cd opencode-acp && npm run build
+npx tsc --noEmit
+node --import tsx --test tests/*.test.ts
+```
+
+### Manual verification
+
+- `BILLION_CONTEXT_PROXY=http://127.0.0.1:8787 opencode run "hi"` → stderr shows `[opencode-acp] disabled: BILLION_CONTEXT_PROXY detected`; no ACP tools registered.
+- Without the var: plugin activates normally, tools present, `/acp` works.
+- End-to-end with the launcher (`node dist/index.js opencode run "reply with exactly: pong"` from billion-context): proxy log shows wire-injected tools `[compress,decompress,search_context,acp_status]` + the bili thin plugin's `/acp` renders the proxy panel.
+
+## 5. Rollback Plan
+
+- Single revert commit; no schema/config/data migrations involved.
+
+## 6. Lessons Learned
+
+- opencode resolves `opencode-acp@latest` from `~/.cache/opencode/packages/` (NOT `~/.config/opencode/node_modules/`) — patching the wrong copy shows no effect; verify the load path in the session log before debugging further.
+- The empty-object return is the same contract as a disabled plugin, so no special-casing is needed elsewhere.

--- a/index.ts
+++ b/index.ts
@@ -34,6 +34,11 @@ const server: Plugin = (async (ctx) => {
         return {}
     }
 
+    if (process.env.BILLION_CONTEXT_PROXY) {
+        console.log("[opencode-acp] disabled: BILLION_CONTEXT_PROXY detected — proxy handles compression")
+        return {}
+    }
+
     const logger = new Logger(config.debug, config.debug ? "debug" : config.logLevel)
     logger.info("ACP plugin initialized", {
         version: typeof ACP_VERSION !== "undefined" ? ACP_VERSION : "dev",


### PR DESCRIPTION
> **Model: qwen3.8-27b (vllm)**

## Problem

When both `opencode-acp` and the `billion-context` proxy MCP are loaded in opencode (via `bili opencode`), they register **identical tool names** (`compress`, `decompress`, `search_context`, `acp_status`). The proxy's tools should take priority.

## Fix

Add a 5-line guard after the `config.enabled` check: if `BILLION_CONTEXT_PROXY` is set (the launcher sets this env var), print a notice and return `{}` early — registering no tools. The proxy MCP then owns all ACP tools.

## Result

- `bili opencode` → opencode-acp disabled, proxy MCP active
- Standalone `opencode` → opencode-acp works normally (client-side compression)
- Both can coexist in plugin config without conflict

## Note

This is the opencode equivalent of billion-context-pi PR #211 (same pattern for pi).
