### PR TITLE
release: v1.15.0 — compress.reasoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+### v1.15.0 — compress.reasoning: drop oversized thinking from closed-turn compress calls
+
+**Problem**: `compress` tool-call messages are hard-exempt from every compression selection (Bug 39) and are therefore re-sent verbatim on every LLM request. Their `reasoning` (thinking) parts ride along forever — a monotonically growing, unreclaimable context floor (measured at 83.5% of residual context in a real session; issue #368).
+
+**Feature** (#377, supersedes #370):
+- New request-time pass that removes `reasoning` parts from a message only when ALL gates hold: (1) **closed turn** — strictly before the last genuine user message (the active round is never touched; some providers require replaying active-round thinking); (2) **selector** — the message carries a `tool === "compress"` part (any status; only compress, not skill/task); (3) **single-thinking size** — the message's total reasoning length (summed across parts) **strictly exceeds** `threshold` chars. Small thinkings are kept; lengths are not accumulated across messages. Persisted history is never modified.
+- New nested config `compress.reasoning { drop: true, threshold: 2048 }`, merged **field-wise** across the three config layers and the #344 provider/model cascade (model > provider > global; a deeper layer overrides only the fields it sets):
+
+```jsonc
+{
+    "compress": {
+        "reasoning": { "drop": true, "threshold": 2048 },
+        "providers": {
+            "my-gateway": { "reasoning": { "drop": false } },
+            "anthropic": { "models": { "claude-opus-4-5": { "reasoning": { "threshold": 8000 } } } }
+        }
+    }
+}
+```
+
+- Provider/model identity comes from the current request's last user message `info.model`, falling back to session state. `threshold: 0` drops any non-empty reasoning.
+- Validation, JSON schema, README/CONFIGURATION (EN/zh) all updated; 29+ new tests (unit, cascade, validation, hook-level e2e — mutation-verified per gate); full suite 1112/1112; dual-agent reviewed (code + test).
+- Also fixes two config-validation defects found in review: `reasoning` overrides inside `compress.providers` were spuriously rejected as unknown fields, and `compress.reasoning: null` crashed plugin startup instead of producing a warning.
+
+**Process** (#367): AGENTS.md now requires issue tracking for problems discovered/fixed during development.
+
+**Install**: `opencode plugin opencode-acp@latest --global`
+
 ### v1.14.27 — Self-disable also triggers in manual proxy mode (/bili/ baseURL detection)
 
 **Problem**: The v1.14.25 self-disable only covered the `bili opencode` launcher (env var `BILLION_CONTEXT_PROXY`). Users pointing a provider `baseURL` at the billion-context proxy directly (manual mode) still got duplicate context-management stacks — ACP's tools and `/acp` command alongside the proxy's wire-level compression (issue #337).

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,33 @@
 # 更新日志
 
+### v1.15.0 — compress.reasoning：按需丢弃已关闭轮次 compress 调用的超大思考
+
+**问题**：`compress` 工具调用消息被硬排除在一切压缩选择之外（Bug 39），每轮请求原样重发，其 `reasoning`（思考）部分随之永久驻留 —— 单调增长、压缩永远无法回收的上下文底座（实测会话中占残余上下文 83.5%；issue #368）。
+
+**新功能**（#377，替代 #370）：
+- 新增请求时 pass，仅当全部门条件成立时才移除消息的 `reasoning` 部分：（1）**轮次已关闭** —— 严格位于最后一条真实用户消息之前（活跃轮永不触碰；部分 provider 要求重放活跃轮 thinking）；（2）**选择器** —— 消息携带 `tool === "compress"` 工具 part（任意 status；仅 compress，不含 skill/task）；（3）**单条大小** —— 消息 reasoning 总长（多 part 求和）**严格大于** `threshold`（字符数）。小思考保留；长度不跨消息累计。持久化历史从不修改。
+- 新增嵌套配置 `compress.reasoning { drop: true, threshold: 2048 }`，三层配置文件与 #344 provider/model cascade 均为**字段级**合并（model > provider > 全局；深层只覆盖显式设置的字段）：
+
+```jsonc
+{
+    "compress": {
+        "reasoning": { "drop": true, "threshold": 2048 },
+        "providers": {
+            "my-gateway": { "reasoning": { "drop": false } },
+            "anthropic": { "models": { "claude-opus-4-5": { "reasoning": { "threshold": 8000 } } } }
+        }
+    }
+}
+```
+
+- provider/model 标识取自当前请求最后一条用户消息的 `info.model`，取不到回落 session state。`threshold: 0` 表示丢弃所有非空 reasoning。
+- 校验、JSON schema、README/CONFIGURATION（中英）全部更新；新增 29+ 测试（单元 / cascade / 校验 / hook 级 e2e，逐门变异验证）；全量 1112/1112 通过；双 agent review（代码 + 测试）。
+- 同时修复 review 中发现的两个配置校验缺陷：`compress.providers` 内的 `reasoning` 覆盖被误报为未知字段；`compress.reasoning: null` 会导致插件启动崩溃而非警告。
+
+**流程**（#367）：AGENTS.md 要求开发中发现/修复的问题必须建 issue 跟踪。
+
+**安装**：`opencode plugin opencode-acp@latest --global`
+
 ### v1.14.27 — 手动代理模式（/bili/ baseURL）也触发自动禁用
 
 **问题**：v1.14.25 的自动禁用只覆盖 `bili opencode` 启动器（环境变量 `BILLION_CONTEXT_PROXY`）。用户直接把某个 provider 的 `baseURL` 指向 billion-context 代理（手动模式）时，仍会同时加载两套上下文管理 —— ACP 的工具和 `/acp` 命令与代理在 wire 层的压缩并存（issue #337）。

--- a/devlog/2026-09-09_release-v1.15.0/REQ.md
+++ b/devlog/2026-09-09_release-v1.15.0/REQ.md
@@ -1,0 +1,24 @@
+# REQ — release v1.15.0
+
+- **日期**: 2026-09-09
+- **分支**: `2026-09-09_release-v1.15.0`（自 github/master @ 4a8b443）
+- **版本**: 1.14.27 → 1.15.0（minor：含新功能）
+
+## 发布内容（v1.14.27..master）
+
+| PR | 类型 | 内容 |
+| --- | --- | --- |
+| #377 | feat | `compress.reasoning` — 请求时丢弃已关闭轮次 compress 调用的超大 reasoning（closes #368，supersedes #370）。嵌套配置字段级合并 + #344 cascade；1112 测试；双 agent review |
+| #367 | docs | AGENTS.md 要求开发中发现/修复的问题必须建 issue 跟踪（流程文档，非用户可见） |
+
+## 版本号决策
+
+含新功能（compress.reasoning）→ minor bump 1.14.27 → **1.15.0**。
+
+## 清单
+
+- [x] package.json version → 1.15.0
+- [x] CHANGELOG.md / CHANGELOG.zh-CN.md 顶部新增 `### v1.15.0` 条目
+- [x] devlog REQ + WORKLOG
+- [x] `./scripts/ci/check-pr.sh` 通过
+- [ ] PR 合并（人工）后 release.yml 自动打 tag `v1.15.0`、构建、测试、发 npm `latest`、建 GitHub Release

--- a/devlog/2026-09-09_release-v1.15.0/WORKLOG.md
+++ b/devlog/2026-09-09_release-v1.15.0/WORKLOG.md
@@ -1,0 +1,23 @@
+# WORKLOG — release v1.15.0
+
+- **日期**: 2026-09-09
+- **分支**: `2026-09-09_release-v1.15.0`
+
+## 步骤（对照 AGENTS.md §5.4.2）
+
+1. `git checkout -b 2026-09-09_release-v1.15.0 github/master`（基点 4a8b443 = PR #377 的 merge commit）
+2. `npm version 1.15.0 --no-git-tag-version`
+3. CHANGELOG.md / CHANGELOG.zh-CN.md 顶部新增 `### v1.15.0` 条目（问题/功能/修复/流程/安装，沿用 v1.14.27 条目格式；含 jsonc 配置示例）
+4. devlog REQ.md + WORKLOG.md
+5. `./scripts/ci/check-pr.sh 2026-09-09_release-v1.15.0 github/master` → All checks passed
+6. commit + push + `gh pr create` → 等待人工合并
+7. 合并后 release.yml 自动：检测 release 分支名 → 打 `v1.15.0` tag → npm ci → check:package → test → `npm publish`（latest）→ GitHub Release
+
+## 发布内容
+
+见 REQ.md 表格。核心：PR #377 `compress.reasoning`（#368）。
+
+## 备注
+
+- merge 由人工执行（AGENTS.md §5.1.1.2 — Agent 绝不合并 PR）。
+- 版本号不含 `-` 后缀 → CI 发布到 `latest`（非 dev tag）。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-acp",
-    "version": "1.14.25",
+    "version": "1.15.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-acp",
-            "version": "1.14.25",
+            "version": "1.15.0",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.14.27",
+    "version": "1.15.0",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Release v1.15.0

Bumps 1.14.27 → **1.15.0** (minor: new feature). Merge of this PR triggers `release.yml` to tag `v1.15.0`, build, test, publish to npm `latest`, and create the GitHub Release automatically.

### Included (v1.14.27..master)

| PR | Type | Summary |
|----|------|---------|
| #377 | feat | `compress.reasoning` — request-time drop of oversized reasoning from closed-turn `compress` tool calls (closes #368, supersedes #370). Nested config with field-wise merge across 3 layers + the #344 provider/model cascade. Also fixes 2 config-validation defects (spurious unknown-field on provider-level `reasoning`; `reasoning: null` startup crash). 1112/1112 tests, dual-agent reviewed. |
| #367 | docs | AGENTS.md — require issue tracking for discovered/fixed problems (process doc). |

### Changes in this PR

- `package.json` version → 1.15.0
- `CHANGELOG.md` / `CHANGELOG.zh-CN.md` — `### v1.15.0` entries
- `devlog/2026-09-09_release-v1.15.0/` — REQ.md + WORKLOG.md

Merge is a human-only operation (AGENTS.md §5.1.1.2).