### PR TITLE
release: v1.16.0 — storagePath config for custom session-state storage location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+### v1.16.0 — storagePath: custom storage location for session state files
+
+**Problem**: ACP's per-session state files (`{sessionId}.json` — compression blocks, nudge state, token stats) were always written to the hardcoded `$XDG_DATA_HOME/opencode/storage/plugin/acp`. Users on containers, NFS homes, or tight XDG data dirs had no way to relocate them (issue #379).
+
+**Feature** (#380, closes #379):
+- New optional top-level config `storagePath` (string) relocating the session-state directory:
+
+| Value | Resolution |
+|---|---|
+| unset / empty | default `$XDG_DATA_HOME/opencode/storage/plugin/acp` (unchanged) |
+| `/abs/path` | as-is |
+| `~` / `~/x` | expanded against the home directory |
+| `rel/path` | resolved against the project directory (opencode cwd) |
+
+```jsonc
+// acp.jsonc — global / config-dir / project layers all supported
+{ "storagePath": "~/data/acp-state" }
+```
+
+- The resolved directory is computed once per session and carried on a transient `SessionState.storageDir` field that is never written to the persisted JSON.
+- **No auto-migration**: when `storagePath` is set, no valid state is found there, but a state file exists at the default location, ACP logs a one-time WARN per session pointing at the file to move manually.
+- Config validation, JSON schema, and CONFIGURATION (EN/zh) updated; 19 new tests (path resolution, custom-dir save/load round-trip, default-location regression, 3-layer merge, migration WARN, non-persistence, registry wiring); full suite 1131/1131; dual-agent code + test review.
+- Default location is byte-for-byte unchanged when the option is unset; all API changes are additive.
+
+**Install**: `opencode plugin opencode-acp@latest --global`
+
 ### v1.15.0 — compress.reasoning: drop oversized thinking from closed-turn compress calls
 
 **Problem**: `compress` tool-call messages are hard-exempt from every compression selection (Bug 39) and are therefore re-sent verbatim on every LLM request. Their `reasoning` (thinking) parts ride along forever — a monotonically growing, unreclaimable context floor (measured at 83.5% of residual context in a real session; issue #368).

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,31 @@
 # 更新日志
 
+### v1.16.0 — storagePath：自定义会话状态文件存储位置
+
+**问题**：ACP 的每会话状态文件（`{sessionId}.json` —— 压缩块、nudge 状态、token 统计）此前固定写入硬编码路径 `$XDG_DATA_HOME/opencode/storage/plugin/acp`。容器、NFS 家目录或 XDG data 目录空间紧张的用户无法迁移（issue #379）。
+
+**新功能**（#380，closes #379）：
+- 新增顶层可选配置 `storagePath`（字符串），用于自定义会话状态目录：
+
+| 取值 | 解析方式 |
+|---|---|
+| 未设置 / 空 | 默认 `$XDG_DATA_HOME/opencode/storage/plugin/acp`（不变） |
+| `/abs/path` | 原样使用 |
+| `~` / `~/x` | 展开到用户主目录 |
+| `rel/path` | 相对项目目录（opencode 工作目录）解析 |
+
+```jsonc
+// acp.jsonc —— 全局 / 配置目录 / 项目三层均支持
+{ "storagePath": "~/data/acp-state" }
+```
+
+- 解析结果在会话初始化时计算一次，挂在瞬态字段 `SessionState.storageDir` 上，**不会**写入持久化 JSON。
+- **不自动迁移**：设置了 `storagePath` 但该位置找不到有效状态、而默认位置存在状态文件时，每会话打一次性 WARN，提示手动迁移。
+- 配置校验、JSON schema、CONFIGURATION（中英）已更新；新增 19 个测试（路径解析、自定义目录读写往返、默认位置回归、三层合并、迁移 WARN、瞬态字段不泄漏、registry 接线）；全量 1131/1131 通过；双 agent 代码 + 测试评审。
+- 未设置时默认位置逐字节不变；所有 API 变更为纯新增。
+
+**安装**：`opencode plugin opencode-acp@latest --global`
+
 ### v1.15.0 — compress.reasoning：按需丢弃已关闭轮次 compress 调用的超大思考
 
 **问题**：`compress` 工具调用消息被硬排除在一切压缩选择之外（Bug 39），每轮请求原样重发，其 `reasoning`（思考）部分随之永久驻留 —— 单调增长、压缩永远无法回收的上下文底座（实测会话中占残余上下文 83.5%；issue #368）。

--- a/devlog/2026-09-09_release-v1.16.0/REQ.md
+++ b/devlog/2026-09-09_release-v1.16.0/REQ.md
@@ -1,0 +1,25 @@
+# REQ — release v1.16.0
+
+- **日期**: 2026-09-09
+- **分支**: `2026-09-09_release-v1.16.0`（自 master @ 5135dfd）
+- **版本**: 1.15.0 → 1.16.0（minor：含新功能）
+
+## 发布内容（v1.15.0..master）
+
+| PR | 类型 | 内容 |
+| --- | --- | --- |
+| #380 | feat | `storagePath` — 自定义会话状态文件存储位置（closes #379）。绝对 / `~` / 项目相对路径语义；瞬态 `SessionState.storageDir`（不持久化）；不自动迁移 + 一次性 WARN；19 新测试（全量 1131/1131）；双 agent 代码 + 测试评审 |
+
+## 版本号决策
+
+含新功能（storagePath）→ minor bump 1.15.0 → **1.16.0**。
+
+注：PR #381（messageFilters 配置文档）截至切分支时仍 open，不在本次发布范围；如需并入需另切 release 分支。
+
+## 清单
+
+- [x] package.json version → 1.16.0
+- [x] CHANGELOG.md / CHANGELOG.zh-CN.md 顶部新增 `### v1.16.0` 条目
+- [x] devlog REQ + WORKLOG
+- [x] `./scripts/ci/check-pr.sh` 通过
+- [ ] PR 合并（人工）后 release.yml 自动打 tag `v1.16.0`、构建、测试、发 npm `latest`、建 GitHub Release

--- a/devlog/2026-09-09_release-v1.16.0/WORKLOG.md
+++ b/devlog/2026-09-09_release-v1.16.0/WORKLOG.md
@@ -1,0 +1,24 @@
+# WORKLOG — release v1.16.0
+
+- **日期**: 2026-09-09
+- **分支**: `2026-09-09_release-v1.16.0`
+
+## 步骤（对照 AGENTS.md §5.4.2）
+
+1. `git checkout -b 2026-09-09_release-v1.16.0 master`（基点 5135dfd = PR #380 的 merge commit；v1.15.0 之后 master 上唯一未发布变更）
+2. `npm version 1.16.0 --no-git-tag-version`
+3. CHANGELOG.md / CHANGELOG.zh-CN.md 顶部新增 `### v1.16.0` 条目（问题/功能/安装，沿用 v1.15.0 条目格式；含 jsonc 配置示例 + 路径语义表）
+4. devlog REQ.md + WORKLOG.md
+5. `./scripts/ci/check-pr.sh 2026-09-09_release-v1.16.0 origin/master` → All checks passed
+6. commit + push + PR → 等待人工合并
+7. 合并后 release.yml 自动：检测 release 分支名 → 打 `v1.16.0` tag → npm ci → check:package → test → `npm publish`（latest）→ GitHub Release
+
+## 发布内容
+
+见 REQ.md 表格。核心：PR #380 `storagePath`（#379）。
+
+## 备注
+
+- merge 由人工执行（AGENTS.md §5.1.1.2 — Agent 绝不合并 PR）。
+- 版本号不含 `-` 后缀 → CI 发布到 `latest`（非 dev tag）。
+- PR #381（docs）合并后如需并入本次发布，需另切 release 分支。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opencode-acp",
-    "version": "1.15.0",
+    "version": "1.16.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opencode-acp",
-            "version": "1.15.0",
+            "version": "1.16.0",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.15.0",
+    "version": "1.16.0",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## Release v1.16.0

Releases PR #380 (closes #379) — the only change on master since v1.15.0.

### Contents

| PR | Type | Description |
|---|---|---|
| #380 | feat | `storagePath` — custom storage location for session state files. Absolute / `~` / project-relative path semantics; transient `SessionState.storageDir` (never persisted); no auto-migration + one-time WARN; 19 new tests (1131/1131); dual-agent code + test review |

### Version decision

New feature → minor bump 1.15.0 → **1.16.0**.

Note: PR #381 (messageFilters docs) is still open and NOT included in this release.

### Changes in this PR

- `package.json` / `package-lock.json` — 1.15.0 → 1.16.0
- `CHANGELOG.md` / `CHANGELOG.zh-CN.md` — `### v1.16.0` entry at top
- `devlog/2026-09-09_release-v1.16.0/` — REQ + WORKLOG

### Verification

- `./scripts/ci/check-pr.sh` → all checks passed (branch name, devlog, changelog)
- `npm run typecheck` ✓, `npm run test` → 1131/1131 ✓, `npm run build` ✓

### After merge (automated, release.yml)

Detects release branch name → tags `v1.16.0` → npm ci → check:package → test → `npm publish` (latest) → GitHub Release.

Merge is a human-only operation (AGENTS.md §5.1.1.2).

<!-- ework-agent-pr -->