### PR TITLE
feat: storagePath config for custom session-state storage location (#379)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -65,6 +65,17 @@ Status legend: **ACTIVE** = currently used | **DEPRECATED** = kept for backward 
 - **Status:** ACTIVE
 - **Description:** File log verbosity for `~/.config/opencode/logs/acp/daily/<date>.log`. Default `info` writes decision-level events by default (nudge decisions, transform summaries, auto-update checks, model switches). `warn`/`error` reduce output; `silent` disables file logging entirely; `debug` additionally enables per-request context snapshots and verbose dumps. Ignored when `debug: true`.
 
+#### `storagePath`
+- **Type:** `string`
+- **Default:** unset — `$XDG_DATA_HOME/opencode/storage/plugin/acp` (i.e. `~/.local/share/opencode/storage/plugin/acp`)
+- **Status:** ACTIVE
+- **Description:** Directory where per-session state files (`{sessionId}.json` — compression blocks, nudge state, token stats) are persisted. Path semantics:
+  - Absolute path → used as-is
+  - `~` / `~/...` → expanded against the home directory
+  - Relative path → resolved against the project directory (where opencode was started)
+
+  The directory is created automatically if it does not exist. If you set this option and the session's state file still exists at the default location, ACP logs a WARN (once per session) instead of migrating it — move the file manually if you want to keep the session history.
+
 #### `pruneNotification`
 - **Type:** `"off" | "minimal" | "detailed"`
 - **Default:** `"off"`
@@ -554,6 +565,15 @@ See the [`compress.providers`](#compressproviders) reference for the full overri
         "**/credentials.json",
         "**/secrets.*"
     ]
+}
+```
+
+### Relocate session state storage
+
+```jsonc
+{
+    // Absolute path, ~ expansion, or project-relative
+    "storagePath": "~/data/acp-state"
 }
 ```
 

--- a/CONFIGURATION.zh-CN.md
+++ b/CONFIGURATION.zh-CN.md
@@ -65,6 +65,17 @@ ACP 从最多三层配置文件中读取（后加载的覆盖先加载的）：
 - **状态：** ACTIVE
 - **说明：** 文件日志详细级别（`~/.config/opencode/logs/acp/daily/<日期>.log`）。默认 `info`：默认落盘决策级事件（压缩提示决策、转换摘要、自动更新检查、模型切换等）。`warn`/`error` 减少输出；`silent` 完全关闭文件日志；`debug` 额外启用按请求的上下文快照与详细转储。`debug: true` 时忽略此配置。
 
+#### `storagePath`
+- **类型：** `string`
+- **默认值：** 未设置 — `$XDG_DATA_HOME/opencode/storage/plugin/acp`（即 `~/.local/share/opencode/storage/plugin/acp`）
+- **状态：** ACTIVE
+- **说明：** 会话状态文件（`{sessionId}.json`，含压缩块、提示状态、token 统计）的持久化目录。路径语义：
+  - 绝对路径 → 原样使用
+  - `~` / `~/...` → 相对于主目录展开
+  - 相对路径 → 相对于项目目录（opencode 启动目录）解析
+
+  目录不存在时会自动创建。若设置了此项、但会话状态文件仍位于默认位置，ACP 会记录一条 WARN（每会话一次）而不会自动迁移——如需保留会话历史，请手动移动该文件。
+
 #### `pruneNotification`
 - **类型：** `"off" | "minimal" | "detailed"`
 - **默认值：** `"off"`
@@ -554,6 +565,15 @@ ACP 从最多三层配置文件中读取（后加载的覆盖先加载的）：
         "**/credentials.json",
         "**/secrets.*"
     ]
+}
+```
+
+### 自定义会话状态存储位置
+
+```jsonc
+{
+    // 绝对路径、~ 展开，或相对于项目目录
+    "storagePath": "~/data/acp-state"
 }
 ```
 

--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -31,6 +31,10 @@
             "default": "info",
             "description": "Log verbosity: decision-level events (info) are written by default. debug adds per-message detail; warn/error/silent reduce output."
         },
+        "storagePath": {
+            "type": "string",
+            "description": "Directory where per-session state files are persisted. Absolute paths are used as-is; ~/... expands against the home directory; relative paths resolve against the project directory. Unset: $XDG_DATA_HOME/opencode/storage/plugin/acp (default)."
+        },
         "pruneNotification": {
             "type": "string",
             "enum": [

--- a/devlog/2026-09-09_custom-storage-path/DESIGN.md
+++ b/devlog/2026-09-09_custom-storage-path/DESIGN.md
@@ -1,0 +1,86 @@
+# DESIGN - Support custom storage location for compressed content (session state files)
+
+- Task ID: `2026-09-09_custom-storage-path`
+- Home Repo: `opencode-acp`
+- Created: 2026-09-09
+- Status: InProgress
+
+## 1. Overview
+
+Add a top-level `storagePath` config option that relocates the per-session
+state directory. The directory is resolved **once per session** at init and
+carried on `SessionState` so every save/load in that session uses the same
+location without re-reading config.
+
+## 2. Data Flow
+
+```
+index.ts
+  └─ new SessionStateRegistry(logger, ctx.directory)   # projectDir captured once
+        │
+        ▼  (each messages.transform / compress tool call)
+SessionStateRegistry.getOrCreate(client, sessionId, messages, config)
+  └─ ensureSessionInitialized(..., config, projectDir)
+        ├─ resetSessionState(state)                    # clears storageDir
+        ├─ state.storageDir = config?.storagePath
+        │      ? resolveStorageDir(config.storagePath, projectDir ?? cwd())
+        │      : undefined                             # undefined = default XDG
+        ├─ loadSessionState(sessionId, logger, state.storageDir)
+        │     └─ if null && state.storageDir && existsSync(defaultPath)
+        │           → logger.warn (no auto-migration, once per session)
+        └─ saveSessionState(state, ...)                # reads state.storageDir
+```
+
+Key invariant: `state.storageDir` is **transient** — it is never serialized
+into the persisted JSON. It is re-derived from config on every session init,
+so a config change takes effect on the next session (or process restart).
+
+## 3. Path Resolution Semantics (`resolveStorageDir`)
+
+| Input                     | Result                                        |
+| ------------------------- | --------------------------------------------- |
+| `undefined` / `""` / ws   | default: `$XDG_DATA_HOME/opencode/storage/plugin/acp` |
+| `~`                       | `homedir()`                                   |
+| `~/foo`                   | `join(homedir(), "foo")`                      |
+| absolute (`/...`)         | as-is                                         |
+| relative (`foo`)          | `join(projectDir, "foo")`                     |
+
+`projectDir` is opencode's `ctx.directory`, threaded through the registry.
+The `process.cwd()` fallback only applies to callers that lack directory
+context (e.g. `decompress`/`pipeline` re-init paths) — in practice the
+messages hook has already initialized the session by then.
+
+## 4. Module Changes
+
+| File                    | Change |
+| ----------------------- | ------ |
+| `lib/config.ts`         | `PluginConfig.storagePath?: string`; `mergeLayer` merges it |
+| `lib/config-validation.ts` | `VALID_CONFIG_KEYS` + string type check |
+| `dcp.schema.json`       | new `storagePath` property |
+| `lib/state/persistence.ts` | `getDefaultStorageDir()` (exported), `resolveStorageDir()` (exported); `storageDir?` threaded through `getSessionFilePath` / `writePersistedSessionState` / `loadSessionState` / `loadAllSessionStats`; `saveSessionState` reads `sessionState.storageDir` |
+| `lib/state/types.ts`    | transient `SessionState.storageDir: string \| undefined` |
+| `lib/state/state.ts`    | `createSessionState`/`resetSessionState` init the field; `ensureSessionInitialized` resolves it + migration WARN; registry takes `projectDir` |
+| `index.ts`              | passes `ctx.directory` to the registry |
+
+## 5. Backward Compatibility
+
+- Option unset → `state.storageDir === undefined` → every path helper falls
+  back to `getDefaultStorageDir()`, which is byte-for-byte the previous
+  behavior. No persisted-format change (field is transient).
+- Existing state files keep loading from the default location.
+
+## 6. Migration Policy
+
+No automatic copy/move of existing state files. When `storagePath` is set,
+the configured dir has no file for the session, but the default location does,
+ACP logs a WARN (once per session, since init runs once per session) naming
+both paths. Rationale: silently moving user data between locations is a
+surprise; a WARN is discoverable and non-destructive.
+
+## 7. Risks & Mitigations
+
+- **Relative-path base ambiguity** → resolved against `ctx.directory`
+  (project dir), matching user expectation of "project-local storage".
+- **State "loss" on switch** → mitigated by the WARN.
+- **Transient field accidentally persisted** → `saveSessionState` never reads
+  `storageDir` into the `PersistedSessionState` shape; covered by tests.

--- a/devlog/2026-09-09_custom-storage-path/DESIGN.md
+++ b/devlog/2026-09-09_custom-storage-path/DESIGN.md
@@ -3,7 +3,7 @@
 - Task ID: `2026-09-09_custom-storage-path`
 - Home Repo: `opencode-acp`
 - Created: 2026-09-09
-- Status: InProgress
+- Status: Done
 
 ## 1. Overview
 

--- a/devlog/2026-09-09_custom-storage-path/REQ.md
+++ b/devlog/2026-09-09_custom-storage-path/REQ.md
@@ -1,0 +1,101 @@
+# REQ - Support custom storage location for compressed content (session state files)
+
+- Task ID: `2026-09-09_custom-storage-path`
+- Home Repo: `opencode-acp`
+- Created: 2026-09-09
+- Status: InProgress
+- Priority: P2
+- Owner: ranxianglei
+- References: https://github.com/ranxianglei/opencode-acp/issues/379
+
+## 1. Background & Problem Statement
+
+- **Context**: ACP persists per-session compression state (compression blocks, nudge
+  anchors, token stats, message ID mappings) to
+  `~/.local/share/opencode/storage/plugin/acp/{sessionId}.json`
+  (honoring `XDG_DATA_HOME`). The location is hardcoded in
+  `lib/state/persistence.ts` (`getStorageDir()`).
+- **Current behavior (symptom)**: Users cannot relocate the state directory.
+  On systems where the default XDG data dir is small, ephemeral, or shared
+  (containers, NFS home dirs, CI runners) the state files land in an
+  undesirable place.
+- **Expected behavior**: A config option lets the user choose where ACP stores
+  session state files, with the current location remaining the default.
+- **Impact**: Configuration/ergonomics only — no change to compression
+  behavior when the option is unset.
+
+## 2. Reproduction (if applicable)
+
+- **Environment**:
+  - Node: 22/24
+  - OS/Arch: any
+- **Minimal reproduction steps**:
+  1) Run opencode with ACP enabled.
+  2) Observe state files created under `$XDG_DATA_HOME/opencode/storage/plugin/acp/`
+     with no way to move them via configuration.
+- **Relevant configuration**: none exists today.
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+  - Backward compatibility: with the option unset, the storage location MUST
+    be byte-for-byte the current default (`XDG_DATA_HOME || ~/.local/share` +
+    `opencode/storage/plugin/acp`). Existing persisted state must keep loading.
+  - Performance requirements: no measurable overhead (path resolution happens
+    once per session at init).
+  - Resource limits: none.
+- **Non-Goals** (explicitly out of scope):
+  - Automatic migration/copy of existing state files from the default
+    location to a newly configured location (a per-session WARN is emitted
+    instead when the custom location is empty but the default location holds
+    the session file).
+  - Per-session or per-project file naming changes.
+  - Environment-variable override as a first-class feature (the config option
+    is the supported path; `XDG_DATA_HOME` still affects the default).
+
+## 4. Acceptance Criteria (must be testable)
+
+- **Correctness**:
+  - [ ] New top-level config option `storagePath` (string, optional) is
+    accepted by all three config layers (global / config-dir / project) and
+    validated by `config-validation.ts` and `dcp.schema.json`.
+  - [ ] Path semantics: absolute → used as-is; `~` / `~/...` → expanded
+    against the home directory; relative → resolved against the project
+    directory (opencode's `ctx.directory`, fallback `process.cwd()`).
+  - [ ] `saveSessionState` writes to the configured directory (created
+    recursively if needed); `loadSessionState` reads from it.
+  - [ ] Option unset → behavior identical to today (default XDG location).
+  - [ ] If state is configured to a custom location, the custom location is
+    empty for the session, but the default location contains the session
+    file, a WARN is logged (at most once per session) pointing at both paths.
+- **Performance / Stability**:
+  - [ ] No change to the number of file I/O operations per turn.
+- **Regression**:
+  - [ ] New test file `tests/storage-path.test.ts` covers path resolution,
+    save/load round-trip in a custom directory, and the default-location
+    fallback; full suite green.
+
+## 5. Proposed Approach (optional)
+
+- **Affected modules & entry files**:
+  - `lib/config.ts` — `PluginConfig.storagePath?: string`, `mergeLayer`,
+    (deepClone via `...config` spread).
+  - `lib/config-validation.ts` — `VALID_CONFIG_KEYS` + type check.
+  - `dcp.schema.json` — new `storagePath` property.
+  - `lib/state/persistence.ts` — `getDefaultStorageDir()`,
+    `resolveStorageDir()`, thread optional `storageDir` through
+    `getSessionFilePath` / `writePersistedSessionState` /
+    `loadSessionState` / `loadAllSessionStats`; `saveSessionState` reads it
+    from `SessionState.storageDir`.
+  - `lib/state/types.ts` — transient `SessionState.storageDir` field.
+  - `lib/state/state.ts` — `createSessionState` / `resetSessionState` /
+    `ensureSessionInitialized` (resolve once per session) /
+    `SessionStateRegistry` (new optional `projectDir` constructor arg).
+  - `index.ts` — pass `ctx.directory` to the registry.
+  - Docs: `CONFIGURATION.md`, `CONFIGURATION.zh-CN.md`, `README.md`,
+    `README.zh-CN.md`.
+- **Risks**:
+  - Relative-path base ambiguity (solved: project dir = `ctx.directory`).
+  - Silent state "loss" when switching locations (mitigated by the WARN).
+- **Rollback strategy**: revert the PR; option is additive and unset by
+  default, so no data migration is needed in either direction.

--- a/devlog/2026-09-09_custom-storage-path/REQ.md
+++ b/devlog/2026-09-09_custom-storage-path/REQ.md
@@ -3,7 +3,7 @@
 - Task ID: `2026-09-09_custom-storage-path`
 - Home Repo: `opencode-acp`
 - Created: 2026-09-09
-- Status: InProgress
+- Status: Done
 - Priority: P2
 - Owner: ranxianglei
 - References: https://github.com/ranxianglei/opencode-acp/issues/379

--- a/devlog/2026-09-09_custom-storage-path/WORKLOG.md
+++ b/devlog/2026-09-09_custom-storage-path/WORKLOG.md
@@ -27,6 +27,9 @@
 | Commit | Description |
 |--------|-------------|
 | `7c1a2ba` | feat: storagePath config for custom session-state storage location |
+| `645928e` | docs: finalize devlog for storagePath |
+| `24bb1e4` | test: address round-1 review findings (config-merge, resume, cwd-fallback, non-persistence) |
+| `7c619bc` | test: address round-2 review findings (registry wiring, resetSessionState, WARN wording) |
 
 ### Key Files
 
@@ -41,7 +44,7 @@
   `ensureSessionInitialized` (resolve + migration WARN) / registry
   `projectDir` constructor arg
 - `index.ts` — `new SessionStateRegistry(logger, ctx.directory)`
-- `tests/storage-path.test.ts` — 12 new tests
+- `tests/storage-path.test.ts` — 19 new tests
 - `CONFIGURATION.md`, `CONFIGURATION.zh-CN.md` — parameter entry + recipe
 - `devlog/2026-09-09_custom-storage-path/` — REQ / DESIGN / WORKLOG
 
@@ -71,29 +74,52 @@ npm run test
 
 ### Test Coverage
 
-- New/modified test files: `tests/storage-path.test.ts` (12 tests)
-- Test count: 1089 total, 1089 pass, 0 fail (full suite)
+- New/modified test files: `tests/storage-path.test.ts` (19 tests)
+- Test count: 1131 total, 1131 pass, 0 fail (full suite)
 - Key scenarios verified:
   - `resolveStorageDir`: unset/empty → default; absolute as-is; `~`/`~/...`
     → home; relative → project dir
   - save to custom dir (not default); load from custom dir; default-location
     round-trip regression; `loadAllSessionStats` with custom dir
   - `ensureSessionInitialized` resolves absolute + relative `storagePath`
-    (relative against `projectDir`)
+    (relative against `projectDir`); `process.cwd()` fallback when
+    `projectDir` omitted; custom-location resume without spurious WARN
   - migration WARN fires only when file exists solely at default location;
     no WARN when `storagePath` unset
+  - `getConfig` layering (global → project override → unset);
+    `validateConfigTypes` rejects non-string / accepts undefined
+  - transient `storageDir` never appears in persisted JSON;
+    `SessionStateRegistry.getOrCreate` passes `projectDir` through;
+    `resetSessionState` clears `storageDir`
+- Regression detection verified by mutation testing: dropping the
+  `mergeLayer` storagePath line, making `resolveStorageDir` always return
+  the default dir, or ignoring `storageDir` in save/load each fail multiple
+  new tests.
+
+### Dual-Agent Review (AGENTS.md §5.3 / §5.6)
+
+- Code review ×2 independent agents: both APPROVE. Round-1 deferred
+  follow-ups (optional `config?` fallback, custom→custom switch not warned,
+  no startup validation of `storagePath`, cwd-fallback threading, e2e
+  hardcoded default path) recorded in §7. Round-2 NIT (WARN wording for a
+  corrupt custom file) fixed.
+- Test review ×2 independent agents: round 1 REQUEST_CHANGES (narrow —
+  missing config-merge / resume / validation / cwd-fallback tests) → all
+  fixed in `24bb1e4`; round 2 APPROVE with two MINOR gaps (registry
+  `projectDir` wiring, `resetSessionState` clearing `storageDir`) → fixed
+  in the round-2 commit.
 
 ### Results
 
 - **PASS/FAIL**: PASS
-- **Key logs/data**: `# tests 1089 / # pass 1089 / # fail 0`
+- **Key logs/data**: `# tests 1131 / # pass 1131 / # fail 0`
 
 ## 5. Risk Assessment & Rollback
 
 - **Risk points**: relative-path base (mitigated: project dir); state
   "loss" on location switch (mitigated: WARN).
 - **Rollback method**:
-  - Revert commit(s): `7c1a2ba`
+  - Revert commit(s): `7c1a2ba`, `645928e`, `24bb1e4`, `7c619bc`
   - Rollback impact: none — option is additive and unset by default.
 - **Compatibility notes** (data format, config schema): No persisted-format
   change; schema gains one optional property.
@@ -107,3 +133,10 @@ npm run test
 
 - [ ] Optional: `ACP_STORAGE_DIR` env var override (deferred per issue
       discussion — config option is the supported path)
+- [ ] WARN when switching `storagePath` from one custom location to another
+      (only default→custom is warned today)
+- [ ] Startup validation of `storagePath` (writability check; today
+      ENOTDIR/EACCES surfaces at first save, logged, no crash)
+- [ ] Thread `projectDir` through `ToolContext` so the compress-tool init
+      path doesn't rely on the `process.cwd()` fallback
+- [ ] `scripts/e2e/run-e2e.sh` hardcodes the default storage path

--- a/devlog/2026-09-09_custom-storage-path/WORKLOG.md
+++ b/devlog/2026-09-09_custom-storage-path/WORKLOG.md
@@ -1,0 +1,109 @@
+# WORKLOG - Support custom storage location for compressed content (session state files)
+
+- Task ID: `2026-09-09_custom-storage-path`
+- Home Repo: `opencode-acp`
+- Status: InProgress
+- Updated: 2026-09-09
+
+## 1. Summary
+
+- **What was done**: New top-level `storagePath` config option relocating the
+  per-session state directory (`{sessionId}.json` files). Absolute / `~` /
+  project-relative path semantics; resolved once per session and carried on
+  `SessionState.storageDir` (transient, never persisted). WARN (no
+  auto-migration) when the custom location is empty but the default location
+  holds the session file.
+- **Why**: Issue #379 — users on containers / NFS homes / small XDG data
+  dirs need to relocate ACP's state files; the location was hardcoded.
+- **Behavior / compatibility changes**: No, when unset. The default location
+  (`$XDG_DATA_HOME/opencode/storage/plugin/acp`) is byte-for-byte unchanged;
+  no persisted-format change.
+- **Risk level**: Low
+
+## 2. Change Log
+
+### Commits
+
+| Commit | Description |
+|--------|-------------|
+| `<sha>` | feat: storagePath config for custom session-state storage location |
+
+### Key Files
+
+- `lib/config.ts` — `PluginConfig.storagePath?: string` + `mergeLayer` merge
+- `lib/config-validation.ts` — `VALID_CONFIG_KEYS` + string type check
+- `dcp.schema.json` — `storagePath` property (schema is `additionalProperties: false`)
+- `lib/state/persistence.ts` — `getDefaultStorageDir()` / `resolveStorageDir()`
+  (exported); `storageDir?` threaded through path/save/load/stats helpers;
+  `saveSessionState` reads `sessionState.storageDir`
+- `lib/state/types.ts` — transient `SessionState.storageDir`
+- `lib/state/state.ts` — `createSessionState` / `resetSessionState` /
+  `ensureSessionInitialized` (resolve + migration WARN) / registry
+  `projectDir` constructor arg
+- `index.ts` — `new SessionStateRegistry(logger, ctx.directory)`
+- `tests/storage-path.test.ts` — 12 new tests
+- `CONFIGURATION.md`, `CONFIGURATION.zh-CN.md` — parameter entry + recipe
+- `devlog/2026-09-09_custom-storage-path/` — REQ / DESIGN / WORKLOG
+
+## 3. Design & Implementation Notes
+
+- **Entry point / key function**: `resolveStorageDir(configured, projectDir)`
+  in `lib/state/persistence.ts`; resolution happens in
+  `ensureSessionInitialized` (`lib/state/state.ts`) once per session.
+- **Key configuration items**: `storagePath` (top-level string, optional).
+- **Key logic explanation**: `state.storageDir` is transient — derived from
+  config at session init, consumed by `saveSessionState` (via
+  `sessionState.storageDir`) and `loadSessionState` (explicit param in
+  `ensureSessionInitialized`). The migration WARN fires in the
+  `persisted === null` branch, at most once per session because init
+  early-returns on repeat calls.
+
+## 4. Testing & Verification
+
+### Build & Test Commands
+
+```sh
+npm run typecheck
+npm run build
+node --import tsx --test tests/storage-path.test.ts
+npm run test
+```
+
+### Test Coverage
+
+- New/modified test files: `tests/storage-path.test.ts` (12 tests)
+- Test count: 1089 total, 1089 pass, 0 fail (full suite)
+- Key scenarios verified:
+  - `resolveStorageDir`: unset/empty → default; absolute as-is; `~`/`~/...`
+    → home; relative → project dir
+  - save to custom dir (not default); load from custom dir; default-location
+    round-trip regression; `loadAllSessionStats` with custom dir
+  - `ensureSessionInitialized` resolves absolute + relative `storagePath`
+    (relative against `projectDir`)
+  - migration WARN fires only when file exists solely at default location;
+    no WARN when `storagePath` unset
+
+### Results
+
+- **PASS/FAIL**: PASS
+- **Key logs/data**: `# tests 1089 / # pass 1089 / # fail 0`
+
+## 5. Risk Assessment & Rollback
+
+- **Risk points**: relative-path base (mitigated: project dir); state
+  "loss" on location switch (mitigated: WARN).
+- **Rollback method**:
+  - Revert commit(s): `<sha>`
+  - Rollback impact: none — option is additive and unset by default.
+- **Compatibility notes** (data format, config schema): No persisted-format
+  change; schema gains one optional property.
+
+## 6. Lessons Learned (optional)
+
+- The repo's prettier baseline is not clean (pre-existing); only new/changed
+  lines were kept prettier-conformant to avoid unrelated diff noise.
+
+## 7. Follow-ups (optional)
+
+- [ ] Optional: `ACP_STORAGE_DIR` env var override (deferred per issue
+      discussion — config option is the supported path)

--- a/devlog/2026-09-09_custom-storage-path/WORKLOG.md
+++ b/devlog/2026-09-09_custom-storage-path/WORKLOG.md
@@ -2,7 +2,7 @@
 
 - Task ID: `2026-09-09_custom-storage-path`
 - Home Repo: `opencode-acp`
-- Status: InProgress
+- Status: Done
 - Updated: 2026-09-09
 
 ## 1. Summary
@@ -26,7 +26,7 @@
 
 | Commit | Description |
 |--------|-------------|
-| `<sha>` | feat: storagePath config for custom session-state storage location |
+| `7c1a2ba` | feat: storagePath config for custom session-state storage location |
 
 ### Key Files
 
@@ -93,7 +93,7 @@ npm run test
 - **Risk points**: relative-path base (mitigated: project dir); state
   "loss" on location switch (mitigated: WARN).
 - **Rollback method**:
-  - Revert commit(s): `<sha>`
+  - Revert commit(s): `7c1a2ba`
   - Rollback impact: none — option is additive and unset by default.
 - **Compatibility notes** (data format, config schema): No persisted-format
   change; schema gains one optional property.

--- a/index.ts
+++ b/index.ts
@@ -51,7 +51,7 @@ const server: Plugin = (async (ctx) => {
         autoUpdate: config.autoUpdate,
         secureMode: isSecureMode(),
     })
-    const registry = new SessionStateRegistry(logger)
+    const registry = new SessionStateRegistry(logger, ctx.directory)
     const prompts = new PromptStore(logger, ctx.directory, config.experimental.customPrompts)
     const hostPermissions: HostPermissionSnapshot = {
         global: undefined,

--- a/lib/config-validation.ts
+++ b/lib/config-validation.ts
@@ -9,6 +9,7 @@ export const VALID_CONFIG_KEYS = new Set([
     "autoUpdate",
     "debug",
     "logLevel",
+    "storagePath",
     "showUpdateToasts",
     "allowSubAgents",
     "pruneNotification",
@@ -117,6 +118,10 @@ export function validateConfigTypes(config: Record<string, any>): ValidationErro
 
     if (config.debug !== undefined && typeof config.debug !== "boolean") {
         errors.push({ key: "debug", expected: "boolean", actual: typeof config.debug })
+    }
+
+    if (config.storagePath !== undefined && typeof config.storagePath !== "string") {
+        errors.push({ key: "storagePath", expected: "string", actual: typeof config.storagePath })
     }
 
     if (config.allowSubAgents !== undefined && typeof config.allowSubAgents !== "boolean") {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -171,6 +171,13 @@ export interface PluginConfig {
     debug: boolean
     /** Log verbosity when `debug` is false; `debug: true` forces full debug logging. Default: "info". */
     logLevel: LogLevel
+    /**
+     * Directory where per-session state files are persisted.
+     * Absolute paths are used as-is; `~`/`~/...` expand against the home
+     * directory; relative paths resolve against the project directory.
+     * Unset → `$XDG_DATA_HOME/opencode/storage/plugin/acp` (default).
+     */
+    storagePath?: string
     allowSubAgents: boolean
     pruneNotification: "off" | "minimal" | "detailed"
     pruneNotificationType: "chat" | "toast"
@@ -673,6 +680,7 @@ function mergeLayer(config: PluginConfig, data: Record<string, any>): PluginConf
         autoUpdate: data.autoUpdate ?? config.autoUpdate,
         debug: data.debug ?? config.debug,
         logLevel: data.logLevel ?? config.logLevel,
+        storagePath: data.storagePath ?? config.storagePath,
         allowSubAgents: data.allowSubAgents ?? data.experimental?.allowSubAgents ?? config.allowSubAgents,
         pruneNotification: data.pruneNotification ?? config.pruneNotification,
         pruneNotificationType: data.pruneNotificationType ?? config.pruneNotificationType,

--- a/lib/state/persistence.ts
+++ b/lib/state/persistence.ts
@@ -102,13 +102,6 @@ function getStorageDir(override?: string): string {
     return override || getDefaultStorageDir()
 }
 
-async function ensureStorageDir(logger: Logger, storageDir?: string): Promise<void> {
-    const dir = getStorageDir(storageDir)
-    if (!existsSync(dir)) {
-        await fs.mkdir(dir, { recursive: true })
-    }
-}
-
 function getSessionFilePath(sessionId: string, storageDir?: string): string {
     return join(getStorageDir(storageDir), `${sessionId}.json`)
 }

--- a/lib/state/persistence.ts
+++ b/lib/state/persistence.ts
@@ -1,13 +1,14 @@
 /**
  * State persistence module for ACP plugin.
  * Persists pruned tool IDs across sessions so they survive OpenCode restarts.
- * Storage location: ~/.local/share/opencode/storage/plugin/acp/{sessionId}.json
+ * Storage location: $XDG_DATA_HOME/opencode/storage/plugin/acp/{sessionId}.json
+ * by default, or the directory configured via `storagePath` (see resolveStorageDir).
  */
 
 import * as fs from "fs/promises"
 import { existsSync } from "fs"
 import { homedir } from "os"
-import { join } from "path"
+import { isAbsolute, join } from "path"
 import type { CompressionBlock, PrunedMessageEntry, SessionState, SessionStats } from "./types"
 import type { Logger } from "../logger"
 import { serializePruneMessagesState } from "./utils"
@@ -62,7 +63,8 @@ export interface PersistedSessionState {
     modelID?: string
 }
 
-function getStorageDir(): string {
+/** Default storage directory: $XDG_DATA_HOME/opencode/storage/plugin/acp */
+export function getDefaultStorageDir(): string {
     return join(
         process.env.XDG_DATA_HOME || join(homedir(), ".local", "share"),
         "opencode",
@@ -72,28 +74,57 @@ function getStorageDir(): string {
     )
 }
 
-async function ensureStorageDir(logger: Logger): Promise<void> {
-    const storageDir = getStorageDir()
-    if (!existsSync(storageDir)) {
-        await fs.mkdir(storageDir, { recursive: true })
+/**
+ * Resolve the configured `storagePath` to an absolute directory.
+ * - undefined/empty → default location
+ * - `~` or `~/...` → expanded against the home directory
+ * - absolute → used as-is
+ * - relative → resolved against `projectDir` (opencode's working directory)
+ */
+export function resolveStorageDir(configured: string | undefined, projectDir: string): string {
+    const trimmed = configured?.trim()
+    if (!trimmed) {
+        return getDefaultStorageDir()
+    }
+    if (trimmed === "~") {
+        return homedir()
+    }
+    if (trimmed.startsWith("~/")) {
+        return join(homedir(), trimmed.slice(2))
+    }
+    if (isAbsolute(trimmed)) {
+        return trimmed
+    }
+    return join(projectDir, trimmed)
+}
+
+function getStorageDir(override?: string): string {
+    return override || getDefaultStorageDir()
+}
+
+async function ensureStorageDir(logger: Logger, storageDir?: string): Promise<void> {
+    const dir = getStorageDir(storageDir)
+    if (!existsSync(dir)) {
+        await fs.mkdir(dir, { recursive: true })
     }
 }
 
-function getSessionFilePath(sessionId: string): string {
-    return join(getStorageDir(), `${sessionId}.json`)
+function getSessionFilePath(sessionId: string, storageDir?: string): string {
+    return join(getStorageDir(storageDir), `${sessionId}.json`)
 }
 
 async function writePersistedSessionState(
     sessionId: string,
     state: PersistedSessionState,
     logger: Logger,
+    storageDir?: string,
 ): Promise<void> {
     // Capture file path synchronously before any await — prevents race condition
     // when fire-and-forget saves execute after XDG_DATA_HOME has changed (tests).
-    const filePath = getSessionFilePath(sessionId)
-    const storageDir = getStorageDir()
-    if (!existsSync(storageDir)) {
-        await fs.mkdir(storageDir, { recursive: true })
+    const filePath = getSessionFilePath(sessionId, storageDir)
+    const dir = getStorageDir(storageDir)
+    if (!existsSync(dir)) {
+        await fs.mkdir(dir, { recursive: true })
     }
 
     const content = JSON.stringify(state, null, 2)
@@ -145,15 +176,16 @@ export async function saveSessionState(
         modelID: sessionState.modelID,
     }
 
-    await writePersistedSessionState(sessionState.sessionId, state, logger)
+    await writePersistedSessionState(sessionState.sessionId, state, logger, sessionState.storageDir)
 }
 
 export async function loadSessionState(
     sessionId: string,
     logger: Logger,
+    storageDir?: string,
 ): Promise<PersistedSessionState | null> {
     try {
-        const filePath = getSessionFilePath(sessionId)
+        const filePath = getSessionFilePath(sessionId, storageDir)
 
         if (!existsSync(filePath)) {
             return null
@@ -255,7 +287,10 @@ export interface AggregatedStats {
     sessionCount: number
 }
 
-export async function loadAllSessionStats(logger: Logger): Promise<AggregatedStats> {
+export async function loadAllSessionStats(
+    logger: Logger,
+    storageDir?: string,
+): Promise<AggregatedStats> {
     const result: AggregatedStats = {
         totalTokens: 0,
         totalTools: 0,
@@ -264,17 +299,17 @@ export async function loadAllSessionStats(logger: Logger): Promise<AggregatedSta
     }
 
     try {
-        const storageDir = getStorageDir()
-        if (!existsSync(storageDir)) {
+        const dir = getStorageDir(storageDir)
+        if (!existsSync(dir)) {
             return result
         }
 
-        const files = await fs.readdir(storageDir)
+        const files = await fs.readdir(dir)
         const jsonFiles = files.filter((f) => f.endsWith(".json"))
 
         for (const file of jsonFiles) {
             try {
-                const filePath = join(storageDir, file)
+                const filePath = join(dir, file)
                 const content = await fs.readFile(filePath, "utf-8")
                 const state = JSON.parse(content) as PersistedSessionState
 

--- a/lib/state/state.ts
+++ b/lib/state/state.ts
@@ -1,3 +1,6 @@
+import { existsSync } from "fs"
+import { join } from "path"
+import { cwd } from "process"
 import type { SessionState, ToolParameterEntry, WithParts } from "./types"
 import type { PluginConfig } from "../config"
 import type { Logger } from "../logger"
@@ -6,7 +9,12 @@ import {
     type CompressionTimingState,
     type PendingCompressionDuration,
 } from "../compress/timing"
-import { loadSessionState, saveSessionState } from "./persistence"
+import {
+    getDefaultStorageDir,
+    loadSessionState,
+    resolveStorageDir,
+    saveSessionState,
+} from "./persistence"
 import { createModelLimitCatalog } from "./model-limits"
 import { rebuildCompressionState } from "./rebuild"
 import {
@@ -77,7 +85,10 @@ export class SessionStateRegistry {
     // composes the same factory.
     private readonly catalog = createModelLimitCatalog()
 
-    constructor(private readonly logger: Logger) {}
+    constructor(
+        private readonly logger: Logger,
+        private readonly projectDir?: string,
+    ) {}
 
     recordModelLimit(
         providerId: string | undefined,
@@ -141,6 +152,7 @@ export class SessionStateRegistry {
                 this.logger,
                 messages,
                 config,
+                this.projectDir,
             )
         } catch (err: any) {
             this.logger.error("Failed to initialize session state", {
@@ -206,6 +218,7 @@ export function createSessionState(): SessionState {
         modelProviderID: undefined,
         modelID: undefined,
         systemPromptTokens: undefined,
+        storageDir: undefined,
         qualityGateRetryPending: false,
     }
 }
@@ -248,6 +261,7 @@ export function resetSessionState(state: SessionState): void {
     state.modelProviderID = undefined
     state.modelID = undefined
     state.systemPromptTokens = undefined
+    state.storageDir = undefined
     state.qualityGateRetryPending = false
 }
 
@@ -258,6 +272,7 @@ export async function ensureSessionInitialized(
     logger: Logger,
     messages: WithParts[],
     config?: PluginConfig,
+    projectDir?: string,
 ): Promise<void> {
     if (state.sessionId === sessionId) {
         return
@@ -265,6 +280,12 @@ export async function ensureSessionInitialized(
 
     resetSessionState(state)
     state.sessionId = sessionId
+    // Resolve the configured storage location once per session (transient).
+    // Relative paths resolve against projectDir (opencode's directory),
+    // falling back to process.cwd() when the caller has no directory context.
+    state.storageDir = config?.storagePath
+        ? resolveStorageDir(config.storagePath, projectDir ?? cwd())
+        : undefined
 
     const isSubAgent = await isSubAgentSession(client, sessionId)
     state.isSubAgent = isSubAgent
@@ -273,8 +294,18 @@ export async function ensureSessionInitialized(
     state.currentTurn = countTurns(state, messages)
     state.nudges.turnNudgeAnchors = collectTurnNudgeAnchors(messages)
 
-    const persisted = await loadSessionState(sessionId, logger)
+    const persisted = await loadSessionState(sessionId, logger, state.storageDir)
     if (persisted === null) {
+        // storagePath points elsewhere but the session file still sits at the
+        // default location (e.g. the user just configured storagePath). No
+        // auto-migration — warn once (this init path runs once per session).
+        const defaultPath = join(getDefaultStorageDir(), `${sessionId}.json`)
+        if (state.storageDir && existsSync(defaultPath)) {
+            logger.warn(
+                "storagePath is set but no state was found there; a state file exists at the default location — move it manually to keep history",
+                { sessionId, storageDir: state.storageDir, defaultPath },
+            )
+        }
         // Fork recovery: no persisted state for this session. If config is
         // available, replay historical compress tool invocations to rebuild
         // pruning state using the current session's message IDs.

--- a/lib/state/state.ts
+++ b/lib/state/state.ts
@@ -302,7 +302,7 @@ export async function ensureSessionInitialized(
         const defaultPath = join(getDefaultStorageDir(), `${sessionId}.json`)
         if (state.storageDir && existsSync(defaultPath)) {
             logger.warn(
-                "storagePath is set but no state was found there; a state file exists at the default location — move it manually to keep history",
+                "storagePath is set but no valid state was found there; a state file exists at the default location — move it manually to keep history",
                 { sessionId, storageDir: state.storageDir, defaultPath },
             )
         }
@@ -331,7 +331,8 @@ export async function ensureSessionInitialized(
     state.nudges.lastPerMessageNudgeTokens = persisted.nudges.lastPerMessageNudgeTokens
     state.nudges.lastNudgeShownTokens = persisted.nudges.lastNudgeShownTokens
     state.nudges.lastToolOutputNudgeTokens = persisted.nudges.lastToolOutputNudgeTokens
-    state.nudges.lastTier2NudgeTokens = persisted.nudges.lastTier2NudgeTokens ?? persisted.nudges.lastTierNudgeTokens
+    state.nudges.lastTier2NudgeTokens =
+        persisted.nudges.lastTier2NudgeTokens ?? persisted.nudges.lastTierNudgeTokens
     state.nudges.lastTier3NudgeTokens = persisted.nudges.lastTier3NudgeTokens
     state.nudges.compressBaselineSet = persisted.nudges.compressBaselineSet ?? false
     state.stats = {

--- a/lib/state/types.ts
+++ b/lib/state/types.ts
@@ -148,6 +148,12 @@ export interface SessionState {
     modelID: string | undefined
     systemPromptTokens: number | undefined
     /**
+     * Resolved directory for this session's persisted state file (absolute path).
+     * Transient (NOT persisted): resolved once per session from config.storagePath
+     * in ensureSessionInitialized. Undefined → default XDG location.
+     */
+    storageDir: string | undefined
+    /**
      * Transient flag (NOT persisted): set to true when a compress call is rejected
      * by the pre-commit quality gate. The model must retry with `acknowledgeRisk: true`
      * to bypass quality on the retry. Consumed (reset to false) on use.

--- a/tests/storage-path.test.ts
+++ b/tests/storage-path.test.ts
@@ -17,7 +17,12 @@ import {
     resolveStorageDir,
     saveSessionState,
 } from "../lib/state/persistence"
-import { createSessionState, ensureSessionInitialized } from "../lib/state"
+import {
+    SessionStateRegistry,
+    createSessionState,
+    ensureSessionInitialized,
+    resetSessionState,
+} from "../lib/state"
 
 const logger = new Logger(false)
 
@@ -382,6 +387,11 @@ test("validateConfigTypes rejects non-string storagePath", () => {
         false,
         "string storagePath should not produce a validation error",
     )
+    assert.equal(
+        validateConfigTypes({ storagePath: undefined }).some((e) => e.key === "storagePath"),
+        false,
+        "undefined storagePath should not produce a validation error",
+    )
 })
 
 test("ensureSessionInitialized resumes state from the custom location without warning", async () => {
@@ -450,4 +460,27 @@ test("saveSessionState does not persist the transient storageDir field", async (
     } finally {
         rmSync(customDir, { recursive: true, force: true })
     }
+})
+
+test("SessionStateRegistry.getOrCreate passes projectDir for relative storagePath resolution", async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "acp-registry-"))
+    try {
+        const registry = new SessionStateRegistry(logger, projectDir)
+        const config = buildConfig({ storagePath: "data/acp-registry" })
+
+        const state = await registry.getOrCreate(null, "sp-registry-proj", [], config)
+
+        assert.equal(state.storageDir, join(projectDir, "data/acp-registry"))
+    } finally {
+        rmSync(projectDir, { recursive: true, force: true })
+    }
+})
+
+test("resetSessionState clears the transient storageDir", () => {
+    const state = createSessionState()
+    state.storageDir = "/some/custom/dir"
+
+    resetSessionState(state)
+
+    assert.equal(state.storageDir, undefined)
 })

--- a/tests/storage-path.test.ts
+++ b/tests/storage-path.test.ts
@@ -2,11 +2,14 @@ import "./test-env"
 import assert from "node:assert/strict"
 import test from "node:test"
 import * as fs from "fs/promises"
-import { existsSync, mkdtempSync, rmSync } from "fs"
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "fs"
 import { join } from "path"
+import { cwd } from "process"
 import { homedir, tmpdir } from "os"
+import type { PluginInput } from "@opencode-ai/plugin"
 import { Logger } from "../lib/logger"
-import type { PluginConfig } from "../lib/config"
+import { getConfig, type PluginConfig } from "../lib/config"
+import { validateConfigTypes } from "../lib/config-validation"
 import {
     getDefaultStorageDir,
     loadAllSessionStats,
@@ -176,11 +179,14 @@ test("save/load without storagePath still use the default location (regression)"
     await saveSessionState(state, logger)
 
     const filePath = join(getDefaultStorageDir(), "sp-default-loc.json")
-    assert.ok(existsSync(filePath), "file should be in default dir")
-    const loaded = await loadSessionState("sp-default-loc", logger)
-    assert.ok(loaded, "should load from default dir")
-    assert.equal(loaded!.stats.totalPruneTokens, 789)
-    await fs.unlink(filePath)
+    try {
+        assert.ok(existsSync(filePath), "file should be in default dir")
+        const loaded = await loadSessionState("sp-default-loc", logger)
+        assert.ok(loaded, "should load from default dir")
+        assert.equal(loaded!.stats.totalPruneTokens, 789)
+    } finally {
+        await fs.unlink(filePath).catch(() => {})
+    }
 })
 
 test("loadAllSessionStats aggregates from the configured storageDir", async () => {
@@ -308,5 +314,140 @@ test("ensureSessionInitialized does not warn when storagePath is unset", async (
         )
     } finally {
         await fs.unlink(join(getDefaultStorageDir(), "sp-no-warn.json")).catch(() => {})
+    }
+})
+
+test("getConfig merges storagePath across global and project config layers", async () => {
+    const savedOpenCodeConfigDir = process.env.OPENCODE_CONFIG_DIR
+    delete process.env.OPENCODE_CONFIG_DIR
+    const globalConfigPath = join(
+        process.env.XDG_CONFIG_HOME || join(homedir(), ".config"),
+        "opencode",
+        "acp.jsonc",
+    )
+    const projectDir = mkdtempSync(join(tmpdir(), "acp-cfg-proj-"))
+    const opencodeDir = join(projectDir, ".opencode")
+    const projectConfigPath = join(opencodeDir, "acp.jsonc")
+    const globalConfigBackup = existsSync(globalConfigPath)
+        ? await fs.readFile(globalConfigPath, "utf-8")
+        : null
+
+    try {
+        mkdirSync(join(process.env.XDG_CONFIG_HOME!, "opencode"), { recursive: true })
+        await fs.writeFile(globalConfigPath, '{ "storagePath": "/global/acp" }', "utf-8")
+
+        const fakeCtx = {
+            directory: projectDir,
+            client: { tui: { showToast: () => {} } },
+        } as unknown as PluginInput
+
+        // Global layer only
+        let config = getConfig(fakeCtx)
+        assert.equal(config.storagePath, "/global/acp", "global layer should apply")
+
+        // Project layer overrides global
+        mkdirSync(opencodeDir, { recursive: true })
+        await fs.writeFile(projectConfigPath, '{ "storagePath": "/project/acp" }', "utf-8")
+        config = getConfig(fakeCtx)
+        assert.equal(config.storagePath, "/project/acp", "project layer should win")
+
+        // No config anywhere → unset (default location)
+        await fs.unlink(globalConfigPath)
+        rmSync(opencodeDir, { recursive: true, force: true })
+        config = getConfig(fakeCtx)
+        assert.equal(config.storagePath, undefined, "unset by default")
+    } finally {
+        if (globalConfigBackup !== null) {
+            await fs.writeFile(globalConfigPath, globalConfigBackup, "utf-8")
+        } else {
+            await fs.unlink(globalConfigPath).catch(() => {})
+        }
+        rmSync(projectDir, { recursive: true, force: true })
+        if (savedOpenCodeConfigDir === undefined) {
+            delete process.env.OPENCODE_CONFIG_DIR
+        } else {
+            process.env.OPENCODE_CONFIG_DIR = savedOpenCodeConfigDir
+        }
+    }
+})
+
+test("validateConfigTypes rejects non-string storagePath", () => {
+    assert.equal(
+        validateConfigTypes({ storagePath: 42 }).some((e) => e.key === "storagePath"),
+        true,
+        "numeric storagePath should produce a validation error",
+    )
+    assert.equal(
+        validateConfigTypes({ storagePath: "/valid/path" }).some((e) => e.key === "storagePath"),
+        false,
+        "string storagePath should not produce a validation error",
+    )
+})
+
+test("ensureSessionInitialized resumes state from the custom location without warning", async () => {
+    const customDir = makeCustomDir()
+    const warnings: string[] = []
+    const spyLogger = makeSpyLogger(warnings)
+    try {
+        // Seed DIFFERENT values at custom and default locations
+        const customSeeded = createSessionState()
+        customSeeded.sessionId = "sp-resume-custom"
+        customSeeded.storageDir = customDir
+        customSeeded.stats.totalPruneTokens = 111
+        await saveSessionState(customSeeded, logger)
+
+        const defaultSeeded = createSessionState()
+        defaultSeeded.sessionId = "sp-resume-custom"
+        defaultSeeded.stats.totalPruneTokens = 222
+        await saveSessionState(defaultSeeded, logger)
+
+        const state = createSessionState()
+        const config = buildConfig({ storagePath: customDir })
+        await ensureSessionInitialized(
+            null,
+            state,
+            "sp-resume-custom",
+            spyLogger,
+            [],
+            config,
+            "/some/project",
+        )
+
+        assert.equal(state.storageDir, customDir)
+        assert.equal(
+            state.stats.totalPruneTokens,
+            111,
+            "state must be restored from the custom location, not the default",
+        )
+        assert.equal(warnings.length, 0, `expected no warnings, got: ${JSON.stringify(warnings)}`)
+    } finally {
+        rmSync(customDir, { recursive: true, force: true })
+        await fs.unlink(join(getDefaultStorageDir(), "sp-resume-custom.json")).catch(() => {})
+    }
+})
+
+test("ensureSessionInitialized falls back to process.cwd() when projectDir is omitted", async () => {
+    const state = createSessionState()
+    const config = buildConfig({ storagePath: "data/acp-cwd" })
+
+    await ensureSessionInitialized(null, state, "sp-init-cwd", logger, [], config)
+
+    assert.equal(state.storageDir, join(cwd(), "data/acp-cwd"))
+})
+
+test("saveSessionState does not persist the transient storageDir field", async () => {
+    const customDir = makeCustomDir()
+    try {
+        const state = createSessionState()
+        state.sessionId = "sp-no-leak"
+        state.storageDir = customDir
+        state.stats.totalPruneTokens = 5
+
+        await saveSessionState(state, logger)
+
+        const raw = JSON.parse(await fs.readFile(join(customDir, "sp-no-leak.json"), "utf-8"))
+        assert.equal("storageDir" in raw, false, "storageDir must not appear in the persisted JSON")
+    } finally {
+        rmSync(customDir, { recursive: true, force: true })
     }
 })

--- a/tests/storage-path.test.ts
+++ b/tests/storage-path.test.ts
@@ -1,0 +1,312 @@
+import "./test-env"
+import assert from "node:assert/strict"
+import test from "node:test"
+import * as fs from "fs/promises"
+import { existsSync, mkdtempSync, rmSync } from "fs"
+import { join } from "path"
+import { homedir, tmpdir } from "os"
+import { Logger } from "../lib/logger"
+import type { PluginConfig } from "../lib/config"
+import {
+    getDefaultStorageDir,
+    loadAllSessionStats,
+    loadSessionState,
+    resolveStorageDir,
+    saveSessionState,
+} from "../lib/state/persistence"
+import { createSessionState, ensureSessionInitialized } from "../lib/state"
+
+const logger = new Logger(false)
+
+function buildConfig(overrides: Partial<PluginConfig> = {}): PluginConfig {
+    return {
+        enabled: true,
+        autoUpdate: false,
+        debug: false,
+        logLevel: "info",
+        allowSubAgents: true,
+        pruneNotification: "off",
+        pruneNotificationType: "chat",
+        commands: {
+            enabled: true,
+            protectedTools: [],
+        },
+        experimental: {
+            customPrompts: false,
+        },
+        protectedFilePatterns: [],
+        compress: {
+            permission: "allow",
+            showCompression: false,
+            summaryBuffer: false,
+            maxContextLimit: "80%",
+            minContextLimit: "80%",
+            nudgeFrequency: 5,
+            minNudgeContextPercent: 5,
+            iterationNudgeThreshold: 15,
+            nudgeForce: "soft",
+            protectedTools: [],
+            protectTags: false,
+            protectUserMessages: false,
+            maxSummaryLengthHard: 20000,
+            minCompressRange: 5000,
+            minNudgeGrowthRatio: 0.45,
+            minNudgeGrowthFloor: 5000,
+            nudgeGrowthTokens: 50000,
+            emergencyThresholdPercent: "98%",
+            maxVisibleSegments: 50,
+            keepEmbedMaxChars: 2000,
+            lastSegmentSoftBlock: true,
+            preserveRecentMessages: 5,
+            preserveRecentTokens: 5000,
+            preserveLastUserMessage: true,
+        },
+        gc: {
+            algorithm: "truncate",
+            promotionThreshold: 5,
+            maxBlockAge: 15,
+            maxOldGenSummaryLength: 3000,
+            majorGcThresholdPercent: "100%",
+            batchCleanup: { lowThreshold: "55%", highThreshold: "75%", forceThreshold: "90%" },
+        },
+        qualityGate: {
+            enabled: false,
+            algorithm: "rouge-recall-v1",
+            algorithms: {
+                "rouge-recall-v1": {
+                    layer1MinChars: 200,
+                    layer1MinRetentionPct: 5.0,
+                    layer2MaxRougeF1: 0.05,
+                    layer2MaxTop20Recall: 0.2,
+                },
+            },
+        },
+        messageFilters: {
+            enabled: true,
+            filters: {},
+        },
+        ...overrides,
+    }
+}
+
+function makeCustomDir(): string {
+    return mkdtempSync(join(tmpdir(), "acp-storage-test-"))
+}
+
+function makeSpyLogger(warnings: string[]): Logger {
+    return {
+        info: () => {},
+        warn: (msg: string) => {
+            warnings.push(msg)
+        },
+        error: () => {},
+        debug: () => {},
+    } as unknown as Logger
+}
+
+test("resolveStorageDir: unset/empty falls back to the default XDG location", () => {
+    assert.equal(resolveStorageDir(undefined, "/some/project"), getDefaultStorageDir())
+    assert.equal(resolveStorageDir("", "/some/project"), getDefaultStorageDir())
+    assert.equal(resolveStorageDir("   ", "/some/project"), getDefaultStorageDir())
+})
+
+test("resolveStorageDir: absolute paths are used as-is", () => {
+    const abs = join(tmpdir(), "acp-custom-abs")
+    assert.equal(resolveStorageDir(abs, "/some/project"), abs)
+})
+
+test("resolveStorageDir: ~ and ~/... expand against the home directory", () => {
+    assert.equal(resolveStorageDir("~", "/some/project"), homedir())
+    assert.equal(resolveStorageDir("~/acp-data", "/some/project"), join(homedir(), "acp-data"))
+})
+
+test("resolveStorageDir: relative paths resolve against the project directory", () => {
+    assert.equal(resolveStorageDir("data/acp", "/some/project"), "/some/project/data/acp")
+    assert.equal(resolveStorageDir("acp", "/some/project"), "/some/project/acp")
+})
+
+test("saveSessionState writes to the configured storageDir, not the default", async () => {
+    const customDir = makeCustomDir()
+    try {
+        const state = createSessionState()
+        state.sessionId = "sp-save-custom"
+        state.storageDir = customDir
+        state.stats.totalPruneTokens = 123
+
+        await saveSessionState(state, logger)
+
+        assert.ok(
+            existsSync(join(customDir, "sp-save-custom.json")),
+            "file should be in custom dir",
+        )
+        assert.ok(
+            !existsSync(join(getDefaultStorageDir(), "sp-save-custom.json")),
+            "file should NOT be in default dir",
+        )
+    } finally {
+        rmSync(customDir, { recursive: true, force: true })
+    }
+})
+
+test("loadSessionState reads from the configured storageDir", async () => {
+    const customDir = makeCustomDir()
+    try {
+        const state = createSessionState()
+        state.sessionId = "sp-load-custom"
+        state.storageDir = customDir
+        state.stats.totalPruneTokens = 456
+        await saveSessionState(state, logger)
+
+        const loaded = await loadSessionState("sp-load-custom", logger, customDir)
+        assert.ok(loaded, "should load from custom dir")
+        assert.equal(loaded!.stats.totalPruneTokens, 456)
+
+        // Without the storageDir argument the default location is probed → null
+        assert.equal(await loadSessionState("sp-load-custom", logger), null)
+    } finally {
+        rmSync(customDir, { recursive: true, force: true })
+    }
+})
+
+test("save/load without storagePath still use the default location (regression)", async () => {
+    const state = createSessionState()
+    state.sessionId = "sp-default-loc"
+    state.stats.totalPruneTokens = 789
+
+    await saveSessionState(state, logger)
+
+    const filePath = join(getDefaultStorageDir(), "sp-default-loc.json")
+    assert.ok(existsSync(filePath), "file should be in default dir")
+    const loaded = await loadSessionState("sp-default-loc", logger)
+    assert.ok(loaded, "should load from default dir")
+    assert.equal(loaded!.stats.totalPruneTokens, 789)
+    await fs.unlink(filePath)
+})
+
+test("loadAllSessionStats aggregates from the configured storageDir", async () => {
+    const customDir = makeCustomDir()
+    try {
+        for (const id of ["sp-stats-a", "sp-stats-b"]) {
+            const state = createSessionState()
+            state.sessionId = id
+            state.storageDir = customDir
+            state.stats.totalPruneTokens = 100
+            await saveSessionState(state, logger)
+        }
+
+        const stats = await loadAllSessionStats(logger, customDir)
+        assert.equal(stats.sessionCount, 2)
+        assert.equal(stats.totalTokens, 200)
+    } finally {
+        rmSync(customDir, { recursive: true, force: true })
+    }
+})
+
+test("ensureSessionInitialized resolves storageDir from config.storagePath", async () => {
+    const customDir = makeCustomDir()
+    try {
+        const state = createSessionState()
+        const config = buildConfig({ storagePath: customDir })
+
+        await ensureSessionInitialized(
+            null,
+            state,
+            "sp-init-resolve",
+            logger,
+            [],
+            config,
+            "/some/project",
+        )
+
+        assert.equal(state.storageDir, customDir)
+    } finally {
+        rmSync(customDir, { recursive: true, force: true })
+    }
+})
+
+test("ensureSessionInitialized resolves relative storagePath against projectDir", async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "acp-proj-"))
+    try {
+        const state = createSessionState()
+        const config = buildConfig({ storagePath: "data/acp-state" })
+
+        await ensureSessionInitialized(
+            null,
+            state,
+            "sp-init-relative",
+            logger,
+            [],
+            config,
+            projectDir,
+        )
+
+        assert.equal(state.storageDir, join(projectDir, "data/acp-state"))
+    } finally {
+        rmSync(projectDir, { recursive: true, force: true })
+    }
+})
+
+test("ensureSessionInitialized warns when state file exists only at the default location", async () => {
+    const customDir = makeCustomDir()
+    const warnings: string[] = []
+    const spyLogger = makeSpyLogger(warnings)
+    try {
+        // Pre-seed a valid state file at the default location
+        const seeded = createSessionState()
+        seeded.sessionId = "sp-migrate-warn"
+        seeded.stats.totalPruneTokens = 42
+        await saveSessionState(seeded, logger)
+
+        const state = createSessionState()
+        const config = buildConfig({ storagePath: customDir })
+        await ensureSessionInitialized(
+            null,
+            state,
+            "sp-migrate-warn",
+            spyLogger,
+            [],
+            config,
+            "/some/project",
+        )
+
+        assert.equal(state.storageDir, customDir)
+        assert.ok(
+            warnings.some((w) => w.includes("storagePath")),
+            `expected a storagePath warning, got: ${JSON.stringify(warnings)}`,
+        )
+    } finally {
+        rmSync(customDir, { recursive: true, force: true })
+        await fs.unlink(join(getDefaultStorageDir(), "sp-migrate-warn.json")).catch(() => {})
+    }
+})
+
+test("ensureSessionInitialized does not warn when storagePath is unset", async () => {
+    const warnings: string[] = []
+    const spyLogger = makeSpyLogger(warnings)
+    try {
+        const seeded = createSessionState()
+        seeded.sessionId = "sp-no-warn"
+        seeded.stats.totalPruneTokens = 7
+        await saveSessionState(seeded, logger)
+
+        const state = createSessionState()
+        const config = buildConfig()
+        await ensureSessionInitialized(
+            null,
+            state,
+            "sp-no-warn",
+            spyLogger,
+            [],
+            config,
+            "/some/project",
+        )
+
+        assert.equal(state.storageDir, undefined)
+        assert.ok(
+            !warnings.some((w) => w.includes("storagePath")),
+            `unexpected storagePath warning: ${JSON.stringify(warnings)}`,
+        )
+    } finally {
+        await fs.unlink(join(getDefaultStorageDir(), "sp-no-warn.json")).catch(() => {})
+    }
+})


### PR DESCRIPTION
## Summary

Fixes #379 — 支持压缩内容自定义存储位置 (support custom storage location for compressed content).

Adds a new optional top-level config option `storagePath` that relocates where ACP persists per-session state files (`{sessionId}.json`). The location was previously hardcoded to `$XDG_DATA_HOME/opencode/storage/plugin/acp`.

## Path semantics

| Value | Resolution |
|---|---|
| unset / empty | default `$XDG_DATA_HOME/opencode/storage/plugin/acp` (unchanged) |
| `/abs/path` | as-is |
| `~` / `~/x` | expanded against the home directory |
| `rel/path` | resolved against the project directory (opencode cwd) |

The resolved directory is computed once per session in `ensureSessionInitialized` and carried on `SessionState.storageDir` — a **transient** field that is never written to the persisted JSON (covered by a dedicated test).

## Migration policy

**No auto-migration** (by design — moving user data silently is worse than warning). If `storagePath` is set, no valid state is found there, but a state file exists at the default location, ACP logs a one-time WARN per session telling the user to move the file manually. Switching `storagePath` from one custom location to another is a documented follow-up.

## Changes

- `lib/config.ts` — `PluginConfig.storagePath?: string` + `mergeLayer` merge (3-layer override works)
- `lib/config-validation.ts` — `VALID_CONFIG_KEYS` + string type check
- `dcp.schema.json` — `storagePath` property (schema is `additionalProperties: false`)
- `lib/state/persistence.ts` — `getDefaultStorageDir()` / `resolveStorageDir()` (exported); `storageDir?` threaded through path/save/load/stats helpers; `saveSessionState` reads `sessionState.storageDir`
- `lib/state/types.ts` — transient `SessionState.storageDir`
- `lib/state/state.ts` — `createSessionState` / `resetSessionState` / `ensureSessionInitialized` (resolve + migration WARN) / registry `projectDir` constructor arg
- `index.ts` — `new SessionStateRegistry(logger, ctx.directory)`
- `tests/storage-path.test.ts` — 19 new tests (1131 total, all passing)
- `CONFIGURATION.md` / `CONFIGURATION.zh-CN.md` — parameter entry + recipe
- `devlog/2026-09-09_custom-storage-path/` — REQ / DESIGN / WORKLOG

## Verification

- `npm run typecheck` ✓, `npm run build` ✓, `npm run test` → 1131/1131 ✓
- `./scripts/ci/check-pr.sh` → all checks passed (version unchanged)
- Regression detection verified via mutation testing (dropping the merge line / always-default resolution / ignoring storageDir in save-load each fail multiple new tests)
- Dual-agent code review (2 independent agents): both APPROVE
- Dual-agent test review (2 independent agents): round-1 findings addressed, round-2 APPROVE

## Compatibility

- No persisted-format change; no internal `dcp` naming change
- Default location byte-for-byte unchanged when the option is unset
- All API changes additive/optional

## Follow-ups (tracked in devlog WORKLOG §7)

- WARN when switching between two custom locations
- Startup validation of `storagePath` (writability)
- `ACP_STORAGE_DIR` env var override (deferred — config option is the supported path)

<!-- ework-agent-pr -->