### PR TITLE
release: v1.18.0 — version bump + changelog (pure bookkeeping)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+### v1.18.0 — adaptive compression candidates (opt-in): MICRO/EPISODE targets, executor-parity validated
+
+**PR #341 + follow-ups.** Adds a candidate-planning layer on top of the existing range nudges — off by default, byte-exact with v1.17.1 behavior until you opt in.
+
+**What it does when enabled** (`{"compress": {"candidates": true}}`):
+- Nudges and `acp_status` advertise pre-validated, batchable compression targets instead of raw ranges: **MICRO** = one large message or a complete tool transaction (call+result closed pair); **EPISODE** = a contiguous historical segment of smaller units (≥ `minCompressRange`).
+- Executor-parity: candidates are validated through the same `prepareExecutableRangePlans` path the `compress` tool uses — everything listed is submittable as-is (tool-pair closure, protection parity, Bug 39 semantics preserved). Planning is fail-closed and bounded to the visible context (v1.17.1 #385 guarantees ~1.2 ms).
+- Solves the over-compression failure mode where a model facing "compress m00150–m00220" nukes a whole span to save one big tool output.
+
+**Default OFF means exactly v1.17.1**: base nudge templates, breakdown copy, `acp_status` overview, and debug logs are restored byte-exact; candidate planning never runs (zero cost). Per-post-merge review, `compress.candidates` is NOT per-model overridable (global/project layers only) — the type surface, validation allowlist, and docs now agree. One deliberate carry-over from the PR branch: the transform pipeline reorder (tool-output truncation and budget guard now run after nudge injection) applies in both modes; e2e scenarios 01–12 all pass in OFF mode with the reorder in place.
+
+**Also in this release**: system-prompt and `compress-range`-prompt candidate guidance is gated behind the same switch (a1a2f23); e2e scenario 13 opts in explicitly; 12 new tests including a §5.7 four-turn growth-cycle with production `preserveRecentMessages: 20` and #207 baseline-retention assertions. Full suite 1263/1263.
+
+**Install**: `opencode plugin opencode-acp@latest --global`
+
 ### v1.17.1 — transform no longer scales with compression history (13.6 s → 1.2 ms) + config/CI fixes
 
 Three fixes bundled — headliner is #385, which removes the long-session slowdown reported in #384:

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,20 @@
 # 更新日志
 
+### v1.18.0 — 自适应压缩候选（opt-in）：MICRO/EPISODE 目标，执行同构校验
+
+**PR #341 + 后续修复。** 在既有范围 nudge 之上加了一层候选规划 —— 默认关闭，未开启时与 v1.17.1 行为逐字节一致。
+
+**开启后**（`{"compress": {"candidates": true}}`）：
+- nudge 与 `acp_status` 展示预先校验、可批量提交的压缩目标，而非原始范围：**MICRO** = 单条大消息或完整工具事务（call+result 闭包）；**EPISODE** = 相邻小单元构成的历史片段（≥ `minCompressRange`）。
+- 执行同构：候选通过与 `compress` 工具相同的 `prepareExecutableRangePlans` 路径校验 —— 列表中的目标均可直接提交（工具对闭合、保护同等、Bug 39 语义保留）。规划 fail-closed，开销限制在可见上下文内（v1.17.1 #385 保证 ~1.2 ms）。
+- 解决过度压缩问题：模型面对 "compress m00150–m00220" 时不再为了省一个大工具输出而整段压掉。
+
+**默认 OFF = 精确还原 v1.17.1**：基础 nudge 模板、breakdown 文案、`acp_status` 概览、debug 日志均恢复原文；候选规划不执行（零开销）。合并后评审确认：`compress.candidates` 不可按模型覆盖（仅全局/项目层）—— 类型、校验白名单、文档三处已对齐。一个有意保留的 PR 分支变更：transform 管道重排（工具输出截断与预算守卫移到 nudge 注入之后）在两种模式下均生效；e2e 场景 01–12 全部在 OFF 模式下通过。
+
+**同版本包含**：system prompt 与 compress-range prompt 的候选指导同样受开关门控（a1a2f23）；e2e 场景 13 显式开启；新增 12 个测试（含 §5.7 四轮 growth-cycle、生产配置 `preserveRecentMessages: 20`、#207 baseline 保留断言）。全量 1263/1263。
+
+**安装**：`opencode plugin opencode-acp@latest --global`
+
 ### v1.17.1 — transform 开销不再随压缩历史增长（13.6 s → 1.2 ms）+ 配置/CI 修复
 
 捆绑三项修复 —— 主打 #385，消除 #384 报告的长会话卡顿：

--- a/devlog/2026-09-12_release-v1.18.0/REQ.md
+++ b/devlog/2026-09-12_release-v1.18.0/REQ.md
@@ -1,0 +1,20 @@
+# REQ — v1.18.0 发布(纯版本簿记)
+
+## 约定
+
+发布 PR 只含:版本号 bump、CHANGELOG.md / CHANGELOG.zh-CN.md 条目、
+devlog。**不含任何功能代码**(按用户要求拆分,修复在 PR #393)。
+
+## 发布内容(均已在 master,经 PR #341 + a1a2f23)
+
+- **adaptive compression candidates(opt-in)**:`compress.candidates`
+  开关默认 false = v1.17.1 行为;开启后 nudge / acp_status 展示
+  MICRO/EPISODE 候选,executor-parity 校验,批量可提交。
+- system prompt / compress-range prompt 候选指导同样门控(a1a2f23)。
+- 依赖:**先合并 PR #393**(评审修复)再合并本 PR,使 v1.18.0 完整。
+
+## 验收
+
+- 版本 1.18.0;changelog 中英条目含 `### v1.18.0`。
+- check-pr.sh 通过;CI 全绿。
+- 人工合并后 CI 自动 tag + npm publish latest + GitHub Release。

--- a/devlog/2026-09-12_release-v1.18.0/WORKLOG.md
+++ b/devlog/2026-09-12_release-v1.18.0/WORKLOG.md
@@ -1,0 +1,18 @@
+# WORKLOG — v1.18.0 发布(纯版本簿记)
+
+## 步骤
+
+1. 初版发布分支(cc868b3)曾捆绑评审修复 —— 按用户要求"发布 PR 不得含
+   功能代码"拆分:
+   - 修复 → PR #393(分支 `2026-09-12_candidates-review-fixes`,210a152)
+   - 本分支 `git reset --hard github/master`(d0c3875)后仅保留簿记
+2. `package.json` 1.17.1 → 1.18.0。
+3. CHANGELOG.md / CHANGELOG.zh-CN.md 增加 v1.18.0 条目(内容描述以
+   #393 先合并为前提)。
+4. 验证:`check-pr.sh` 全绿(分支名 / devlog / changelog 版本串)。
+
+## 验证结果
+
+- 发布 PR #392 已更新为纯簿记 diff(3 文件 + devlog);合并顺序:
+   **先 #393(修复)后 #392(发布)**。#393 合并后本分支需 Update branch
+   同步 master,再等 CI 绿。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
     "name": "opencode-acp",
-    "version": "1.17.1",
+    "version": "1.18.0",
     "type": "module",
     "description": "Active Context Pruning — model-driven context management for OpenCode (hardened fork of DCP with 35 bug fixes)",
     "main": "./dist/index.js",


### PR DESCRIPTION
## v1.18.0 — pure release bookkeeping

Per convention this PR contains **no functional code**: only `package.json` 1.18.0, CHANGELOG.md / CHANGELOG.zh-CN.md entries, and devlog. (An earlier revision bundled review fixes; those moved to **PR #393**.)

### What v1.18.0 ships (already on master via PR #341 + a1a2f23 + #393)
- `compress.candidates` opt-in switch (default `false` = v1.17.1 byte-exact behavior): MICRO/EPISODE candidate planning, executor-parity validated, batchable targets in nudges / `acp_status`
- Candidate guidance in system & compress-range prompts gated behind the same switch
- Review fixes from #393: overridable-surface alignment + OFF-mode byte-exactness

### ⚠️ Merge order
1. **Merge #393 first** (review fixes)
2. **Update this branch** with master after #393 lands (I will do this once #393 merges)
3. Then merge this PR → CI auto-tags v1.18.0, publishes npm `latest`, creates GitHub Release