### PR TITLE
promote: stable v1.14.26 — sync stable tag with latest (1.14.19 → 1.14.26)

### DIFF
--- a/devlog/2026-09-03_promote-stable-v1.14.26/REQ.md
+++ b/devlog/2026-09-03_promote-stable-v1.14.26/REQ.md
@@ -1,0 +1,31 @@
+# REQ — Promote v1.14.26 to npm stable tag
+
+## Goal
+
+Point the npm `stable` dist-tag at `opencode-acp@1.14.26` (currently at 1.14.19, seven versions behind). Users installing via `opencode plugin opencode-acp@stable --global` receive the latest stable release.
+
+Issue: [#356](https://github.com/ranxianglei/opencode-acp/issues/356) "发布一个 stable 版本 pr".
+
+## Context
+
+- v1.14.26 published to npm `latest` on 2026-08-29 (PR #353 merged; release.yml succeeded) and has been running as `latest` for ~5 days
+- v1.14.19 (promoted 2026-08-15 via PR #309, squash commit `df0b194`) is still the `stable` pointer — versions 1.14.20–1.14.26 never reached `stable`
+- master HEAD (`ba5ef36`) is v1.14.26 + PR #352 only (soft deprecation marking of `minContextLimit`/`modelMinLimits`: 11 lines in `lib/config.ts` + docs/schema; no behavior change). No unreleased feature or fix justifies cutting a new version number for this promotion.
+
+## Mechanism
+
+No code changes. Branch name `2026-09-03_promote-stable-v1.14.26` + commit title `promote: stable v1.14.26 — ...` triggers release.yml Pattern 3 (squash) / Pattern 4 (standard merge), which runs `npm dist-tag add opencode-acp@1.14.26 stable`. Version is extracted from the merge title/branch name by CI — `package.json` is NOT modified.
+
+## Content shipped in stable 1.14.19 → 1.14.26
+
+- v1.14.20 (#316): post-v1.14.19 fix batch (modelContextLimit, inactive-block decompress, logging)
+- v1.14.21 (#317): /acp command fixes and completion (permission gate, export, help)
+- v1.14.22 (#323): stable system prompt token estimate (#255)
+- v1.14.23 (#331): fix batch (#325 #326 #327 #328)
+- v1.14.24 (#333): default-on decision-level logging
+- v1.14.25 (#336): self-disable under billion-context proxy (`BILLION_CONTEXT_PROXY`)
+- v1.14.26 (#353): per-provider/per-model `compress.providers` overrides (#351); growth nudges respect the `minNudgeContextPercent` floor (#343)
+
+## Known risks (accepted, tracked separately)
+
+- #346 / #347 (context-overflow death loop on resume with custom providers) are fixed by open PRs #348/#349/#350, not yet merged. These bugs affect current `stable` (1.14.19) and `latest` (1.14.26) users equally — promoting does not introduce a regression. Will be covered by the next release after those PRs land.

--- a/devlog/2026-09-03_promote-stable-v1.14.26/WORKLOG.md
+++ b/devlog/2026-09-03_promote-stable-v1.14.26/WORKLOG.md
@@ -1,0 +1,17 @@
+# WORKLOG — Promote v1.14.26 to stable
+
+## Steps
+
+1. Verified v1.14.26 published to npm `latest`: `npm view opencode-acp dist-tags` → `latest: 1.14.26`, published 2026-08-29T05:53:00Z (PR #353 merged)
+2. Verified current `stable` pointer is stale: `npm view opencode-acp dist-tags.stable` → `1.14.19` (7 versions behind)
+3. Verified master HEAD `ba5ef36` = origin/master; diff vs tag `v1.14.26` is PR #352 only (soft deprecation docs + 11 lines `lib/config.ts`, no behavior change) — no new release number needed
+4. Created branch `2026-09-03_promote-stable-v1.14.26` from master `ba5ef36`
+5. No code/config changes — promote-only PR (devlog only), per the established pattern of PRs #270/#273/#283/#309
+
+## Verification
+
+- `./scripts/ci/check-pr.sh 2026-09-03_promote-stable-v1.14.26 origin/master` — branch name, devlog REQ/WORKLOG present, version unchanged (changelog check skipped)
+
+## After merge
+
+release.yml Pattern 3 (squash title `promote: stable v1.14.26 — ...`) or Pattern 4 (standard merge of branch `..._promote-stable-v1.14.26`) runs `npm dist-tag add opencode-acp@1.14.26 stable`. Verify with `npm view opencode-acp dist-tags` → `stable: 1.14.26`.


### PR DESCRIPTION
Promotes `opencode-acp@1.14.26` (current npm `latest`) to the npm `stable` dist-tag.

## Why

- npm `stable` still points at **1.14.19** (promoted 2026-08-15 via #309) — 7 versions behind `latest` (1.14.26, published 2026-08-29).
- Users installing `opencode plugin opencode-acp@stable --global` get 1.14.19 and miss every fix/feature since.

## What's included in stable 1.14.19 → 1.14.26

| Version | Highlights |
|---|---|
| v1.14.20 (#316) | post-v1.14.19 fix batch (modelContextLimit, inactive-block decompress, logging) |
| v1.14.21 (#317) | /acp command fixes & completion (permission gate, export, help) |
| v1.14.22 (#323) | stable system-prompt token estimate (#255) |
| v1.14.23 (#331) | fix batch (#325 #326 #327 #328) |
| v1.14.24 (#333) | decision-level logging enabled by default |
| v1.14.25 (#336) | self-disable under billion-context proxy |
| v1.14.26 (#353) | per-provider/per-model `compress.providers` overrides (#351); growth nudge floor `minNudgeContextPercent` (#343) |

## Why not cut v1.14.27

Master HEAD (`ba5ef36`) differs from tag `v1.14.26` only by PR #352 (soft-deprecation docs + 11 lines in `lib/config.ts`, no behavior change). No new code justifies a fresh release number; v1.14.26 has already run as `latest` for ~5 days.

## How it works

No code change (devlog only). On merge, `release.yml` detects the promote-stable pattern (squash title `promote: stable v1.14.26 — ...`, or standard merge of branch `..._promote-stable-v1.14.26`) and runs `npm dist-tag add opencode-acp@1.14.26 stable`. Both squash and merge-commit merge styles trigger it.

## Verification

- [x] `npm view opencode-acp dist-tags` → `latest: 1.14.26` (published 2026-08-29T05:53Z), `stable: 1.14.19`
- [x] master HEAD `ba5ef36` = tag `v1.14.26` + PR #352 docs only
- [x] `./scripts/ci/check-pr.sh 2026-09-03_promote-stable-v1.14.26 origin/master` — all checks passed (branch name, devlog REQ/WORKLOG, version unchanged)

## After merge

Verify with `npm view opencode-acp dist-tags` → `stable: 1.14.26`.

## Known risks (out of scope here)

#346/#347 (resume context-overflow loop) are being fixed by open PRs #348/#349/#350. Those bugs affect current stable and latest users equally — promoting introduces no new regression risk.
