### PR TITLE
release: v1.14.27 — self-disable also triggers in manual proxy mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+### v1.14.27 — Self-disable also triggers in manual proxy mode (/bili/ baseURL detection)
+
+**Problem**: The v1.14.25 self-disable only covered the `bili opencode` launcher (env var `BILLION_CONTEXT_PROXY`). Users pointing a provider `baseURL` at the billion-context proxy directly (manual mode) still got duplicate context-management stacks — ACP's tools and `/acp` command alongside the proxy's wire-level compression (issue #337).
+
+**Fix** (#338):
+- The plugin's config hook now scans every configured provider for the documented `/bili/` path prefix in `options.baseURL` and, when found, self-disables: all five ACP tools (`compress`, `decompress`, `search_context`, `acp_status`, `acp_context_recap`) are permission-denied (removed from the LLM tool list), the `/acp` command and `primary_tools` registration are skipped, and every transform/event hook becomes a no-op. One log line explains why.
+- Detection is per-provider and case-sensitive; lookalikes (`/bilix/`, `bilibili.com`, bare `/bili`) do not match. The disable flag un-latches on config reload when no provider routes through the proxy again.
+- Zero behavior change when no provider routes through the proxy — standalone installs are unaffected. 15 new tests (unit + integration through the real plugin factory); full suite 1044/1044.
+
+**Docs** (#352):
+- Soft-deprecated `minContextLimit` and `modelMinLimits` (JSDoc + JSON schema + README/CONFIGURATION, EN/zh). Both remain fully honored until removed; growth nudges (`minNudgeContextPercent` + `nudgeGrowthTokens`) are the maintained nudge mechanism. `modelMaxLimits` is **not** deprecated.
+
+**Bookkeeping** (#358): promoted the npm `stable` dist-tag to 1.14.26.
+
+**Install**: `opencode plugin opencode-acp@latest --global`
+
 ### v1.14.26 — Per-provider/per-model compress overrides; growth nudges respect the minNudgeContextPercent floor
 
 **Problem**: T1 growth nudges fired well below any configured lower context limit — the `minNudgeContextPercent` floor was plumbed into the trigger policy but ignored, so growth nudges fired at any context size (issue #342: ten `trigger=growth` nudges at 67K–152K against a 150K minimum on a 400K model).

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,21 @@
 # 更新日志
 
+### v1.14.27 — 手动代理模式（/bili/ baseURL）也触发自动禁用
+
+**问题**：v1.14.25 的自动禁用只覆盖 `bili opencode` 启动器（环境变量 `BILLION_CONTEXT_PROXY`）。用户直接把某个 provider 的 `baseURL` 指向 billion-context 代理（手动模式）时，仍会同时加载两套上下文管理 —— ACP 的工具和 `/acp` 命令与代理在 wire 层的压缩并存（issue #337）。
+
+**修复**（#338）：
+- 插件的 config hook 现在扫描所有已配置 provider 的 `options.baseURL`，发现文档约定的 `/bili/` 路径前缀即自动禁用：五个 ACP 工具（`compress`、`decompress`、`search_context`、`acp_status`、`acp_context_recap`）全部 permission-deny（从 LLM 工具列表中移除）、跳过 `/acp` 命令和 `primary_tools` 注册、所有 transform/event hook 变为 no-op，并打印一行日志说明原因。
+- 检测按 provider 进行且区分大小写；相似前缀（`/bilix/`、`bilibili.com`、裸 `/bili`）不会误判。禁用标志在配置重新加载、不再有 provider 走代理后自动解除。
+- 没有任何 provider 走代理时行为零变化 —— 独立安装完全不受影响。新增 15 个测试（单元测试 + 通过真实插件工厂的集成测试）；全量测试 1044/1044 通过。
+
+**文档**（#352）：
+- 软废弃 `minContextLimit` 与 `modelMinLimits`（JSDoc + JSON schema + README/CONFIGURATION，中英）。两者在移除前仍完全生效；维护中的提醒机制是增长型提醒（`minNudgeContextPercent` + `nudgeGrowthTokens`）。`modelMaxLimits` **未**废弃。
+
+**记账**（#358）：将 npm `stable` dist-tag 提升到 1.14.26。
+
+**安装**：`opencode plugin opencode-acp@latest --global`
+
 ### v1.14.26 — 任意 compress 字段支持按 provider/按模型覆盖；增长型提醒遵循 minNudgeContextPercent 下限
 
 **问题**：T1 增长型提醒在远低于配置的上下文下限时就触发 —— `minNudgeContextPercent` 下限被传入触发策略但被忽略，导致增长型提醒在任何上下文大小下都会触发（issue #342：400K 模型上配置了 150K 下限，却在 67K–152K 触发了 10 次 `trigger=growth` 提醒）。

--- a/devlog/2026-09-03_release-v1.14.27/REQ.md
+++ b/devlog/2026-09-03_release-v1.14.27/REQ.md
@@ -1,0 +1,30 @@
+# REQ — Release v1.14.27
+
+- Task ID: `2026-09-03_release-v1.14.27`
+- Home Repo: `opencode-acp`
+- Created: 2026-09-03
+- Status: In Progress
+- Priority: P1
+- Owner: ework-daemon
+- References: issue ranxianglei/opencode-acp#337, PR ranxianglei/opencode-acp#338, PR ranxianglei/opencode-acp#352, PR ranxianglei/opencode-acp#358
+
+## 1. Background & Problem Statement
+
+- Release the issue #337 fix (self-disable in manual proxy mode — detect the documented `/bili/` prefix in provider `baseURL`, not only via the launcher env var `BILLION_CONTEXT_PROXY`) so it reaches npm `latest`. The fix is merged on master (PR #338, merge commit `6a8e531`) but unreleased — npm `latest` is still 1.14.26.
+- The fix branch was a feature branch, not a release branch, so `release.yml` did not tag/publish on merge.
+- Maintainer directed after merging PR #338: “合并了 发一个新版本” (merged — cut a new version).
+- **Scope**: everything merged since v1.14.26 (tag `c62ba56`): PR #338 (code), PR #352 (soft-deprecate `minContextLimit` / `modelMinLimits` — docs/schema/JSDoc only, no behavior change; `modelMaxLimits` NOT deprecated), PR #358 (promote npm `stable` dist-tag to 1.14.26, bookkeeping).
+
+## 2. Release Contents
+
+- PR #338 (issue #337): config-hook scan of every provider's `options.baseURL` for `/bili/`; on match — permission-deny all five ACP tools (`compress`, `decompress`, `search_context`, `acp_status`, `acp_context_recap`), skip `/acp` command + `primary_tools`, no-op all five hooks, one explanatory log line. Case-sensitive, per-provider; lookalikes (`/bilix/`, `bilibili.com`, bare `/bili`) rejected. Disable flag un-latches on config reload without proxy routing. New pure module `lib/bili-proxy.ts`; 15 new tests (unit + integration through the real plugin factory); full suite 1044/1044.
+- PR #352: soft deprecation of `minContextLimit` + `modelMinLimits` (JSDoc `@deprecated` in `lib/config.ts`, `[DEPRECATED …]` descriptions in `dcp.schema.json`, README EN/zh + CONFIGURATION zh doc updates). Both remain fully honored until removed; growth nudges (`minNudgeContextPercent` + `nudgeGrowthTokens`) are the maintained mechanism. No behavior change.
+- PR #358: promote npm `stable` dist-tag from 1.14.25 to 1.14.26 (bookkeeping).
+
+## 3. Acceptance Criteria
+
+- [ ] `package.json` version bumped to 1.14.27
+- [ ] `CHANGELOG.md` + `CHANGELOG.zh-CN.md` updated with `### v1.14.27`
+- [ ] `./scripts/ci/check-pr.sh 2026-09-03_release-v1.14.27 refs/remotes/origin/master` passes
+- [ ] typecheck + full test suite pass
+- [ ] PR created; human merges → CI auto-publishes to npm `latest` + GitHub Release

--- a/devlog/2026-09-03_release-v1.14.27/WORKLOG.md
+++ b/devlog/2026-09-03_release-v1.14.27/WORKLOG.md
@@ -2,7 +2,7 @@
 
 - Task ID: `2026-09-03_release-v1.14.27`
 - Home Repo: `opencode-acp`
-- Status: In Progress
+- Status: PR Open (awaiting human merge)
 - Updated: 2026-09-03
 
 ## 1. Summary
@@ -15,6 +15,8 @@ Release for PR #338 (issue #337 fix: self-disable also triggers in manual proxy 
 |--------|-------------|
 | `2e93281` | release: v1.14.27 — self-disable also triggers in manual proxy mode (/bili/ baseURL detection) |
 | (this commit) | docs: record release commit hash and check-pr result in WORKLOG |
+
+PR: https://github.com/ranxianglei/opencode-acp/pull/361 (open, awaiting human merge).
 
 ## 3. Verification
 

--- a/devlog/2026-09-03_release-v1.14.27/WORKLOG.md
+++ b/devlog/2026-09-03_release-v1.14.27/WORKLOG.md
@@ -1,0 +1,28 @@
+# WORKLOG — Release v1.14.27
+
+- Task ID: `2026-09-03_release-v1.14.27`
+- Home Repo: `opencode-acp`
+- Status: In Progress
+- Updated: 2026-09-03
+
+## 1. Summary
+
+Release for PR #338 (issue #337 fix: self-disable also triggers in manual proxy mode — detect `/bili/` in provider `baseURL`) **+ PR #352** (soft-deprecate `minContextLimit` / `modelMinLimits`, docs/schema/JSDoc only) **+ PR #358** (promote npm `stable` dist-tag to 1.14.26, bookkeeping). Version 1.14.26 → 1.14.27.
+
+## 2. Change Log
+
+| Commit | Description |
+|--------|-------------|
+| (pending) | release: v1.14.27 — self-disable also triggers in manual proxy mode (/bili/ baseURL detection) |
+| (pending) | docs: record release commit hash and check-pr result in WORKLOG |
+
+## 3. Verification
+
+- Release branch @ master `6a8e531` (incl. PR #338): typecheck clean (`tsc --noEmit`, no errors).
+- Full test suite on the release branch: **1077 tests pass, 0 fail** (~110 s).
+- `./scripts/ci/check-pr.sh 2026-09-03_release-v1.14.27 refs/remotes/origin/master`: see follow-up docs commit for final result (initial run failed only because the changelog/devlog changes were uncommitted at check time).
+- Note: sandbox `node_modules` and `/tmp` are wiped between agent turns — `npm ci` re-run before verification.
+
+## 4. Rollback Plan
+
+Close the PR before merge — no tag/publish happens until a human merges. If already published, `npm dist-tag add opencode-acp@1.14.26 latest` restores the previous version as `latest`.

--- a/devlog/2026-09-03_release-v1.14.27/WORKLOG.md
+++ b/devlog/2026-09-03_release-v1.14.27/WORKLOG.md
@@ -13,14 +13,14 @@ Release for PR #338 (issue #337 fix: self-disable also triggers in manual proxy 
 
 | Commit | Description |
 |--------|-------------|
-| (pending) | release: v1.14.27 — self-disable also triggers in manual proxy mode (/bili/ baseURL detection) |
-| (pending) | docs: record release commit hash and check-pr result in WORKLOG |
+| `2e93281` | release: v1.14.27 — self-disable also triggers in manual proxy mode (/bili/ baseURL detection) |
+| (this commit) | docs: record release commit hash and check-pr result in WORKLOG |
 
 ## 3. Verification
 
 - Release branch @ master `6a8e531` (incl. PR #338): typecheck clean (`tsc --noEmit`, no errors).
 - Full test suite on the release branch: **1077 tests pass, 0 fail** (~110 s).
-- `./scripts/ci/check-pr.sh 2026-09-03_release-v1.14.27 refs/remotes/origin/master`: see follow-up docs commit for final result (initial run failed only because the changelog/devlog changes were uncommitted at check time).
+- `./scripts/ci/check-pr.sh 2026-09-03_release-v1.14.27 refs/remotes/origin/master`: **all checks passed** (branch name, devlog REQ+WORKLOG, changelog version string in both files).
 - Note: sandbox `node_modules` and `/tmp` are wiped between agent turns — `npm ci` re-run before verification.
 
 ## 4. Rollback Plan

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.26",
+    "version": "1.14.27",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Release v1.14.27 (1.14.26 → 1.14.27)

Ships everything merged to master since v1.14.26:

- **PR #338** (issue #337): self-disable now also triggers in **manual proxy mode** — the `config` hook scans every provider baseURL for `/bili/`; on match ACP denies all 5 of its tools, skips `/acp` + `primary_tools`, and no-ops its hooks (log line emitted). Case-sensitive per-provider detection; lookalikes (`/bilix/`, `bilibili.com`) rejected; flag un-latches on config reload. Zero behavior change for non-proxy setups.
- **PR #352**: soft-deprecate `minContextLimit` + `modelMinLimits` (JSDoc `@deprecated`, schema descriptions, README EN/ZH + CONFIGURATION.zh-CN docs). Still honored until removed; `modelMaxLimits` NOT deprecated.
- **PR #358**: promote npm `stable` dist-tag to 1.14.26 (bookkeeping).

## Verification (local — GitHub Actions inactive in this repo since Aug 24)
- typecheck clean (`tsc --noEmit`)
- full test suite: **1077 pass, 0 fail**
- `scripts/ci/check-pr.sh`: all checks passed (branch name, devlog REQ+WORKLOG, `### v1.14.27` in both changelogs)

## After merge (automated by release.yml)
Merge commit from the `YYYY-MM-DD_release-v*` branch → auto tag `v1.14.27` → build + test → publish to npm `latest` → GitHub Release.

_Per AGENTS.md §5.1.1.2: merge is human-only._