### PR TITLE
feat: self-disable in manual proxy mode (detect /bili/ in provider baseURL)

### DIFF
--- a/devlog/2026-08-27_bili-proxy-self-disable/DESIGN.md
+++ b/devlog/2026-08-27_bili-proxy-self-disable/DESIGN.md
@@ -1,0 +1,119 @@
+# DESIGN - Self-disable in manual proxy mode
+
+- Task ID: `2026-08-27_bili-proxy-self-disable`
+- Home Repo: `opencode-acp`
+- Created: 2026-08-27
+- Status: InProgress
+
+## 1. Problem
+
+The v1.14.25 self-disable (PR #335) only checks `process.env.BILLION_CONTEXT_PROXY`
+at plugin-factory time. That variable is set exclusively by the `bili <client>`
+launcher. Manual proxy mode (`bili start` + provider `baseURL` pointed at the
+proxy) leaves it unset, so ACP stays active on top of a proxy that already
+manages context.
+
+## 2. Where the provider config is observable
+
+Empirically verified against a live opencode 1.14.46 instance (probe harness in
+`.opencode/probe/`, logs `run*.log` / `fakellm.log`):
+
+1. **The plugin factory (`ctx`) does NOT expose the merged opencode config.**
+   `PluginInput` is `{ client, project, directory, worktree, experimental_workspace,
+   serverUrl, $ }`. Awaiting `ctx.client.config.get()` *inside* the factory
+   **deadlocks** (the HTTP server is not listening yet; the factory promise is
+   awaited before listen). Fire-and-forget succeeds ~30ms after the factory
+   returns — this is why `registry.hydrateModelLimitsFromClient` is already
+   fire-and-forget (index.ts).
+2. **The `config` hook** (`Hooks.config?: (input: Config) => Promise<void>`)
+   fires after the factory returns and **before the first LLM request**, and
+   receives the full merged `Config` including
+   `provider[name].options.baseURL`.
+3. **Setting `permission.<tool> = "deny"` for a plugin-registered tool in the
+   config hook removes that tool from the LLM's tool list** (captured request
+   no longer contained the probe tool). This is the verified lever for
+   tool-level disable.
+
+Therefore detection must happen in the `config` hook, not in the factory.
+
+## 3. Design
+
+### 3.1 Detection — `lib/bili-proxy.ts` (new, pure)
+
+```ts
+export const BILI_PROXY_MARKER = "/bili/"
+export interface BiliProxyMatch { provider: string; baseURL: string }
+export function findBiliProxyProviders(provider: unknown): BiliProxyMatch[]
+```
+
+- Scans every entry of the (possibly undefined) provider map.
+- Reads `options.baseURL` (the SDK-typed location); falls back to a top-level
+  `baseURL` defensively in case the config shape drifts.
+- Case-sensitive substring match on `/bili/`. Deliberately conservative: any
+  provider whose path contains the marker triggers the disable (sessions can
+  switch providers mid-run, so checking only the "default" model's provider
+  would miss switches). Lookalikes (`/bilix/`, `bilibili.com`, bare `/bili`)
+  do not match.
+- Pure function of its input → trivially unit-testable, no SDK imports.
+
+### 3.2 Disable wiring — `index.ts`
+
+Factory scope gains:
+
+```ts
+let disabledByBiliProxy = false
+const guard =
+    <TArgs extends unknown[]>(fn: (...args: TArgs) => Promise<void>) =>
+    (...args: TArgs): Promise<void> =>
+        disabledByBiliProxy ? Promise.resolve() : fn(...args)
+```
+
+- All five hooks (`experimental.chat.system.transform`,
+  `experimental.chat.messages.transform`, `experimental.text.complete`,
+  `command.execute.before`, `event`) are wrapped in `guard(...)`. The creators
+  in `lib/hooks.ts` are untouched — no signature changes, no new parameters
+  flowing through the hook pipeline.
+- The `config` hook, at its top:
+  1. `const biliMatches = findBiliProxyProviders(opencodeConfig.provider)`
+  2. `disabledByBiliProxy = biliMatches.length > 0` — **assigned, not
+     latched**, so a config reload without the proxy restores ACP (the flag
+     and the permission/config mutations are both re-derived per invocation).
+  3. If matches: log
+     `[opencode-acp] disabled: /bili/ proxy detected in provider baseURL (<names>) — proxy handles compression`
+     (console.log, mirroring the env-var guard's user-visible style), set
+     `permission` deny for all five ACP tools (same `as typeof permission`
+     cast pattern as the existing default-permission block), and **return
+     early** — skipping `/acp` command registration, `primary_tools` wiring,
+     default-permission application, and host-permission seeding (all
+     meaningless while disabled).
+
+### 3.3 What is NOT done (and why)
+
+- **The `tool` object on the plugin result is not mutated.** It is built at
+  factory time, before the config hook runs. Removal from the LLM tool list is
+  achieved by the permission `deny` (verified in §2.3). Mutating the returned
+  hooks object late is unverified behavior and unnecessary.
+- **No network probing** of the baseURL — config inspection only (see REQ
+  non-goals).
+- **Factory-time side effects are left as-is** (`startAutoUpdate`,
+  `hydrateModelLimitsFromClient`, `configureClientAuth`): they run before the
+  config hook can detect the proxy, but none of them activate ACP behavior
+  (no tools, transforms, prompts, or commands), so they are harmless.
+- **The env-var guard is unchanged** and remains the fast path (checked before
+  any object allocation at factory time).
+
+### 3.4 State / compatibility impact
+
+- No `SessionState` / persisted-format change.
+- No internal `dcp` tag/naming change.
+- No `package.json` version change (feature branch; release handled separately).
+
+## 4. Failure modes
+
+| Scenario | Behavior |
+|----------|----------|
+| Proxy in one of several providers | Disable triggers (conservative) |
+| `/bili/` appears in a non-proxy URL | ACP disabled; user removes the marker to re-enable (documented trade-off) |
+| Config reload removes the proxy | Flag flips back; next config hook re-applies defaults; hooks resume |
+| `BILLION_CONTEXT_PROXY` also set | Env-var guard wins at factory time; config hook never registered — same outcome |
+| `config.enabled: false` | Unchanged early return before any of this |

--- a/devlog/2026-08-27_bili-proxy-self-disable/REQ.md
+++ b/devlog/2026-08-27_bili-proxy-self-disable/REQ.md
@@ -1,0 +1,109 @@
+# REQ - Self-disable in manual proxy mode (detect `/bili/` in provider baseURL)
+
+- Task ID: `2026-08-27_bili-proxy-self-disable`
+- Home Repo: `opencode-acp`
+- Created: 2026-08-27
+- Status: InProgress
+- Priority: P1
+- Owner: ranxianglei
+- References: https://github.com/ranxianglei/opencode-acp/issues/337, prior art PR #335 (`devlog/2026-08-23_self-disable-proxy/`)
+
+## 1. Background & Problem Statement
+
+- **Context**: Since v1.14.25 (PR #335), opencode-acp self-disables when the
+  `BILLION_CONTEXT_PROXY` environment variable is set, because the
+  billion-context proxy performs its own context compression and running ACP
+  on top of it would double-process context. However, that env var is only
+  set by the `bili <client>` launcher.
+- **Current behavior (symptom)**: In **manual proxy mode** — user runs
+  `bili start` and points an opencode provider's `baseURL` at the proxy
+  (`http://<proxy-host>:<port>/bili/<upstream-url>`) — ACP stays fully
+  active: it injects `mNNNNN` message IDs, appends the ACP system prompt,
+  fires nudges, and registers the compress/decompress/acp_status/
+  acp_context_recap/search_context tools. The proxy and ACP then both try to
+  manage context.
+- **Expected behavior**: ACP detects the proxy in the provider config and
+  disables itself with the same effect as the env-var guard: no ACP tools in
+  the LLM tool list, no system-prompt injection, no message-transform
+  pipeline (IDs/nudges/pruning), no `/acp` command.
+- **Impact**: Users in manual proxy mode get conflicting context management
+  (ACP nudges reference compression tools/state the proxy does not know
+  about); the documented zero-config detection signal (`/bili/` in baseURL,
+  per billion-context CONFIGURATION.md) is ignored.
+
+## 2. Reproduction (if applicable)
+
+- **Environment**:
+  - Node: 22/24
+  - OS/Arch: linux
+- **Minimal reproduction steps**:
+  1) `bili start` (proxy on some port, e.g. 8787)
+  2) In opencode config, set a provider
+     `options.baseURL = "http://127.0.0.1:8787/bili/https://api.openai.com/v1"`
+  3) Start opencode with the opencode-acp plugin (no `BILLION_CONTEXT_PROXY`
+     env var)
+  4) Observe: ACP system prompt appended, `mNNNNN` IDs injected, ACP tools
+     present in the LLM request — ACP did NOT self-disable.
+- **Relevant configuration**: provider `options.baseURL` containing the
+  `/bili/` path prefix.
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+  - Backward compatibility: the `BILLION_CONTEXT_PROXY` env-var guard must
+    keep working unchanged (fast path at plugin init). Persisted state
+    format and internal `dcp` naming are untouched.
+  - Performance: detection runs once per config-hook invocation over the
+    provider map (O(providers)); zero added cost per LLM request when no
+    proxy is present (one boolean check in each guarded hook).
+  - No new dependencies.
+- **Non-Goals** (explicitly out of scope):
+  - Detecting the proxy by probing the network (e.g. HTTP HEAD to the
+    baseURL) — config inspection only.
+  - Changing what the billion-context proxy itself does.
+  - A user-facing config option to opt out of the disable (if the proxy is
+    in the path, ACP must be off; remove the proxy to re-enable).
+
+## 4. Acceptance Criteria (must be testable)
+
+- **Correctness**:
+  - [x] When any provider's `baseURL` (under `options`, or defensively at the
+    provider top level) contains `/bili/`, the config hook sets
+    `permission = "deny"` for all five ACP tools
+    (compress, decompress, search_context, acp_status, acp_context_recap).
+  - [x] In that case the `/acp` command is not registered and
+    `experimental.primary_tools` is not modified.
+  - [x] In that case all five ACP hooks (system.transform,
+    messages.transform, text.complete, command.execute.before, event) are
+    no-ops: messages arrive at the LLM unmodified and no ACP system prompt is
+    appended.
+  - [x] When no provider routes through the proxy, behavior is identical to
+    before (command registered, defaults applied, full pipeline runs).
+  - [x] If a later config-hook invocation sees no proxy (config reload),
+    ACP behavior is restored (flag is assigned, not latched).
+  - [x] Lookalike paths do NOT trigger the disable: `/bilix/`,
+    `bilibili.com`, `/bili` without trailing slash, `api.bili.example.com`.
+- **Performance / Stability**:
+  - [x] No per-request cost beyond a boolean read; no network calls.
+- **Regression**:
+  - [x] New/modified test cases added to test suite and passing
+    (`tests/bili-proxy.test.ts`, `tests/bili-proxy-integration.test.ts`;
+    full suite green).
+
+## 5. Proposed Approach (optional)
+
+- **Affected modules & entry files**:
+  - `lib/bili-proxy.ts` (new) — pure detection: `findBiliProxyProviders(provider)`
+  - `index.ts` — config hook: detect → deny tools → skip wiring → set flag;
+    factory-scoped `guard()` wraps the five hooks
+  - `tests/bili-proxy.test.ts`, `tests/bili-proxy-integration.test.ts` (new)
+- **Risks**:
+  - False positive: a non-proxy baseURL that happens to contain `/bili/`
+    would disable ACP. Accepted — the marker is the documented proxy path
+    prefix; user removes it from the URL to re-enable.
+  - The `tool` object on the plugin result is not mutated; disabling relies
+    on permission `deny` removing the tools from the LLM tool list. This was
+    verified empirically against a live opencode instance (probe run in
+    `.opencode/probe/`, see WORKLOG).
+- **Rollback strategy**: revert the single commit; no state migration
+  involved.

--- a/devlog/2026-08-27_bili-proxy-self-disable/WORKLOG.md
+++ b/devlog/2026-08-27_bili-proxy-self-disable/WORKLOG.md
@@ -1,0 +1,135 @@
+# WORKLOG - Self-disable in manual proxy mode (detect `/bili/` in provider baseURL)
+
+- Task ID: `2026-08-27_bili-proxy-self-disable`
+- Home Repo: `opencode-acp`
+- Status: InProgress
+- Updated: 2026-08-27
+
+## 1. Summary
+
+- **What was done** (1–3 sentences): Added `lib/bili-proxy.ts` (pure
+  detection of the `/bili/` proxy marker in provider baseURLs) and wired it
+  into the plugin `config` hook in `index.ts`: on detection, all five ACP
+  tools are permission-denied (removing them from the LLM tool list), the
+  `/acp` command and `primary_tools` wiring are skipped, and a factory-scoped
+  flag turns all five ACP hooks into no-ops.
+- **Why** (1–3 sentences): Issue #337 — the v1.14.25 self-disable only checks
+  `BILLION_CONTEXT_PROXY`, which only the `bili <client>` launcher sets.
+  Manual proxy mode (`bili start` + provider `baseURL` at the proxy) left ACP
+  fully active on top of a proxy that already compresses context. The
+  `/bili/` path prefix in a baseURL is the documented zero-config detection
+  signal.
+- **Behavior / compatibility changes**: Yes — new: when a provider baseURL
+  contains `/bili/`, ACP disables itself (same effect as the env-var guard).
+  No change to persisted state format, internal `dcp` naming, or the env-var
+  path.
+- **Risk level**: Low
+
+## 2. Change Log
+
+### Commits
+
+| Commit | Description |
+|--------|-------------|
+| `08441a2` | feat: self-disable in manual proxy mode (detect `/bili/` in provider baseURL) |
+
+### Key Files
+
+- `lib/bili-proxy.ts` (new) — pure detection: `BILI_PROXY_MARKER = "/bili/"`,
+  `findBiliProxyProviders(provider): BiliProxyMatch[]`; reads
+  `options.baseURL` (SDK-typed location) with a defensive top-level
+  `baseURL` fallback.
+- `index.ts` — import; factory-scoped `disabledByBiliProxy` flag + `guard()`
+  wrapper around the five hooks; config hook: detect → log → deny five ACP
+  tools → early return (skip command/primary_tools/permission defaults/
+  host-permission seeding).
+- `tests/bili-proxy.test.ts` (new) — 11 unit tests for the detector
+  (marker constant, null/non-object input, options vs top-level precedence,
+  multi-provider, non-string values, lookalike negatives).
+- `tests/bili-proxy-integration.test.ts` (new) — 4 integration tests through
+  the real plugin factory (index.ts) with isolated XDG homes and
+  `autoUpdate: false`: deny + skip-wiring on detection; all hooks no-op;
+  enabled path unchanged (command registered, ID injection runs); re-enable
+  after the proxy is removed from config.
+- `devlog/2026-08-27_bili-proxy-self-disable/` — REQ / DESIGN / WORKLOG.
+
+## 3. Design & Implementation Notes
+
+- **Entry point / key function**: `findBiliProxyProviders` (lib/bili-proxy.ts)
+  called from the `config` hook (index.ts).
+- **Key logic explanation**: See DESIGN.md. Detection must live in the
+  `config` hook because the plugin factory (`ctx`) does not expose the merged
+  opencode config, and awaiting `client.config.get()` inside the factory
+  deadlocks (verified empirically — the server is not listening yet). The
+  config hook fires before the first LLM request with the full merged
+  provider config. Tool removal from the LLM request is achieved via
+  `permission: "deny"` (verified against a live opencode 1.14.46 instance:
+  denied plugin tools are absent from the captured request's tool list).
+- **Flag semantics**: `disabledByBiliProxy` is assigned (not latched) on each
+  config-hook invocation so a config reload without the proxy restores ACP.
+
+## 4. Testing & Verification
+
+### Build & Test Commands
+
+```sh
+npm run build
+npm run typecheck
+node --import tsx --test tests/*.test.ts
+node --import tsx --test tests/bili-proxy.test.ts tests/bili-proxy-integration.test.ts
+```
+
+### Test Coverage
+
+- New/modified test files: `tests/bili-proxy.test.ts`,
+  `tests/bili-proxy-integration.test.ts`
+- Test count: 1044 total, 1044 pass, 0 fail (15 new: 11 unit + 4 integration)
+- Key scenarios verified:
+  - `/bili/` in `options.baseURL` → all 5 tools denied, no `/acp` command,
+    no `primary_tools` mutation
+  - disabled: messages.transform leaves message text byte-identical
+    (no ID injection), system.transform appends nothing, text.complete is a
+    no-op, event hook resolves
+  - no proxy: `/acp` command registered, `compress: "allow"` default applied,
+    `dcp-message-id` injection runs (real pipeline)
+  - proxy removed in a later config invocation → ACP behavior restored
+  - lookalikes rejected: `/bilix/`, `bilibili.com`, `/bili` (no slash),
+    `api.bili.example.com`
+
+### Results
+
+- **PASS/FAIL**: PASS — typecheck clean, build clean, 1044/1044 tests pass.
+- **Key logs/data**: live-opencode probe (`.opencode/probe/`, gitignored):
+  config hook receives merged provider config before first LLM request;
+  permission-deny removes plugin tools from the request; factory-time
+  `client.config.get()` await deadlocks.
+
+## 5. Risk Assessment & Rollback
+
+- **Risk points**:
+  - False positive on a non-proxy URL containing `/bili/` → ACP disabled
+    until the URL changes. Accepted, documented in REQ §3/DESIGN §4.
+  - `format:check` fails on ~413 pre-existing files in this environment
+    (prettier 3.9.5 vs the repo's 3.8.x formatting baseline); files touched
+    by this change were formatted with the installed prettier. CI does not
+    run format:check.
+- **Rollback method**:
+  - Revert commit(s): `08441a2`
+  - Rollback impact: none — additive module + index.ts wiring; no state
+    migration.
+- **Compatibility notes** (data format, config schema): No changes.
+
+## 6. Lessons Learned (optional)
+
+- The plugin `config` hook is the only reliable, non-deadlocking point to
+  read the merged opencode config (provider baseURLs included) — factory-time
+  client awaits deadlock because the server starts listening after the
+  factory resolves.
+- Permission `deny` is a verified lever for removing plugin-registered tools
+  from the LLM tool list without mutating the plugin result object late.
+
+## 7. Follow-ups (optional)
+
+- [ ] Consider a config option to override the disable (REQ non-goal for now)
+- [ ] Docker E2E scenario for the nudge→compress flow is unaffected; no
+      nudge/growth logic changed (§5.7 not triggered)

--- a/devlog/2026-08-27_bili-proxy-self-disable/WORKLOG.md
+++ b/devlog/2026-08-27_bili-proxy-self-disable/WORKLOG.md
@@ -31,7 +31,7 @@
 
 | Commit | Description |
 |--------|-------------|
-| `08441a2` | feat: self-disable in manual proxy mode (detect `/bili/` in provider baseURL) |
+| `52f3356` | feat: self-disable in manual proxy mode (detect `/bili/` in provider baseURL) |
 
 ### Key Files
 
@@ -114,7 +114,7 @@ node --import tsx --test tests/bili-proxy.test.ts tests/bili-proxy-integration.t
     by this change were formatted with the installed prettier. CI does not
     run format:check.
 - **Rollback method**:
-  - Revert commit(s): `08441a2`
+  - Revert commit(s): `52f3356`
   - Rollback impact: none — additive module + index.ts wiring; no state
     migration.
 - **Compatibility notes** (data format, config schema): No changes.

--- a/index.ts
+++ b/index.ts
@@ -25,6 +25,7 @@ import {
     createTextCompleteHandler,
 } from "./lib/hooks"
 import { configureClientAuth, isSecureMode } from "./lib/auth"
+import { findBiliProxyProviders } from "./lib/bili-proxy"
 import { startAutoUpdate } from "./lib/update"
 
 const server: Plugin = (async (ctx) => {
@@ -35,7 +36,9 @@ const server: Plugin = (async (ctx) => {
     }
 
     if (process.env.BILLION_CONTEXT_PROXY) {
-        console.log("[opencode-acp] disabled: BILLION_CONTEXT_PROXY detected — proxy handles compression")
+        console.log(
+            "[opencode-acp] disabled: BILLION_CONTEXT_PROXY detected — proxy handles compression",
+        )
         return {}
     }
 
@@ -100,31 +103,44 @@ const server: Plugin = (async (ctx) => {
         prompts,
     }
 
+    // [FIX #337] Manual proxy mode: the bili proxy may be detected in a
+    // provider baseURL by the config hook (the BILLION_CONTEXT_PROXY env var
+    // is only set by the `bili <client>` launcher, not by manual proxy mode).
+    // When detected, every ACP hook becomes a no-op so the proxy handles
+    // compression alone. Assigned (not latched) so a config reload that
+    // removes the proxy restores ACP behavior.
+    let disabledByBiliProxy = false
+    const guard =
+        <TArgs extends unknown[]>(fn: (...args: TArgs) => Promise<void>) =>
+        (...args: TArgs): Promise<void> =>
+            disabledByBiliProxy ? Promise.resolve() : fn(...args)
+
     return {
-        "experimental.chat.system.transform": createSystemPromptHandler(
-            registry,
-            logger,
-            config,
-            prompts,
+        "experimental.chat.system.transform": guard(
+            createSystemPromptHandler(registry, logger, config, prompts),
         ),
-        "experimental.chat.messages.transform": createChatMessageTransformHandler(
-            ctx.client,
-            registry,
-            logger,
-            config,
-            prompts,
-            hostPermissions,
+        "experimental.chat.messages.transform": guard(
+            createChatMessageTransformHandler(
+                ctx.client,
+                registry,
+                logger,
+                config,
+                prompts,
+                hostPermissions,
+            ),
         ) as any,
-        "experimental.text.complete": createTextCompleteHandler(),
-        "command.execute.before": createCommandExecuteHandler(
-            ctx.client,
-            registry,
-            logger,
-            config,
-            ctx.directory,
-            hostPermissions,
+        "experimental.text.complete": guard(createTextCompleteHandler()),
+        "command.execute.before": guard(
+            createCommandExecuteHandler(
+                ctx.client,
+                registry,
+                logger,
+                config,
+                ctx.directory,
+                hostPermissions,
+            ),
         ),
-        event: createEventHandler(registry, logger),
+        event: guard(createEventHandler(registry, logger)),
         tool: {
             ...(config.compress.permission !== "deny" && {
                 compress: createCompressRangeTool(compressToolContext),
@@ -135,6 +151,32 @@ const server: Plugin = (async (ctx) => {
             }),
         },
         config: async (opencodeConfig) => {
+            // [FIX #337] Manual proxy mode: a provider baseURL routed through
+            // the bili proxy (`/bili/` prefix) means the proxy handles context
+            // compression — ACP must stay fully off, mirroring the
+            // BILLION_CONTEXT_PROXY env-var guard. Denying the ACP tools
+            // removes them from the LLM tool list (verified against a live
+            // opencode instance), and the guard flag no-ops every hook.
+            const biliMatches = findBiliProxyProviders(opencodeConfig.provider)
+            disabledByBiliProxy = biliMatches.length > 0
+            if (biliMatches.length > 0) {
+                console.log(
+                    "[opencode-acp] disabled: /bili/ proxy detected in provider baseURL (" +
+                        biliMatches.map((m) => m.provider).join(", ") +
+                        ") — proxy handles compression",
+                )
+                const permission = opencodeConfig.permission ?? {}
+                opencodeConfig.permission = {
+                    ...permission,
+                    compress: "deny",
+                    decompress: "deny",
+                    search_context: "deny",
+                    acp_status: "deny",
+                    acp_context_recap: "deny",
+                } as typeof permission
+                return
+            }
+
             if (
                 config.compress.permission !== "deny" &&
                 compressDisabledByOpencode(opencodeConfig.permission)

--- a/lib/bili-proxy.ts
+++ b/lib/bili-proxy.ts
@@ -1,0 +1,58 @@
+/**
+ * Billion-context (`bili`) proxy detection in opencode provider config.
+ *
+ * Manual proxy mode (`bili start` + a provider whose baseURL is pointed at
+ * the proxy) does NOT set `BILLION_CONTEXT_PROXY` — that env var is only set
+ * by the `bili <client>` launcher. The `/bili/` path prefix in a provider
+ * baseURL is the documented zero-config self-detection signal (billion-context
+ * CONFIGURATION.md): `http://<proxy-host>:<port>/bili/<upstream-url>`.
+ *
+ * When a provider routes through the proxy, the proxy handles context
+ * compression itself, so ACP must disable itself (same behavior as the
+ * `BILLION_CONTEXT_PROXY` env-var guard in index.ts).
+ */
+
+export const BILI_PROXY_MARKER = "/bili/"
+
+export interface BiliProxyMatch {
+    provider: string
+    baseURL: string
+}
+
+function extractBaseURL(entry: unknown): string | undefined {
+    if (!entry || typeof entry !== "object") return undefined
+    const record = entry as Record<string, unknown>
+    const options = record.options
+    if (options && typeof options === "object") {
+        const optionBaseURL = (options as Record<string, unknown>).baseURL
+        if (typeof optionBaseURL === "string" && optionBaseURL.length > 0) {
+            return optionBaseURL
+        }
+    }
+    // Defensive fallback: some configs place baseURL at the provider top
+    // level rather than under `options`.
+    const topLevelBaseURL = record.baseURL
+    if (typeof topLevelBaseURL === "string" && topLevelBaseURL.length > 0) {
+        return topLevelBaseURL
+    }
+    return undefined
+}
+
+/**
+ * Scan opencode's provider config for every provider whose baseURL routes
+ * through the bili proxy (contains the `/bili/` path prefix).
+ *
+ * Pure function — safe to unit test. Returns `[]` for null/undefined/non-object
+ * input and for providers without a string baseURL.
+ */
+export function findBiliProxyProviders(provider: unknown): BiliProxyMatch[] {
+    if (!provider || typeof provider !== "object") return []
+    const matches: BiliProxyMatch[] = []
+    for (const [name, entry] of Object.entries(provider as Record<string, unknown>)) {
+        const baseURL = extractBaseURL(entry)
+        if (baseURL !== undefined && baseURL.includes(BILI_PROXY_MARKER)) {
+            matches.push({ provider: name, baseURL })
+        }
+    }
+    return matches
+}

--- a/tests/bili-proxy-integration.test.ts
+++ b/tests/bili-proxy-integration.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Integration tests for the #337 manual-proxy self-disable: the plugin
+ * factory's config hook detects a `/bili/` proxy in a provider baseURL and
+ * (a) denies all ACP tools in opencode's permission config (which removes
+ * them from the LLM tool list), (b) skips the /acp command + primary_tools
+ * wiring, and (c) turns every ACP hook into a no-op via the guard flag.
+ *
+ * The plugin is imported through the real factory (index.ts) with an
+ * isolated XDG_CONFIG_HOME / XDG_DATA_HOME so no host config or state is
+ * touched. autoUpdate is disabled via the ACP config file so the factory
+ * performs no network activity.
+ */
+
+import assert from "node:assert/strict"
+import test from "node:test"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { mkdirSync, writeFileSync } from "node:fs"
+import type { PluginInput, Hooks, Config } from "@opencode-ai/plugin"
+import type { WithParts } from "../lib/state"
+
+const testDataHome = join(tmpdir(), `opencode-acp-bili-data-${process.pid}`)
+const testConfigHome = join(tmpdir(), `opencode-acp-bili-config-${process.pid}`)
+
+// Must be set BEFORE importing ../index: lib/config.ts captures
+// XDG_CONFIG_HOME into a module-level constant at import time.
+process.env.XDG_DATA_HOME = testDataHome
+process.env.XDG_CONFIG_HOME = testConfigHome
+delete process.env.BILLION_CONTEXT_PROXY
+delete process.env.OPENCODE_CONFIG_DIR
+delete process.env.OPENCODE_SERVER_PASSWORD
+
+mkdirSync(join(testConfigHome, "opencode"), { recursive: true })
+writeFileSync(
+    join(testConfigHome, "opencode", "acp.jsonc"),
+    JSON.stringify({ autoUpdate: false }),
+    "utf-8",
+)
+mkdirSync(testDataHome, { recursive: true })
+
+const { default: plugin } = await import("../index")
+
+function makeCtx(): PluginInput {
+    const client = {
+        config: {
+            providers: async () => ({ data: { providers: [] } }),
+            get: async () => ({ data: {} }),
+        },
+        session: {
+            get: async () => ({ data: {} }),
+            messages: async () => ({ data: [] }),
+        },
+        tui: { showToast: async () => {} },
+    }
+    // The factory only touches client.config.providers(),
+    // client.session.get() and (in secure mode) client interceptors — a
+    // structural stub is sufficient for the hooks under test.
+    return {
+        client: client as PluginInput["client"],
+        project: { path: testDataHome },
+        directory: testDataHome,
+        worktree: testDataHome,
+        experimental_workspace: { register: () => {} },
+        serverUrl: new URL("http://127.0.0.1:1"),
+        $: { command: async () => "" } as PluginInput["$"],
+    }
+}
+
+const ACP_TOOLS = ["compress", "decompress", "search_context", "acp_status", "acp_context_recap"]
+
+function makeUserMessage(id: string, text: string, sessionId: string): WithParts {
+    return {
+        info: {
+            id,
+            sessionID: sessionId,
+            role: "user",
+            agent: "assistant",
+            time: { created: Date.now() },
+            model: { providerID: "test-provider", modelID: "test-model" },
+        } as WithParts["info"],
+        parts: [{ type: "text", text, id: `${id}-p1`, sessionID: sessionId, messageID: id }],
+    }
+}
+
+async function makeHooks(): Promise<Hooks> {
+    const hooks = await plugin(makeCtx())
+    assert.ok(hooks.config, "plugin factory must register a config hook")
+    return hooks
+}
+
+test("config hook with /bili/ proxy: denies all ACP tools and skips command wiring", async () => {
+    const hooks = await makeHooks()
+
+    const opencodeConfig: Config = {
+        provider: {
+            openai: {
+                options: {
+                    baseURL: "http://127.0.0.1:8787/bili/https://api.openai.com/v1",
+                },
+            },
+        },
+    }
+
+    await hooks.config!(opencodeConfig)
+
+    for (const tool of ACP_TOOLS) {
+        assert.equal(
+            (opencodeConfig.permission as Record<string, unknown>)[tool],
+            "deny",
+            `permission.${tool} must be "deny" when the bili proxy is detected`,
+        )
+    }
+    assert.equal(
+        opencodeConfig.command?.["acp"],
+        undefined,
+        "/acp command must not be registered when disabled by the bili proxy",
+    )
+    assert.equal(
+        opencodeConfig.experimental?.primary_tools,
+        undefined,
+        "primary_tools must not be touched when disabled by the bili proxy",
+    )
+})
+
+test("config hook with /bili/ proxy: every ACP hook is a no-op", async () => {
+    const hooks = await makeHooks()
+
+    const opencodeConfig: Config = {
+        provider: {
+            anthropic: { options: { baseURL: "http://127.0.0.1:8787/bili/" } },
+        },
+    }
+    await hooks.config!(opencodeConfig)
+
+    // messages.transform must leave the messages untouched (no ID injection,
+    // no nudges, no pruning) — the proxy handles compression.
+    const messages = [
+        makeUserMessage("msg-1", "hello world", "session-bili-1"),
+        makeUserMessage("msg-2", "second message", "session-bili-1"),
+    ]
+    const output = { messages }
+    await hooks["experimental.chat.messages.transform"]!({}, output)
+    assert.equal(output.messages[0].parts[0].text, "hello world")
+    assert.equal(output.messages[1].parts[0].text, "second message")
+
+    // system.transform must not append the ACP system prompt.
+    const system: string[] = ["base system prompt"]
+    await hooks["experimental.chat.system.transform"]!(
+        {
+            sessionID: "session-bili-1",
+            model: { providerID: "anthropic", id: "claude", limit: { context: 200000 } },
+        },
+        { system },
+    )
+    assert.equal(system.length, 1)
+    assert.equal(system[0], "base system prompt")
+
+    // text.complete must not strip anything.
+    const textOutput = { text: "m00001 b0 some refs" }
+    await hooks["experimental.text.complete"]!(
+        { sessionID: "session-bili-1", messageID: "msg-1", partID: "part-1" },
+        textOutput,
+    )
+    assert.equal(textOutput.text, "m00001 b0 some refs")
+
+    // event hook must resolve without error.
+    await hooks.event!({
+        event: { type: "session.idle", properties: { sessionID: "session-bili-1" } },
+    })
+})
+
+test("config hook without /bili/ proxy: ACP stays enabled (command + defaults wired)", async () => {
+    const hooks = await makeHooks()
+
+    const opencodeConfig: Config = {
+        provider: {
+            openai: { options: { baseURL: "https://api.openai.com/v1" } },
+        },
+    }
+
+    await hooks.config!(opencodeConfig)
+
+    assert.equal(
+        opencodeConfig.command?.["acp"]?.description,
+        "Show available ACP commands",
+        "/acp command must be registered when no bili proxy is detected",
+    )
+    assert.equal(
+        (opencodeConfig.permission as Record<string, unknown>)["compress"],
+        "allow",
+        "default compress permission must be applied when no bili proxy is detected",
+    )
+
+    // messages.transform must run the real pipeline (ID injection happens).
+    const messages = [makeUserMessage("msg-1", "hello world", "session-bili-2")]
+    const output = { messages }
+    await hooks["experimental.chat.messages.transform"]!({}, output)
+    const text = output.messages[0].parts[0].text as string
+    assert.ok(
+        text.includes("dcp-message-id"),
+        `ACP ID injection must run when enabled, got: ${JSON.stringify(text)}`,
+    )
+})
+
+test("config hook re-enable: removing the proxy restores ACP behavior", async () => {
+    const hooks = await makeHooks()
+
+    const withProxy: Config = {
+        provider: {
+            openai: {
+                options: { baseURL: "http://127.0.0.1:8787/bili/https://api.openai.com/v1" },
+            },
+        },
+    }
+    await hooks.config!(withProxy)
+    assert.equal((withProxy.permission as Record<string, unknown>)["compress"], "deny")
+
+    // Simulate a config reload where the provider no longer routes through
+    // the proxy: the flag must flip back and the real pipeline must resume.
+    const withoutProxy: Config = {
+        provider: { openai: { options: { baseURL: "https://api.openai.com/v1" } } },
+    }
+    await hooks.config!(withoutProxy)
+    assert.equal((withoutProxy.permission as Record<string, unknown>)["compress"], "allow")
+
+    const messages = [makeUserMessage("msg-1", "hello world", "session-bili-3")]
+    const output = { messages }
+    await hooks["experimental.chat.messages.transform"]!({}, output)
+    const text = output.messages[0].parts[0].text as string
+    assert.ok(
+        text.includes("dcp-message-id"),
+        `ACP must be re-enabled after the proxy is removed, got: ${JSON.stringify(text)}`,
+    )
+})

--- a/tests/bili-proxy.test.ts
+++ b/tests/bili-proxy.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { BILI_PROXY_MARKER, findBiliProxyProviders } from "../lib/bili-proxy"
+
+describe("BILI_PROXY_MARKER", () => {
+    it("is the /bili/ path prefix", () => {
+        assert.equal(BILI_PROXY_MARKER, "/bili/")
+    })
+})
+
+describe("findBiliProxyProviders", () => {
+    it("returns [] for undefined, null, and non-object input", () => {
+        assert.deepEqual(findBiliProxyProviders(undefined), [])
+        assert.deepEqual(findBiliProxyProviders(null), [])
+        assert.deepEqual(findBiliProxyProviders("http://x/bili/y"), [])
+        assert.deepEqual(findBiliProxyProviders(42), [])
+    })
+
+    it("returns [] for an empty provider map", () => {
+        assert.deepEqual(findBiliProxyProviders({}), [])
+    })
+
+    it("matches a provider whose options.baseURL contains /bili/", () => {
+        const matches = findBiliProxyProviders({
+            openai: {
+                options: {
+                    baseURL: "http://127.0.0.1:8787/bili/https://api.openai.com/v1",
+                },
+            },
+        })
+        assert.equal(matches.length, 1)
+        assert.equal(matches[0].provider, "openai")
+        assert.equal(matches[0].baseURL, "http://127.0.0.1:8787/bili/https://api.openai.com/v1")
+    })
+
+    it("matches a bare proxy baseURL ending in /bili/", () => {
+        const matches = findBiliProxyProviders({
+            anthropic: {
+                options: { baseURL: "http://proxy-host:8787/bili/" },
+            },
+        })
+        assert.equal(matches.length, 1)
+        assert.equal(matches[0].provider, "anthropic")
+    })
+
+    it("matches a top-level baseURL (defensive fallback)", () => {
+        const matches = findBiliProxyProviders({
+            google: {
+                baseURL: "http://127.0.0.1:8787/bili/https://generativelanguage.googleapis.com",
+            },
+        })
+        assert.equal(matches.length, 1)
+        assert.equal(matches[0].provider, "google")
+    })
+
+    it("prefers options.baseURL over top-level baseURL", () => {
+        // options.baseURL wins: no marker there → no match even if top-level has one
+        const none = findBiliProxyProviders({
+            p: {
+                baseURL: "http://x/bili/y",
+                options: { baseURL: "https://direct.example.com/v1" },
+            },
+        })
+        assert.deepEqual(none, [])
+
+        // options.baseURL wins: marker there → match reports options value
+        const some = findBiliProxyProviders({
+            p: {
+                baseURL: "https://direct.example.com/v1",
+                options: { baseURL: "http://x/bili/y" },
+            },
+        })
+        assert.equal(some.length, 1)
+        assert.equal(some[0].baseURL, "http://x/bili/y")
+    })
+
+    it("returns all matching providers when several route through the proxy", () => {
+        const matches = findBiliProxyProviders({
+            openai: {
+                options: { baseURL: "http://127.0.0.1:8787/bili/https://api.openai.com/v1" },
+            },
+            anthropic: { options: { baseURL: "https://api.anthropic.com" } },
+            google: {
+                options: {
+                    baseURL: "http://127.0.0.1:8787/bili/https://generativelanguage.googleapis.com",
+                },
+            },
+        })
+        assert.deepEqual(
+            matches.map((m) => m.provider),
+            ["openai", "google"],
+        )
+    })
+
+    it("returns [] when no provider routes through the proxy", () => {
+        assert.deepEqual(
+            findBiliProxyProviders({
+                openai: { options: { baseURL: "https://api.openai.com/v1" } },
+                anthropic: { options: { apiKey: "sk-test" } },
+                google: {},
+            }),
+            [],
+        )
+    })
+
+    it("ignores non-string and empty baseURL values", () => {
+        assert.deepEqual(
+            findBiliProxyProviders({
+                a: { options: { baseURL: 8787 } },
+                b: { options: { baseURL: { host: "x" } } },
+                c: { options: { baseURL: "" } },
+                d: { options: {} },
+                e: null,
+                f: "not-an-object",
+            }),
+            [],
+        )
+    })
+
+    it("does not match lookalike paths (/bilix/, bilibili.com, /bili without slash)", () => {
+        assert.deepEqual(
+            findBiliProxyProviders({
+                a: { options: { baseURL: "http://x/bilix/v1" } },
+                b: { options: { baseURL: "https://bilibili.com/api" } },
+                c: { options: { baseURL: "http://x/bili" } },
+                d: { options: { baseURL: "https://api.bili.example.com/v1" } },
+            }),
+            [],
+        )
+    })
+})


### PR DESCRIPTION
Closes #337

## Problem

The v1.14.25 self-disable (PR #335) only checks `BILLION_CONTEXT_PROXY`, which is set exclusively by the `bili <client>` launcher. In **manual proxy mode** (`bili start` + provider `baseURL` pointed at the proxy, e.g. `http://127.0.0.1:8787/bili/https://api.openai.com/v1`) the env var is unset, so ACP stayed fully active on top of a proxy that already manages context.

## Fix

Detection now also runs in the plugin `config` hook (the only non-deadlocking point that sees the merged provider config — verified empirically against a live opencode instance; awaiting `client.config.get()` in the factory deadlocks because the server listens after the factory resolves):

- **`lib/bili-proxy.ts`** (new, pure): `findBiliProxyProviders()` scans provider `options.baseURL` (defensive top-level fallback) for the documented `/bili/` path prefix. Lookalikes (`/bilix/`, `bilibili.com`, bare `/bili`) do not match.
- **`index.ts`**: on detection the config hook (which fires before the first LLM request)
  - sets `permission: "deny"` for all five ACP tools — verified this removes them from the LLM tool list,
  - skips `/acp` command registration and `primary_tools` wiring,
  - sets a factory-scoped flag that no-ops all five ACP hooks (system prompt, message transform, text complete, command, event) via a type-safe `guard()` wrapper — no signature changes in `lib/hooks.ts`.
  - The flag is **assigned, not latched**: a config reload without the proxy restores ACP.
- The `BILLION_CONTEXT_PROXY` env-var fast path is unchanged.

## Tests

15 new tests, full suite **1044/1044 pass**, typecheck + build clean:

- `tests/bili-proxy.test.ts` — 11 unit tests (marker, null/non-object input, `options` vs top-level precedence, multi-provider, non-string values, lookalike negatives)
- `tests/bili-proxy-integration.test.ts` — 4 integration tests through the real plugin factory with isolated XDG homes: deny + skip-wiring on detection; all hooks no-op (messages byte-identical, no system prompt appended); enabled path unchanged (command registered, `dcp-message-id` injection runs); re-enable after proxy removal

## Verification notes

- Live-opencode probe (opencode 1.14.46 + fake LLM server) confirmed: config hook receives merged provider config before first request; permission-deny removes plugin tools from the captured request.
- `scripts/ci/check-pr.sh` passes locally (branch name, devlog, version unchanged).
- Devlog: `devlog/2026-08-27_bili-proxy-self-disable/` (REQ / DESIGN / WORKLOG).
