### PR TITLE
release: v1.14.26 — per-provider/per-model compress overrides + nudge floor (#343, #351)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### v1.14.26 — Growth nudges respect the minNudgeContextPercent floor
+
+**Problem**: T1 growth nudges fired well below any configured lower context limit — the `minNudgeContextPercent` floor was plumbed into the trigger policy but ignored, so growth nudges fired at any context size (issue #342: ten `trigger=growth` nudges at 67K–152K against a 150K minimum on a 400K model).
+
+**Fix** (#343):
+- Growth nudges now require `currentTokens >= minNudgeContextPercent% × model context` (default **5%**; set `0` to disable). Over-max (`maxContextLimit`) and the 98% emergency override bypass the floor; T2/T3 tier-promotion nudges are unaffected.
+- When the model context window is unknown the floor is unresolvable and pre-fix growth-only behavior is preserved.
+- Docs: corrected stale `minContextLimit`/`maxContextLimit` defaults in README/CONFIGURATION (45%/55% → 80%/80%) and clarified that `minContextLimit` governs turn/iteration reminder nudges while `minNudgeContextPercent` governs the growth-nudge floor.
+
+**Install**: `opencode plugin opencode-acp@latest --global`
+
 ### v1.14.25 — Self-disable under the billion-context proxy
 
 **Problem**: Users running `bili opencode` (the billion-context launcher) got BOTH stacks at once: the proxy injects compress / decompress / search_context / acp_status at the wire level and adds its own `/acp` panel, while opencode-acp registered the same tool names and a competing `/acp` — duplicate tools and a client-side panel shadowing the proxy's real compression state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### v1.14.26 — Growth nudges respect the minNudgeContextPercent floor
+### v1.14.26 — Per-provider/per-model compress overrides; growth nudges respect the minNudgeContextPercent floor
 
 **Problem**: T1 growth nudges fired well below any configured lower context limit — the `minNudgeContextPercent` floor was plumbed into the trigger policy but ignored, so growth nudges fired at any context size (issue #342: ten `trigger=growth` nudges at 67K–152K against a 150K minimum on a 400K model).
 
@@ -8,6 +8,11 @@
 - Growth nudges now require `currentTokens >= minNudgeContextPercent% × model context` (default **5%**; set `0` to disable). Over-max (`maxContextLimit`) and the 98% emergency override bypass the floor; T2/T3 tier-promotion nudges are unaffected.
 - When the model context window is unknown the floor is unresolvable and pre-fix growth-only behavior is preserved.
 - Docs: corrected stale `minContextLimit`/`maxContextLimit` defaults in README/CONFIGURATION (45%/55% → 80%/80%) and clarified that `minContextLimit` governs turn/iteration reminder nudges while `minNudgeContextPercent` governs the growth-nudge floor.
+
+**Feature** (#351):
+- New nested `compress.providers` map: override **any** `compress` field per provider and per model (23 fields — thresholds, nudge behavior, protection, preservation, …). Resolution is per field: model > provider > global; unknown provider/model IDs fall back to the global value.
+- A nested `maxContextLimit` outranks the legacy flat `modelMaxLimits` map (nested > flat > global). Overrides deep-merge across the three config layers per provider/model key.
+- Strict validation (unknown fields and wrong types rejected) + JSON schema; documented in README (EN/zh) and CONFIGURATION (EN/zh) with recipes.
 
 **Install**: `opencode plugin opencode-acp@latest --global`
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,6 +1,6 @@
 # 更新日志
 
-### v1.14.26 — 增长型压缩提醒遵循 minNudgeContextPercent 下限
+### v1.14.26 — 任意 compress 字段支持按 provider/按模型覆盖；增长型提醒遵循 minNudgeContextPercent 下限
 
 **问题**：T1 增长型提醒在远低于配置的上下文下限时就触发 —— `minNudgeContextPercent` 下限被传入触发策略但被忽略，导致增长型提醒在任何上下文大小下都会触发（issue #342：400K 模型上配置了 150K 下限，却在 67K–152K 触发了 10 次 `trigger=growth` 提醒）。
 
@@ -8,6 +8,11 @@
 - 增长型提醒现在要求 `currentTokens >= minNudgeContextPercent% × 模型上下文窗口`（默认 **5%**；设为 `0` 表示禁用）。超 max（`maxContextLimit`）和 98% 紧急提醒绕过下限；T2/T3 层级提升提醒不受影响。
 - 模型上下文窗口未知时，下限不可解析，保持修复前的纯增长行为。
 - 文档：修正 README/CONFIGURATION 中过期的 `minContextLimit`/`maxContextLimit` 默认值（45%/55% → 80%/80%），并澄清 `minContextLimit` 管 turn/iteration 提醒、`minNudgeContextPercent` 管增长型提醒下限。
+
+**新功能**（#351）：
+- 新增嵌套 `compress.providers` 映射：任意 `compress` 字段都可按 provider 和按模型覆盖（23 项 —— 阈值、提醒行为、保护、保留策略等）。逐字段解析优先级：model > provider > 全局；未知的 provider/model ID 回退到全局值。
+- 嵌套 `maxContextLimit` 优先于旧版扁平 `modelMaxLimits` 映射（嵌套 > 扁平 > 全局）。覆盖在三层配置文件间按 provider/model 键深合并。
+- 严格校验（未知字段和错误类型均拒绝）+ JSON schema；README（中英）与 CONFIGURATION（中英）均已补充文档与配方。
 
 **安装**：`opencode plugin opencode-acp@latest --global`
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,16 @@
 # 更新日志
 
+### v1.14.26 — 增长型压缩提醒遵循 minNudgeContextPercent 下限
+
+**问题**：T1 增长型提醒在远低于配置的上下文下限时就触发 —— `minNudgeContextPercent` 下限被传入触发策略但被忽略，导致增长型提醒在任何上下文大小下都会触发（issue #342：400K 模型上配置了 150K 下限，却在 67K–152K 触发了 10 次 `trigger=growth` 提醒）。
+
+**修复**（#343）：
+- 增长型提醒现在要求 `currentTokens >= minNudgeContextPercent% × 模型上下文窗口`（默认 **5%**；设为 `0` 表示禁用）。超 max（`maxContextLimit`）和 98% 紧急提醒绕过下限；T2/T3 层级提升提醒不受影响。
+- 模型上下文窗口未知时，下限不可解析，保持修复前的纯增长行为。
+- 文档：修正 README/CONFIGURATION 中过期的 `minContextLimit`/`maxContextLimit` 默认值（45%/55% → 80%/80%），并澄清 `minContextLimit` 管 turn/iteration 提醒、`minNudgeContextPercent` 管增长型提醒下限。
+
+**安装**：`opencode plugin opencode-acp@latest --global`
+
 ### v1.14.25 — 在 billion-context 代理下自动禁用
 
 **问题**：运行 `bili opencode`（billion-context 启动器）的用户会同时加载两套 ACP：代理在 wire 层注入 compress / decompress / search_context / acp_status 并提供自己的 `/acp` 面板，而 opencode-acp 又注册了同名工具和竞争性的 `/acp` 命令 —— 工具重复注册，且客户端面板遮蔽了代理的真实压缩状态。

--- a/devlog/2026-08-29_release-v1.14.26/REQ.md
+++ b/devlog/2026-08-29_release-v1.14.26/REQ.md
@@ -1,0 +1,27 @@
+# REQ — Release v1.14.26
+
+- Task ID: `2026-08-29_release-v1.14.26`
+- Home Repo: `opencode-acp`
+- Created: 2026-08-29
+- Status: In Progress
+- Priority: P1
+- Owner: ework-daemon
+- References: issue ranxianglei/opencode-acp#342, PR ranxianglei/opencode-acp#343
+
+## 1. Background & Problem Statement
+
+- Release the issue #342 fix (T1 growth nudges respect the `minNudgeContextPercent` floor) so it reaches npm `latest`. The fix is merged on master (PR #343, merge commit `574c1c4`) but unreleased — npm `latest` is still 1.14.25.
+- The fix branch was a feature branch, not a release branch, so `release.yml` did not tag/publish on merge.
+- Reporter (bernhardberger) is waiting for the fix on `latest` before restoring `nudgeGrowthTokens: 50000` and verifying T1 growth nudges stay suppressed below his configured 150K floor (`minNudgeContextPercent: 37.5` on his 400K model).
+
+## 2. Release Contents
+
+- PR #343 (issue #342): growth-nudge floor via `minNudgeContextPercent` (default 5%, `0` disables; over-max and 98% emergency bypass; T2/T3 unaffected), docs corrections (stale 45%/55% → 80%/80% defaults; `minContextLimit` vs `minNudgeContextPercent` semantics), 6 new/updated tests in `tests/inject.test.ts`.
+
+## 3. Acceptance Criteria
+
+- [ ] `package.json` version bumped to 1.14.26
+- [ ] `CHANGELOG.md` + `CHANGELOG.zh-CN.md` updated with `### v1.14.26`
+- [ ] `./scripts/ci/check-pr.sh 2026-08-29_release-v1.14.26 origin/master` passes
+- [ ] typecheck + full test suite pass
+- [ ] PR created; human merges → CI auto-publishes to npm `latest` + GitHub Release

--- a/devlog/2026-08-29_release-v1.14.26/REQ.md
+++ b/devlog/2026-08-29_release-v1.14.26/REQ.md
@@ -6,17 +6,19 @@
 - Status: In Progress
 - Priority: P1
 - Owner: ework-daemon
-- References: issue ranxianglei/opencode-acp#342, PR ranxianglei/opencode-acp#343
+- References: issue ranxianglei/opencode-acp#342, PR ranxianglei/opencode-acp#343, PR ranxianglei/opencode-acp#351
 
 ## 1. Background & Problem Statement
 
 - Release the issue #342 fix (T1 growth nudges respect the `minNudgeContextPercent` floor) so it reaches npm `latest`. The fix is merged on master (PR #343, merge commit `574c1c4`) but unreleased — npm `latest` is still 1.14.25.
 - The fix branch was a feature branch, not a release branch, so `release.yml` did not tag/publish on merge.
 - Reporter (bernhardberger) is waiting for the fix on `latest` before restoring `nudgeGrowthTokens: 50000` and verifying T1 growth nudges stay suppressed below his configured 150K floor (`minNudgeContextPercent: 37.5` on his 400K model).
+- **Scope extension (2026-08-29, post #351 merge)**: PR #351 (per-provider/per-model overrides for ALL compress fields via nested `compress.providers`, issue #344) merged into master (`46014bc`) while this release PR was open. Maintainer directed: “合并了 发一个新版本” — the release must ship #343 + #351 together, so master was merged into the release branch and the changelog/devlog extended. PR #352 (soft-deprecate `minContextLimit`/`modelMinLimits`, docs-only) remains open and is NOT part of this release.
 
 ## 2. Release Contents
 
 - PR #343 (issue #342): growth-nudge floor via `minNudgeContextPercent` (default 5%, `0` disables; over-max and 98% emergency bypass; T2/T3 unaffected), docs corrections (stale 45%/55% → 80%/80% defaults; `minContextLimit` vs `minNudgeContextPercent` semantics), 6 new/updated tests in `tests/inject.test.ts`.
+- PR #351 (issue #344): nested `compress.providers` — any compress field overridable per provider/model (23 fields; model > provider > global per field; nested `maxContextLimit` > flat `modelMaxLimits` > global; 3-layer deep-merge), strict validation + JSON schema, 17+ new tests, README/CONFIGURATION EN+zh docs.
 
 ## 3. Acceptance Criteria
 

--- a/devlog/2026-08-29_release-v1.14.26/WORKLOG.md
+++ b/devlog/2026-08-29_release-v1.14.26/WORKLOG.md
@@ -1,0 +1,25 @@
+# WORKLOG — Release v1.14.26
+
+- Task ID: `2026-08-29_release-v1.14.26`
+- Home Repo: `opencode-acp`
+- Status: In Progress
+- Updated: 2026-08-29
+
+## 1. Summary
+
+Release for PR #343 (issue #342 fix: growth nudges respect the `minNudgeContextPercent` floor). Version 1.14.25 → 1.14.26.
+
+## 2. Change Log
+
+| Commit | Description |
+|--------|-------------|
+| (pending) | release: v1.14.26 — growth nudges respect the minNudgeContextPercent floor |
+
+## 3. Verification
+
+- master @ `574c1c4`: typecheck clean; 1036 tests pass, 0 fail.
+- `check-pr.sh`: (pending)
+
+## 4. Rollback Plan
+
+Close the PR before merge — no tag/publish happens until a human merges.

--- a/devlog/2026-08-29_release-v1.14.26/WORKLOG.md
+++ b/devlog/2026-08-29_release-v1.14.26/WORKLOG.md
@@ -7,19 +7,31 @@
 
 ## 1. Summary
 
-Release for PR #343 (issue #342 fix: growth nudges respect the `minNudgeContextPercent` floor). Version 1.14.25 → 1.14.26.
+Release for PR #343 (issue #342 fix: growth nudges respect the `minNudgeContextPercent` floor) **+ PR #351** (issue #344: nested `compress.providers` — per-provider/per-model overrides for ALL compress fields). Version 1.14.25 → 1.14.26.
 
 ## 2. Change Log
 
 | Commit | Description |
 |--------|-------------|
 | `5554101` | release: v1.14.26 — growth nudges respect the minNudgeContextPercent floor |
+| `0e12bb7` | docs: record release commit hash and check-pr result in WORKLOG |
+| `4c4262d` | docs: mark release v1.14.26 WORKLOG as PR open |
+| (merge) | merge master (`46014bc`, PR #351) into release branch — brings the all-field cascade into the release; CHANGELOG EN+zh extended with the #351 feature section; devlog REQ/WORKLOG scope extension |
 
 ## 3. Verification
 
 - master @ `574c1c4`: typecheck clean; 1036 tests pass, 0 fail.
+- master @ `46014bc` (incl. #351): typecheck clean; 1062 tests pass, 0 fail (verified on PR #351 CI — test 22/24 both green).
+- Post-merge verification on the release branch: see §5.
 - `check-pr.sh`: all checks passed (branch name, devlog, changelog).
 
 ## 4. Rollback Plan
 
 Close the PR before merge — no tag/publish happens until a human merges.
+
+## 5. Scope Extension — include PR #351 (2026-08-29)
+
+- After PR #351 merged to master (`46014bc`), maintainer directed “合并了 发一个新版本”. Merged master into this release branch (clean, no conflicts) so the release ships #343 + #351 together.
+- CHANGELOG.md / CHANGELOG.zh-CN.md: `### v1.14.26` entry retitled + new **Feature (#351)** section (nested `compress.providers`, 23 overridable fields, per-field cascade, nested `maxContextLimit` > flat map, 3-layer deep-merge, validation/schema/docs).
+- Post-merge re-verification: full suite re-run on the release branch — see verification block above for the final tally.
+- PR #352 (`docs(deprecate): mark minContextLimit + modelMinLimits deprecated`) intentionally NOT included — it is still open and is docs-only; it ships in the next release.

--- a/devlog/2026-08-29_release-v1.14.26/WORKLOG.md
+++ b/devlog/2026-08-29_release-v1.14.26/WORKLOG.md
@@ -13,12 +13,12 @@ Release for PR #343 (issue #342 fix: growth nudges respect the `minNudgeContextP
 
 | Commit | Description |
 |--------|-------------|
-| (pending) | release: v1.14.26 — growth nudges respect the minNudgeContextPercent floor |
+| `5554101` | release: v1.14.26 — growth nudges respect the minNudgeContextPercent floor |
 
 ## 3. Verification
 
 - master @ `574c1c4`: typecheck clean; 1036 tests pass, 0 fail.
-- `check-pr.sh`: (pending)
+- `check-pr.sh`: all checks passed (branch name, devlog, changelog).
 
 ## 4. Rollback Plan
 

--- a/devlog/2026-08-29_release-v1.14.26/WORKLOG.md
+++ b/devlog/2026-08-29_release-v1.14.26/WORKLOG.md
@@ -2,7 +2,7 @@
 
 - Task ID: `2026-08-29_release-v1.14.26`
 - Home Repo: `opencode-acp`
-- Status: In Progress
+- Status: PR Open (awaiting human merge)
 - Updated: 2026-08-29
 
 ## 1. Summary

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.25",
+    "version": "1.14.26",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
Model: Claude Sonnet 4.6

Release v1.14.25 → **v1.14.26**. Maintainer directed: "合并了 发一个新版本" after #351 merged, so this release PR was updated in place to ship both merged changes.

## Contents

### Fix — growth nudges respect the `minNudgeContextPercent` floor (PR #343, issue #342)
- Growth nudges require `currentTokens >= minNudgeContextPercent% × model context` (default **5%**, `0` disables). Over-max and the 98% emergency override bypass the floor; T2/T3 tier-promotion nudges unaffected.
- Unknown model window → floor unresolvable → pre-fix behavior preserved.
- Docs: stale default corrections (45%/55% → 80%/80%), `minContextLimit` vs `minNudgeContextPercent` semantics.

### Feature — nested `compress.providers` (PR #351, issue #344)
- Override **any** `compress` field per provider and per model (23 fields). Per-field resolution: model > provider > global; unknown IDs → global fallback.
- Nested `maxContextLimit` outranks the legacy flat `modelMaxLimits` map. Overrides deep-merge across the three config layers per provider/model key.
- Strict validation + JSON schema + README/CONFIGURATION EN+zh docs.

```jsonc
{
  "compress": {
    "providers": {
      "anthropic": {
        "nudgeGrowthTokens": 20000,
        "models": { "claude-sonnet-4.6": { "maxContextLimit": "70%", "nudgeForce": "strong" } }
      }
    }
  }
}
```

## Not included
- PR #352 (docs-only soft deprecation of `minContextLimit`/`modelMinLimits`) — still open, ships next release.

## Release mechanics (per AGENTS.md §5.4)
- Branch `2026-08-29_release-v1.14.26`, version bumped to 1.14.26, CHANGELOG.md + CHANGELOG.zh-CN.md entries, devlog REQ/WORKLOG extended.
- Verified: typecheck ✓, **1062/1062 tests ✓**, build ✓, `check-pr.sh` ✓ (on the merged branch incl. #351).
- Human merges this PR → `release.yml` auto-tags `v1.14.26`, publishes to npm `latest`, creates GitHub Release.